### PR TITLE
Add project scoping support

### DIFF
--- a/src/app/[transport]/route.ts
+++ b/src/app/[transport]/route.ts
@@ -21,8 +21,7 @@ function createKernelClient(apiKey: string) {
     "X-Referral-Source": "mcp.onkernel.com",
   };
 
-  const projectId =
-    process.env.KERNEL_PROJECT || process.env.KERNEL_PROJECT_ID;
+  const projectId = process.env.KERNEL_PROJECT;
   if (projectId) {
     headers["X-Kernel-Project-Id"] = projectId;
   }

--- a/src/app/[transport]/route.ts
+++ b/src/app/[transport]/route.ts
@@ -16,13 +16,21 @@ interface MintlifySearchResult {
 }
 
 function createKernelClient(apiKey: string) {
+  const headers: Record<string, string> = {
+    "X-Source": "mcp-server",
+    "X-Referral-Source": "mcp.onkernel.com",
+  };
+
+  const projectId =
+    process.env.KERNEL_PROJECT || process.env.KERNEL_PROJECT_ID;
+  if (projectId) {
+    headers["X-Kernel-Project-Id"] = projectId;
+  }
+
   return new Kernel({
     apiKey,
     baseURL: process.env.API_BASE_URL,
-    defaultHeaders: {
-      "X-Source": "mcp-server",
-      "X-Referral-Source": "mcp.onkernel.com",
-    },
+    defaultHeaders: headers,
   });
 }
 


### PR DESCRIPTION
Adds server-side project scoping for the MCP server.

## What changed

`createKernelClient()` now reads `KERNEL_PROJECT` from env vars and, when set, injects the `X-Kernel-Project-Id` header into all SDK requests.

## Scope

This is **server-side env-var scoping** — the deployment is pinned to one project for every user that connects. Useful for **self-hosted MCP deployments** where the operator wants every connecting user/agent locked to a single project.

For the hosted `mcp.onkernel.com` (multi-tenant), this env var is not the right knob — it would scope every user of the hosted deployment to the same project. For per-user project scoping on hosted MCP, use either:

- A **project-scoped API key** as the bearer token — works today, no header needed (the server resolves scope from the key).
- Once OAuth project scoping ships (Neil), the Clerk OAuth token will carry the user's selected project.

## Notes

- Reads `KERNEL_PROJECT` only. `KERNEL_PROJECT_ID` was never shipped, so there's no legacy fallback to preserve.
- If `KERNEL_PROJECT` is not set, no header is sent (backwards compatible).

## Related

- Dashboard: kernel/kernel#1692
- CLI: kernel/cli#147