### PR TITLE
ci: Install publisher via binary release

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -17,13 +17,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.22"
-
       - name: Install MCP Registry Publisher
-        run: go install github.com/modelcontextprotocol/registry/tools/publisher@latest
+        run: |
+          set -euo pipefail
+          ARCH="$(uname -m)"
+          if [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; elif [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; fi
+          OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          URL="https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_${OS}_${ARCH}.tar.gz"
+          curl -L "$URL" | tar xz mcp-publisher
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 mcp-publisher "$HOME/.local/bin/mcp-publisher"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Publish to MCP Registry
         env:
@@ -34,7 +38,6 @@ jobs:
 
           # Publish. The CLI defaults may evolve; these flags keep it explicit.
           # If the CLI prefers envs, it will read MCP_REGISTRY_URL.
-          "$(go env GOPATH)"/bin/publisher \
-            publish \
+          mcp-publisher publish \
             --mcp-file server.json \
             --registry-url "$MCP_REGISTRY_URL"


### PR DESCRIPTION
<!-- mesa-description-start -->
## TL;DR

Updated the `publish-mcp` workflow to install the `mcp-publisher` via its binary release instead of building it from source.

## Why we made these changes

Building the publisher from source during the CI run is slow and adds unnecessary complexity. Downloading a pre-compiled binary is faster, simplifies the workflow by removing the Go build dependency, and improves reliability.

## What changed?

- The `publish-mcp.yml` workflow now downloads the `mcp-publisher` binary directly from its GitHub release assets.
- Removed the `setup-go` action and the `go install` command, as the Go toolchain is no longer required.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->