### PR TITLE
refactor(mintlify): switch to Assistant API format

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,8 @@ NEXT_PUBLIC_CLERK_DOMAIN=<x>
 API_BASE_URL=<x>
 
 # Mintlify API Configuration - Only needed for the search_docs tool call
-MINTLIFY_API_TOKEN=<x>
+MINTLIFY_ASSISTANT_API_TOKEN=<x>
+MINTLIFY_DOMAIN=<x>
 
 # Redis Configuration
 REDIS_URL=<x>


### PR DESCRIPTION
<!-- mesa-description-start -->
## TL;DR

Refactored the Mintlify integration, switching from a legacy API to the new Assistant API format for documentation search.

## Why we made these changes

The previous implementation was causing authentication errors. This change aligns our documentation search with Mintlify's current API standards, resolving the auth issues and ensuring future compatibility.

## What changed?

- Updated the request payload for the Mintlify search endpoint to conform to the Assistant API's message-based structure.
- Modified the response handling logic to correctly parse the new API format.
- Adjusted the authentication mechanism to work with the new endpoint.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->