### PR TITLE
[codex] Update Kernel SDK compatibility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@clerk/themes": "^2.4.19",
         "@mcp-ui/server": "^5.10.0",
         "@modelcontextprotocol/sdk": "1.26.0",
-        "@onkernel/sdk": "^0.35.0",
+        "@onkernel/sdk": "^0.58.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/redis": "^4.0.11",
         "builtin-modules": "^5.0.0",
@@ -145,7 +145,7 @@
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.0.10", "", { "os": "win32", "cpu": "x64" }, "sha512-E+njfCoFLb01RAFEnGZn6ERoOqhK1Gl3Lfz1Kjnj0Ulfu7oJbuMyvBKNj/bw8XZnenHDASlygTjZICQW+rYW1Q=="],
 
-    "@onkernel/sdk": ["@onkernel/sdk@0.35.0", "", {}, "sha512-EnTEyTm85WwOOXZziDTySNHl46ZO+DSJjVDJDJNarwkD+kv623TzXDLpgH7vwy4LfQjQ4DzOQe0hHKgCYrAv5A=="],
+    "@onkernel/sdk": ["@onkernel/sdk@0.58.0", "", {}, "sha512-eJNydQ8WzZWq837EX+V2QMUhK4O8feVnj9EXZukOvOHXH9PfIr40IQXUxIZ1ic/s08witQ6hQmtlCqY7VeF2aQ=="],
 
     "@redis/bloom": ["@redis/bloom@5.6.0", "", { "peerDependencies": { "@redis/client": "^5.6.0" } }, "sha512-l13/d6BaZDJzogzZJEphIeZ8J0hpQpjkMiozomTm6nJiMNYkoPsNOBOOQua4QsG0fFjyPmLMDJFPAp5FBQtTXg=="],
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@clerk/themes": "^2.4.19",
     "@mcp-ui/server": "^5.10.0",
     "@modelcontextprotocol/sdk": "1.26.0",
-    "@onkernel/sdk": "^0.35.0",
+    "@onkernel/sdk": "^0.58.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/redis": "^4.0.11",
     "builtin-modules": "^5.0.0",

--- a/src/app/[transport]/route.ts
+++ b/src/app/[transport]/route.ts
@@ -67,6 +67,14 @@ function createAuthErrorResponse(
   );
 }
 
+async function listProfiles(client: ReturnType<typeof createKernelClient>) {
+  const profiles: Awaited<ReturnType<typeof client.profiles.retrieve>>[] = [];
+  for await (const profile of client.profiles.list()) {
+    profiles.push(profile);
+  }
+  return profiles;
+}
+
 // Create MCP handler with tools
 const handler = createMcpHandler((server) => {
   // Register MCP resources
@@ -80,7 +88,7 @@ const handler = createMcpHandler((server) => {
 
     if (uriString === "profiles://") {
       // List all profiles
-      const profiles = await client.profiles.list();
+      const profiles = await listProfiles(client);
       return {
         contents: [
           {
@@ -915,7 +923,7 @@ Based on your issue "${issue_description}", start with:
                   },
                 ],
               };
-            const existingProfiles = await client.profiles.list();
+            const existingProfiles = await listProfiles(client);
             const existingProfile = existingProfiles?.find(
               (p) => p.name === params.profile_name,
             );
@@ -973,7 +981,7 @@ Based on your issue "${issue_description}", start with:
             };
           }
           case "list": {
-            const profiles = await client.profiles.list();
+            const profiles = await listProfiles(client);
             return {
               content: [
                 {

--- a/src/app/[transport]/route.ts
+++ b/src/app/[transport]/route.ts
@@ -94,7 +94,7 @@ const handler = createMcpHandler((server) => {
           {
             uri: "profiles://",
             mimeType: "application/json",
-            text: profiles
+            text: profiles.length > 0
               ? JSON.stringify(profiles, null, 2)
               : "No profiles found",
           },


### PR DESCRIPTION
## Summary

- Bump `@onkernel/sdk` to the `^0.58.0` release line.
- Adapt MCP profile listing call sites to the SDK 0.58 paginated `profiles.list()` response.
- Preserve the previous all-profiles behavior by iterating the SDK paginator before listing profiles or checking for existing profile names.

## Validation

- `git diff --check`
- `bun run build` with dummy build-time Clerk/OAuth env values and network access for Google Fonts
- `python3 /Users/ilyaas/.codex/skills/autoreview/scripts/autoreview --mode local` clean after the pagination fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Profile setup and listing depend on fully consuming the new paginator; incomplete iteration could miss existing profiles or change duplicate-detection behavior, though the change is localized to profile APIs.
> 
> **Overview**
> Upgrades **`@onkernel/sdk`** from `^0.35.0` to **`^0.58.0`** and updates the MCP server so profile listing still returns the full set of profiles.
> 
> SDK **0.58** exposes **`profiles.list()`** as a **paginated async iterator**, not a plain array. A new **`listProfiles`** helper drains that iterator into an array, and all former direct **`client.profiles.list()`** call sites (the `profiles://` resource, **`manage_profiles`** setup duplicate check, and list action) now use it. The profiles resource empty response is keyed off **`profiles.length`** instead of treating the list result as an array directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 078dc8fb8d9db91805298e79984eb1c006f310dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->