### PR TITLE
ci: add MCP publish workflow and server.json

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,42 @@
+name: Publish MCP server.json
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write   # future-friendly if/when registry supports OIDC from Actions
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Install MCP Registry Publisher
+        run: go install github.com/modelcontextprotocol/registry/tools/publisher@latest
+
+      - name: Publish to MCP Registry
+        env:
+          MCP_GITHUB_TOKEN: ${{ secrets.MCP_GITHUB_TOKEN }}
+          MCP_REGISTRY_URL: https://registry.modelcontextprotocol.io
+        run: |
+          # Fail early if the file is missing
+          test -f .mcp/server.json
+
+          # Publish. The CLI defaults may evolve; these flags keep it explicit.
+          # If the CLI prefers envs, it will read MCP_GITHUB_TOKEN and MCP_REGISTRY_URL.
+          "$(go env GOPATH)"/bin/publisher \
+            publish \
+            --mcp-file .mcp/server.json \
+            --registry-url "$MCP_REGISTRY_URL" \
+            --github-token "$MCP_GITHUB_TOKEN"

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write   # future-friendly if/when registry supports OIDC from Actions
+  id-token: write
 
 jobs:
   publish:
@@ -27,16 +27,14 @@ jobs:
 
       - name: Publish to MCP Registry
         env:
-          MCP_GITHUB_TOKEN: ${{ secrets.MCP_GITHUB_TOKEN }}
           MCP_REGISTRY_URL: https://registry.modelcontextprotocol.io
         run: |
           # Fail early if the file is missing
-          test -f .mcp/server.json
+          test -f server.json
 
           # Publish. The CLI defaults may evolve; these flags keep it explicit.
-          # If the CLI prefers envs, it will read MCP_GITHUB_TOKEN and MCP_REGISTRY_URL.
+          # If the CLI prefers envs, it will read MCP_REGISTRY_URL.
           "$(go env GOPATH)"/bin/publisher \
             publish \
-            --mcp-file .mcp/server.json \
-            --registry-url "$MCP_REGISTRY_URL" \
-            --github-token "$MCP_GITHUB_TOKEN"
+            --mcp-file server.json \
+            --registry-url "$MCP_REGISTRY_URL"

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ Makefile
 
 # Redis
 **/*.rdb
+
+# private key
+pem.key

--- a/.gitignore
+++ b/.gitignore
@@ -105,4 +105,4 @@ Makefile
 **/*.rdb
 
 # private key
-key.pem
+mcp-key.pem

--- a/.gitignore
+++ b/.gitignore
@@ -105,4 +105,4 @@ Makefile
 **/*.rdb
 
 # private key
-pem.key
+key.pem

--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "com.onkernel/kernel",
   "title": "Kernel MCP Server",
-  "description": "Access Kernel’s cloud-based browsers and app actions via MCP (remote HTTP + OAuth).",
+  "description": "Access Kernel's cloud-based browsers and app actions via MCP (remote HTTP + OAuth).",
   "status": "active",
 
   "homepage_url": "https://onkernel.com",
@@ -20,7 +20,5 @@
     "transport": "streamable-http",
     "url": "https://mcp.onkernel.com/mcp",
     "auth": { "type": "oauth2" }
-  },
-
-  "version_detail": { "version": "1.0.0" }
+  }
 }

--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "com.onkernel/kernel",
+  "title": "Kernel MCP Server",
+  "description": "Access Kernel’s cloud-based browsers and app actions via MCP (remote HTTP + OAuth).",
+  "status": "active",
+
+  "homepage_url": "https://onkernel.com",
+  "documentation_url": "https://docs.onkernel.com/reference/mcp-server",
+  "repository": {
+    "source": "github",
+    "url": "https://github.com/onkernel/kernel-mcp-server"
+  },
+  "license": "MIT",
+
+  "tags": ["browser", "automation", "actions", "cloud"],
+  "categories": ["automation", "devtools"],
+
+  "remote": {
+    "transport": "streamable-http",
+    "url": "https://mcp.onkernel.com/mcp",
+    "auth": { "type": "oauth2" }
+  },
+
+  "version_detail": { "version": "1.0.0" }
+}

--- a/server.json
+++ b/server.json
@@ -1,24 +1,23 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
-  "name": "com.onkernel/kernel",
+  "name": "com.onkernel/kernel-mcp-server",
   "title": "Kernel MCP Server",
   "description": "Access Kernel's cloud-based browsers and app actions via MCP (remote HTTP + OAuth).",
   "status": "active",
-
   "homepage_url": "https://onkernel.com",
   "documentation_url": "https://docs.onkernel.com/reference/mcp-server",
   "repository": {
-    "source": "github",
-    "url": "https://github.com/onkernel/kernel-mcp-server"
+    "url": "https://github.com/onkernel/kernel-mcp-server",
+    "source": "github"
   },
   "license": "MIT",
-
+  "version": "1.0.0",
   "tags": ["browser", "automation", "actions", "cloud"],
   "categories": ["automation", "devtools"],
-
-  "remote": {
-    "transport": "streamable-http",
-    "url": "https://mcp.onkernel.com/mcp",
-    "auth": { "type": "oauth2" }
-  }
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.onkernel.com/mcp"
+    }
+  ]
 }


### PR DESCRIPTION
<!-- mesa-description-start -->
## TL;DR

Adds a GitHub Actions workflow to automatically publish the MCP server to the public registry.

## Why we made these changes

To automate the release process, making deployments faster and more consistent while reducing manual effort.

## What changed?

- **.github/workflows/publish-mcp.yml**: New GitHub Action that triggers on pushes to `main` to publish the server's configuration to the MCP Registry.
- **.mcp/server.json**: New configuration file defining the server's metadata, including its ID (`com.onkernel/kernel`) and transport endpoint.
- **.gitignore**: Updated to ignore `pem.key` files, preventing private keys from being committed.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->