### PR TITLE
added source tracking for api requests from mcp

### DIFF
--- a/src/app/[transport]/route.ts
+++ b/src/app/[transport]/route.ts
@@ -19,6 +19,17 @@ import {
 } from "@/lib/dependency-resolver";
 import { AppAction } from "@onkernel/sdk/resources";
 
+function createKernelClient(apiKey: string) {
+  return new Kernel({
+    apiKey,
+    baseURL: process.env.API_BASE_URL,
+    defaultHeaders: {
+      "X-Source": "mcp-server",
+      "X-Referral-Source": "mcp.onkernel.com",
+    },
+  });
+}
+
 export async function OPTIONS(_req: NextRequest): Promise<Response> {
   return new Response(null, {
     status: 204,
@@ -204,10 +215,7 @@ const handler = createMcpHandler((server) => {
         throw new Error("Authentication required");
       }
 
-      const client = new Kernel({
-        apiKey: extra.authInfo.token,
-        baseURL: process.env.API_BASE_URL,
-      });
+      const client = createKernelClient(extra.authInfo.token);
 
       try {
         const result = await client.apps.list({
@@ -269,10 +277,7 @@ const handler = createMcpHandler((server) => {
         throw new Error("Authentication required");
       }
 
-      const client = new Kernel({
-        apiKey: extra.authInfo.token,
-        baseURL: process.env.API_BASE_URL,
-      });
+      const client = createKernelClient(extra.authInfo.token);
 
       try {
         // Create the invocation
@@ -378,10 +383,7 @@ const handler = createMcpHandler((server) => {
         throw new Error("Authentication required");
       }
 
-      const client = new Kernel({
-        apiKey: extra.authInfo.token,
-        baseURL: process.env.API_BASE_URL,
-      });
+      const client = createKernelClient(extra.authInfo.token);
 
       try {
         const result = await client.browsers.retrieve(id);
@@ -453,10 +455,7 @@ const handler = createMcpHandler((server) => {
         throw new Error("Authentication required");
       }
 
-      const client = new Kernel({
-        apiKey: extra.authInfo.token,
-        baseURL: process.env.API_BASE_URL,
-      });
+      const client = createKernelClient(extra.authInfo.token);
 
       try {
         const result = await client.browsers.create({
@@ -506,10 +505,7 @@ const handler = createMcpHandler((server) => {
         throw new Error("Authentication required");
       }
 
-      const client = new Kernel({
-        apiKey: extra.authInfo.token,
-        baseURL: process.env.API_BASE_URL,
-      });
+      const client = createKernelClient(extra.authInfo.token);
 
       try {
         await client.browsers.delete({
@@ -553,10 +549,7 @@ const handler = createMcpHandler((server) => {
         throw new Error("Authentication required");
       }
 
-      const client = new Kernel({
-        apiKey: extra.authInfo.token,
-        baseURL: process.env.API_BASE_URL,
-      });
+      const client = createKernelClient(extra.authInfo.token);
 
       try {
         const result = await client.deployments.retrieve(id);
@@ -600,10 +593,7 @@ const handler = createMcpHandler((server) => {
         throw new Error("Authentication required");
       }
 
-      const client = new Kernel({
-        apiKey: extra.authInfo.token,
-        baseURL: process.env.API_BASE_URL,
-      });
+      const client = createKernelClient(extra.authInfo.token);
 
       try {
         const result = await client.invocations.retrieve(id);
@@ -641,10 +631,7 @@ const handler = createMcpHandler((server) => {
         throw new Error("Authentication required");
       }
 
-      const client = new Kernel({
-        apiKey: extra.authInfo.token,
-        baseURL: process.env.API_BASE_URL,
-      });
+      const client = createKernelClient(extra.authInfo.token);
 
       try {
         const result = await client.browsers.list();
@@ -688,10 +675,7 @@ const handler = createMcpHandler((server) => {
         throw new Error("Authentication required");
       }
 
-      const client = new Kernel({
-        apiKey: extra.authInfo.token,
-        baseURL: process.env.API_BASE_URL,
-      });
+      const client = createKernelClient(extra.authInfo.token);
 
       try {
         const result = await client.deployments.list({
@@ -771,10 +755,7 @@ const handler = createMcpHandler((server) => {
         throw new Error("No files provided");
       }
 
-      const client = new Kernel({
-        apiKey: extra.authInfo.token,
-        baseURL: process.env.API_BASE_URL,
-      });
+      const client = createKernelClient(extra.authInfo.token);
 
       try {
         // Detect entrypoint


### PR DESCRIPTION
<span data-mesa-description="start"></span>
## TL;DR
Centralized `Kernel` client creation to add source tracking for API requests originating from MCP.

## Why we made these changes
To improve observability and debugging by identifying the source of API requests, specifically those made from the Multi-Chain Protocol (MCP). This helps in understanding traffic patterns and attributing usage.

## What changed?
- `src/app/[transport]/route.ts`: Introduced a new helper function, `createKernelClient`, to centralize the instantiation of the `Kernel` client. This function now automatically sets a source tracking header (e.g., `x-source: mcp`) along with other default headers, API keys, and base URLs from environment variables. Existing `Kernel` client usages were refactored to use this new helper.

## Validation
- [ ] Verified that API requests originating from MCP now include the expected source tracking header.
- [ ] Confirmed existing `Kernel` client functionality remains unchanged after refactoring.
<span data-mesa-description="end"></span>