### PR TITLE
added redis dump to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ temp/
 
 # Makefiles
 Makefile
+
+# Redis
+**/*.rdb


### PR DESCRIPTION
<span data-mesa-description="start"></span>
## TL;DR
Added Redis database dump files (`.rdb`) to `.gitignore`.

## Why we made these changes
To prevent transient, often large, Redis database dump files from being accidentally committed to the repository, ensuring a cleaner and more focused version control.

## What changed?
- `.gitignore`: Added `*.rdb` to ignore Redis database dump files across all directories.

## Validation
- [x] Verified that `.rdb` files are no longer tracked by Git.
<span data-mesa-description="end"></span>