### PR TITLE
fix(select-org): show all of a user's orgs

### DIFF
--- a/src/app/select-org/page.tsx
+++ b/src/app/select-org/page.tsx
@@ -12,8 +12,15 @@ function SelectOrgContent(): React.ReactElement {
   const { isLoaded, setActive, userMemberships } = useOrganizationList({
     userMemberships: {
       infinite: true,
+      pageSize: 100,
     },
   });
+
+  useEffect(() => {
+    if (userMemberships?.hasNextPage && !userMemberships.isFetching) {
+      userMemberships.fetchNext?.();
+    }
+  }, [userMemberships?.hasNextPage, userMemberships?.isFetching]);
   const { orgId } = useAuth();
   const { user } = useUser();
   const searchParams = useSearchParams();


### PR DESCRIPTION
## Summary

- The select-org page was only showing 10 organizations because Clerk's `useOrganizationList` defaults `pageSize` to 10. `infinite: true` only *enables* pagination — nothing in the page ever called `fetchNext()`.
- Bumped `pageSize` to 100 and added an effect that calls `fetchNext()` while `hasNextPage` is true, so users with more memberships still see everything.

## Test plan

- [ ] Sign in as a user with >10 org memberships and confirm all orgs appear in the list.
- [ ] Sign in as a user with <10 org memberships and confirm behavior is unchanged.
- [ ] Confirm scroll fade indicators still render correctly when the list overflows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to org list loading on the select-org page; no auth, data, or payment logic touched.
> 
> **Overview**
> Fixes the **select-org** screen so users with many Clerk memberships see the full list instead of only the first page.
> 
> `useOrganizationList` now requests **`pageSize: 100`** (Clerk’s default is 10). A **`useEffect`** keeps calling **`fetchNext()`** while **`hasNextPage`** is true and a fetch isn’t already in flight, so pagination actually loads remaining memberships when someone has more than one page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a663cb70bbbb635e62e8150bb5f923f4e26894b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->