### PR TITLE
[codex] Add MCP project management tool

### DIFF
--- a/src/lib/mcp/register.ts
+++ b/src/lib/mcp/register.ts
@@ -8,6 +8,7 @@ import { registerDocsTools } from "@/lib/mcp/tools/docs";
 import { registerExtensionTools } from "@/lib/mcp/tools/extensions";
 import { registerPlaywrightTool } from "@/lib/mcp/tools/playwright";
 import { registerProfileCapabilities } from "@/lib/mcp/tools/profiles";
+import { registerProjectCapabilities } from "@/lib/mcp/tools/projects";
 import { registerProxyTools } from "@/lib/mcp/tools/proxies";
 import { registerShellTool } from "@/lib/mcp/tools/shell";
 
@@ -16,6 +17,7 @@ export function registerMcpCapabilities(server: McpServer) {
   registerKernelPrompts(server);
   registerDocsTools(server);
   registerBrowserCapabilities(server);
+  registerProjectCapabilities(server);
   registerBrowserPoolCapabilities(server);
   registerProxyTools(server);
   registerExtensionTools(server);

--- a/src/lib/mcp/tools/projects.ts
+++ b/src/lib/mcp/tools/projects.ts
@@ -1,0 +1,159 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { createKernelClient } from "@/lib/mcp/kernel-client";
+
+export function registerProjectCapabilities(server: McpServer) {
+  // manage_projects -- Create, list, get, update, and delete organization projects
+  server.tool(
+    "manage_projects",
+    'Manage Kernel projects for resource isolation within an organization. Use "create" to create a project, "list" to discover projects, "get" to retrieve one, "update" to rename or archive one, or "delete" to remove an empty project.',
+    {
+      action: z
+        .enum(["create", "list", "get", "update", "delete"])
+        .describe("Operation to perform."),
+      project_id: z
+        .string()
+        .describe("Project ID. Required for get, update, and delete.")
+        .optional(),
+      name: z.string().describe("(create, update) Project name.").optional(),
+      status: z
+        .enum(["active", "archived"])
+        .describe('(update) Project status. Use "archived" to archive.')
+        .optional(),
+      query: z
+        .string()
+        .describe(
+          "(list) Case-insensitive substring match against project name.",
+        )
+        .optional(),
+      limit: z.number().describe("(list) Max results per page.").optional(),
+      offset: z.number().describe("(list) Pagination offset.").optional(),
+    },
+    async (params, extra) => {
+      if (!extra.authInfo) throw new Error("Authentication required");
+      const client = createKernelClient(extra.authInfo.token);
+
+      try {
+        switch (params.action) {
+          case "create": {
+            if (!params.name) {
+              return {
+                content: [
+                  { type: "text", text: "Error: name is required for create." },
+                ],
+              };
+            }
+            const project = await client.projects.create({ name: params.name });
+            return {
+              content: [
+                { type: "text", text: JSON.stringify(project, null, 2) },
+              ],
+            };
+          }
+          case "list": {
+            const page = await client.projects.list({
+              ...(params.query && { query: params.query }),
+              ...(params.limit !== undefined && { limit: params.limit }),
+              ...(params.offset !== undefined && { offset: params.offset }),
+            });
+            const items = page.getPaginatedItems();
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    {
+                      items,
+                      has_more: page.has_more,
+                      next_offset: page.next_offset,
+                    },
+                    null,
+                    2,
+                  ),
+                },
+              ],
+            };
+          }
+          case "get": {
+            if (!params.project_id) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: "Error: project_id is required for get.",
+                  },
+                ],
+              };
+            }
+            const project = await client.projects.retrieve(params.project_id);
+            return {
+              content: [
+                { type: "text", text: JSON.stringify(project, null, 2) },
+              ],
+            };
+          }
+          case "update": {
+            if (!params.project_id) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: "Error: project_id is required for update.",
+                  },
+                ],
+              };
+            }
+            if (!params.name && !params.status) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: "Error: name or status is required for update.",
+                  },
+                ],
+              };
+            }
+            const updateParams: Parameters<typeof client.projects.update>[1] =
+              {};
+            if (params.name) updateParams.name = params.name;
+            if (params.status) updateParams.status = params.status;
+            const project = await client.projects.update(
+              params.project_id,
+              updateParams,
+            );
+            return {
+              content: [
+                { type: "text", text: JSON.stringify(project, null, 2) },
+              ],
+            };
+          }
+          case "delete": {
+            if (!params.project_id) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: "Error: project_id is required for delete.",
+                  },
+                ],
+              };
+            }
+            await client.projects.delete(params.project_id);
+            return {
+              content: [{ type: "text", text: "Project deleted successfully" }],
+            };
+          }
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error in manage_projects (${params.action}): ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Add `manage_projects` for Kernel project create/list/get/update/delete workflows.
- Register the projects tool through the new MCP capability module stack from PR 1.5.
- Keep project handling isolated in `src/lib/mcp/tools/projects.ts` so `route.ts` stays HTTP/auth-only.

## Agent Experience / Flow

This PR gives agents a first-class way to discover and select the project boundary before doing resource-scoped work. Projects are the isolation primitive that later tools, especially API-key creation, depend on through `project_id`.

Typical flow:

1. Agent calls `manage_projects list` to discover existing projects and avoid creating duplicates.
2. If the user names a project, agent uses `query` on list or `get` by known `project_id` to resolve the exact target.
3. If no suitable project exists, agent calls `manage_projects create name=<name>` and keeps the returned `project_id` for downstream tool calls.
4. For project-scoped API keys, agent passes that returned `project_id` into `manage_api_keys create` from the next PR.
5. If project metadata needs to change, agent calls `manage_projects update project_id=<id> name=<new>` or `status=archived`.
6. Agent only calls `delete` for scratch or explicitly requested projects, because project deletion affects the resource boundary for other workflows.

Agent ergonomics:

- The action-oriented schema keeps all project lifecycle operations in one tool, but required IDs stay explicit per action.
- List pagination lets agents scan safely before mutating.
- Returning the full project object after create/get/update gives agents a stable `project_id` handoff to later tools.

## Validation

- `git diff --check codex/route-tools-breakdown...HEAD`
- `KERNEL_CLI_PROD_CLIENT_ID=dummy-prod KERNEL_CLI_STAGING_CLIENT_ID=dummy-staging KERNEL_CLI_DEV_CLIENT_ID=dummy-dev NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_Y2xlcmsuZXhhbXBsZS5jb20k bun run build`
- `python3 /Users/ilyaas/.codex/skills/autoreview/scripts/autoreview --mode branch --base codex/route-tools-breakdown`
- localhost MCP CRUD smoke against `http://127.0.0.1:3002/mcp` with `API_BASE_URL=http://127.0.0.1:3001`: initialized MCP, verified `manage_projects` was listed, created a scratch project, got/updated/listed/deleted it, and confirmed post-delete get failed as expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces authenticated create/update/delete against org projects; mistakes or overly broad MCP access could change isolation boundaries, though behavior mirrors existing MCP tool patterns.
> 
> **Overview**
> Exposes **Kernel project lifecycle** over MCP via a new **`manage_projects`** tool (create, list, get, update, delete), including list pagination and archive-by-status on update.
> 
> Wires it in through **`registerProjectCapabilities`** in `register.ts`, with implementation isolated in **`projects.ts`** using the authenticated Kernel client like other MCP tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 608f5aae528d2a659d752b69c69c0c848c56d80c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->