### PR TITLE
ci: fix publisher binary copy path

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -32,7 +32,7 @@ jobs:
           git clone https://github.com/modelcontextprotocol/registry publisher-repo
           cd publisher-repo
           make publisher
-          cp cmd/publisher/bin/mcp-publisher ../mcp-publisher
+          cp bin/mcp-publisher ../mcp-publisher
           cd ..
           chmod +x mcp-publisher
       


### PR DESCRIPTION
<!-- mesa-description-start -->
## TL;DR

Fixes the binary copy path in the publisher release CI workflow.

## Why we made these changes

The publisher release workflow was failing because the binary was being copied to the wrong directory, causing subsequent steps to fail.

## What changed?

- Corrected the destination path in the CI workflow step that copies the publisher binary.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->