### PR TITLE
ci: fix MCP private key handling in workflow

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -38,8 +38,13 @@ jobs:
       
       - name: Login to MCP Registry
         run: |
-          echo "${{ secrets.MCP_PRIVATE_KEY }}" > key.pem
-          ./mcp-publisher login dns -domain onkernel.com --private-key $(openssl pkey -in key.pem -noout -text | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n')
+          KEY_B64='${{ secrets.MCP_PRIVATE_KEY }}'
+          ./mcp-publisher login dns --domain onkernel.com --private-key "$(
+            printf '-----BEGIN PRIVATE KEY-----\n%s\n-----END PRIVATE KEY-----\n' "$KEY_B64" \
+            | openssl pkey -in /dev/stdin -noout -text 2>/dev/null \
+            | awk '/priv:/{p=1;next}/pub:/{p=0}p' \
+            | tr -d ' :\n'
+          )"
 
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish


### PR DESCRIPTION
<!-- mesa-description-start -->
## TL;DR

Fixes how the MCP private key is handled in the CI workflow to ensure releases are not blocked.

## Why we made these changes

The previous method for handling the MCP private key was causing authentication failures in the release workflow. This change ensures the key is securely and reliably available to the necessary jobs.

## What changed?

- Updated `.github/workflows/publish-mcp.yml` to correctly load the MCP private key from GitHub secrets.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->