### PR TITLE
Remove optional flag from application name input schema in list_deplo…

### DIFF
--- a/src/app/[transport]/route.ts
+++ b/src/app/[transport]/route.ts
@@ -654,7 +654,6 @@ const handler = createMcpHandler((server) => {
         .describe(
           'Filter results to show only deployments for this specific application name (e.g., "my-web-scraper")',
         )
-        .optional(),
     },
     async ({ app_name }, extra) => {
       if (!extra.authInfo) {


### PR DESCRIPTION
…yments tool

---

<span data-mesa-description="start"></span>
## TL;DR
Made the `app_name` parameter required for the `list_deployments` API.

## Why we made these changes
To ensure consistent and accurate listing of deployments by always requiring a specific application name, preventing ambiguous or unintended behavior when the name is omitted.

## What changed?
- `src/app/[transport]/route.ts`: Changed the `app_name` parameter in the API handler from optional to required.

## Validation
- [ ] Verified that API requests to `list_deployments` without `app_name` now correctly return an error.
- [ ] Verified that API requests with a valid `app_name` continue to function as expected.
<span data-mesa-description="end"></span>