### PR TITLE
ci: add Semgrep SAST scanning on pull requests

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,17 @@
+name: Semgrep
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan:
+    uses: kernel/security-workflows/.github/workflows/semgrep.yml@main
+    with:
+      extra-configs: '--config p/javascript --config p/typescript'
+      codebase-description: 'Hosted MCP server handling authenticated tool execution and browser session data'
+    secrets: inherit

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+.next/
+out/
+bun.lock
+package-lock.json
+**/*.test.ts
+**/*.spec.ts


### PR DESCRIPTION
Adds Semgrep static analysis on PRs to main via the reusable workflow in kernel/security-workflows. Includes .semgrepignore for generated code, test fixtures, and lock files.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds CI security scanning and an ignore file without changing runtime code. Main risk is potential PR noise or CI failures from new Semgrep findings/misconfigured ignores.
> 
> **Overview**
> Adds a new GitHub Actions workflow, `semgrep.yml`, to run Semgrep SAST on pull requests targeting `main` via the reusable `kernel/security-workflows` workflow, with JavaScript/TypeScript rules enabled.
> 
> Introduces `.semgrepignore` to exclude common generated/build outputs, dependencies, lockfiles, and test files from scanning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72a946aa6512c0ce135d12a8fcedfe2ed7cd1290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->