### PR TITLE
Support Redis TLS server name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ MINTLIFY_DOMAIN=<x>
 
 # Redis Configuration
 REDIS_URL=<x> # redis://127.0.0.1:6379
+# REDIS_TLS_SERVER_NAME=<x> # optional; requires REDIS_URL to use rediss://
 
 # OAuth Client IDs
 KERNEL_CLI_PROD_CLIENT_ID=<x>

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,16 +1,34 @@
 import { createClient } from "redis";
 import { createHmac } from "crypto";
 
+const redisUrl = process.env.REDIS_URL;
+const redisTlsServerName = process.env.REDIS_TLS_SERVER_NAME;
+const parsedRedisUrl = redisUrl ? new URL(redisUrl) : null;
+
+if (redisTlsServerName && parsedRedisUrl?.protocol !== "rediss:") {
+  throw new Error("REDIS_TLS_SERVER_NAME requires REDIS_URL to use rediss://");
+}
+
+// Modest backoff to smooth over first-hit cold connections
+const reconnectStrategy = (retries: number) =>
+  Math.min(500 + retries * 100, 2000);
+
 // Connect on first use
 let isConnected = false;
 let connectPromise: Promise<void> | null = null;
 
 const client = createClient({
-  url: process.env.REDIS_URL,
-  socket: {
-    // Modest backoff to smooth over first-hit cold connections
-    reconnectStrategy: (retries) => Math.min(500 + retries * 100, 2000),
-  },
+  url: redisUrl,
+  socket: redisTlsServerName
+    ? {
+        host: parsedRedisUrl!.hostname,
+        tls: true,
+        servername: redisTlsServerName,
+        reconnectStrategy,
+      }
+    : {
+        reconnectStrategy,
+      },
 });
 
 client.on("error", (err) => {


### PR DESCRIPTION
## Summary
- read REDIS_TLS_SERVER_NAME in the MCP Redis client
- pass it through as the TLS servername for rediss:// connections
- document the optional env var in the example env file

## Testing
- bunx prettier --check src/lib/redis.ts
- bunx tsc --noEmit
- bun run build reaches compile/typecheck, then local prerender requires valid Clerk env values

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, opt-in connection configuration for managed Redis TLS; no changes to auth or data key logic.
> 
> **Overview**
> Adds optional **TLS SNI** support for Redis when connecting over `rediss://`.
> 
> The MCP Redis client now reads `REDIS_TLS_SERVER_NAME` and, when set, configures the socket with `tls: true` and `servername` (using the URL hostname for `host`). Startup **fails fast** if that variable is set but `REDIS_URL` is not `rediss://`. Reconnect backoff is unchanged; it is just shared via a small refactor.
> 
> `.env.example` documents the new optional variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28fe644776eb3d3ad19865a35501906b2e872056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->