### PR TITLE
feat: add OAuth discovery endpoints for ChatGPT MCP compatibility

### DIFF
--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest } from "next/server";
+
+export async function OPTIONS(): Promise<Response> {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    },
+  });
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const clerkDomain = process.env.NEXT_PUBLIC_CLERK_DOMAIN;
+
+  if (!clerkDomain) {
+    return Response.json(
+      { error: "server_error", error_description: "Clerk domain not found" },
+      { status: 500 },
+    );
+  }
+
+  const baseUrl = `${request.nextUrl.protocol}//${request.nextUrl.host}`;
+  const clerkBaseUrl = `https://${clerkDomain}`;
+
+  const metadata = {
+    issuer: baseUrl,
+    authorization_endpoint: `${baseUrl}/authorize`,
+    token_endpoint: `${baseUrl}/token`,
+    registration_endpoint: `${clerkBaseUrl}/oauth/register`,
+    jwks_uri: `${clerkBaseUrl}/.well-known/jwks.json`,
+    scopes_supported: ["openid"],
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: [
+      "none",
+      "client_secret_post",
+      "client_secret_basic",
+    ],
+  };
+
+  return Response.json(metadata, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    },
+  });
+}

--- a/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,52 @@
+import { protectedResourceHandlerClerk } from "@clerk/mcp-tools/next";
+import { NextRequest } from "next/server";
+
+const handler = async (request: NextRequest) => {
+  const clerkResponse = await protectedResourceHandlerClerk({
+    scopes_supported: ["openid"],
+  })(request);
+
+  const clerkMetadata = await clerkResponse.json();
+
+  const baseUrl = `${request.nextUrl.protocol}//${request.nextUrl.host}`;
+  const clerkDomain = process.env.NEXT_PUBLIC_CLERK_DOMAIN;
+
+  if (!clerkDomain) {
+    return Response.json(
+      { error: "server_error", error_description: "Clerk domain not found" },
+      { status: 500 },
+    );
+  }
+
+  const clerkBaseUrl = `https://${clerkDomain}`;
+
+  const modifiedMetadata: Record<string, unknown> = {
+    ...clerkMetadata,
+    resource: baseUrl,
+    authorization_servers: [baseUrl],
+    authorization_endpoint: `${baseUrl}/authorize`,
+    token_endpoint: `${baseUrl}/token`,
+    registration_endpoint: `${clerkBaseUrl}/oauth/register`,
+    scopes_supported: ["openid"],
+  };
+
+  return Response.json(modifiedMetadata, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    },
+  });
+};
+
+export const OPTIONS = async (): Promise<Response> =>
+  new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    },
+  });
+
+export { handler as GET };


### PR DESCRIPTION
## Summary

- Add `/.well-known/oauth-protected-resource` root-level route — ChatGPT strips the `/mcp` path suffix and checks the base URL, which was returning 404
- Add `/.well-known/oauth-authorization-server` route (RFC 8414) — the protected resource metadata declares `authorization_servers: ["https://mcp.onkernel.com"]`, so OAuth clients follow that to discover AS capabilities; the missing endpoint caused ChatGPT to report "does not implement OAuth"

## Context

ChatGPT's MCP connector failed with: _"MCP server https://mcp.onkernel.com/ does not implement OAuth"_

The existing `/.well-known/oauth-protected-resource/mcp` route was correct per RFC 9728 path construction, but ChatGPT also checks the root `/.well-known/oauth-protected-resource` and then follows `authorization_servers` to discover `/.well-known/oauth-authorization-server` — both of which were 404ing.

## Test plan

- [ ] Deploy and verify `https://mcp.onkernel.com/.well-known/oauth-protected-resource` returns JSON (not 404)
- [ ] Verify `https://mcp.onkernel.com/.well-known/oauth-authorization-server` returns JSON with `issuer`, `authorization_endpoint`, `token_endpoint`, etc.
- [ ] Connect `https://mcp.onkernel.com/mcp` from ChatGPT Apps / MCP connector and confirm OAuth flow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new public `/.well-known/*` OAuth discovery endpoints (with permissive CORS) that affect how clients locate auth/token servers; misconfiguration could break OAuth interoperability but does not change core token verification logic.
> 
> **Overview**
> Adds RFC-style OAuth discovery metadata endpoints to improve MCP client compatibility.
> 
> Introduces `/.well-known/oauth-authorization-server` to publish authorization server capabilities (issuer, auth/token endpoints, JWKS, supported grants, and auth methods) derived from the current host plus `NEXT_PUBLIC_CLERK_DOMAIN`. Also adds a root `/.well-known/oauth-protected-resource` endpoint (in addition to the existing `/mcp` variant) that proxies Clerk-provided metadata and rewrites it to point clients at this server’s `/authorize` and `/token`, returning CORS-enabled JSON responses for both `GET` and `OPTIONS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40a0a2e7d4f7a910ff39f96e2c1bb0406a12ad38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->