### PR TITLE
Add MCP API key management tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ API_BASE_URL=<x>
 MINTLIFY_ASSISTANT_API_TOKEN=mint_dsc_<x>
 MINTLIFY_DOMAIN=<x>
 
+# Optional MCP toolset gating. Comma-separated values.
+# Example: api_keys hides manage_api_keys so deployments can opt out of key management.
+# Supported: apps, api_keys, browser_pools, browsers, computer, docs, extensions, playwright, profiles, projects, proxies, shell
+# KERNEL_MCP_DISABLED_TOOLSETS=api_keys
+
 # Redis Configuration
 REDIS_URL=<x> # redis://127.0.0.1:6379
 # REDIS_TLS_SERVER_NAME=<x> # optional; requires REDIS_URL to use rediss://

--- a/README.md
+++ b/README.md
@@ -255,9 +255,11 @@ Many other MCP-capable tools accept:
 
 Configure these values wherever the tool expects MCP server settings.
 
-## Tools (10 total)
+## Tools (12 total)
 
 Each Kernel feature has a single `manage_*` tool with an `action` parameter, keeping the tool set small and consistent. Four standalone tools handle high-frequency workflows.
+
+Self-hosted deployments can hide sensitive tool families by setting `KERNEL_MCP_DISABLED_TOOLSETS` to a comma-separated list. For example, `KERNEL_MCP_DISABLED_TOOLSETS=api_keys` prevents `manage_api_keys` from being registered.
 
 ### manage\_\* tools
 
@@ -267,6 +269,8 @@ Each Kernel feature has a single `manage_*` tool with an `action` parameter, kee
 - `manage_proxies` - Create, list, and delete proxy configurations (datacenter, ISP, residential, mobile, custom).
 - `manage_extensions` - List and delete uploaded browser extensions.
 - `manage_apps` - List apps, invoke actions, get/list deployments, and get invocation results.
+- `manage_projects` - Create, list, get, update, and delete organization projects.
+- `manage_api_keys` - Create, list, get, update, and delete Kernel API keys. Create returns the plaintext key once.
 
 ### Standalone tools
 

--- a/src/lib/mcp/register.ts
+++ b/src/lib/mcp/register.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerKernelPrompts } from "@/lib/mcp/prompts";
+import { registerAPIKeyCapabilities } from "@/lib/mcp/tools/api-keys";
 import { registerAppCapabilities } from "@/lib/mcp/tools/apps";
 import { registerBrowserPoolCapabilities } from "@/lib/mcp/tools/browser-pools";
 import { registerBrowserCapabilities } from "@/lib/mcp/tools/browsers";
@@ -18,6 +19,7 @@ export function registerMcpCapabilities(server: McpServer) {
   registerDocsTools(server);
   registerBrowserCapabilities(server);
   registerProjectCapabilities(server);
+  registerAPIKeyCapabilities(server);
   registerBrowserPoolCapabilities(server);
   registerProxyTools(server);
   registerExtensionTools(server);

--- a/src/lib/mcp/register.ts
+++ b/src/lib/mcp/register.ts
@@ -13,18 +13,103 @@ import { registerProjectCapabilities } from "@/lib/mcp/tools/projects";
 import { registerProxyTools } from "@/lib/mcp/tools/proxies";
 import { registerShellTool } from "@/lib/mcp/tools/shell";
 
+type RegisterMcpToolset = (server: McpServer) => void;
+
+const mcpToolRegistrations = [
+  ["profiles", registerProfileCapabilities],
+  ["docs", registerDocsTools],
+  ["browsers", registerBrowserCapabilities],
+  ["projects", registerProjectCapabilities],
+  ["api_keys", registerAPIKeyCapabilities],
+  ["browser_pools", registerBrowserPoolCapabilities],
+  ["proxies", registerProxyTools],
+  ["extensions", registerExtensionTools],
+  ["apps", registerAppCapabilities],
+  ["computer", registerComputerActionTool],
+  ["shell", registerShellTool],
+  ["playwright", registerPlaywrightTool],
+] as const satisfies readonly (readonly [string, RegisterMcpToolset])[];
+
+type McpToolset = (typeof mcpToolRegistrations)[number][0];
+
+const mcpToolsets = mcpToolRegistrations.map(([toolset]) => toolset);
+const mcpToolsetSet: ReadonlySet<string> = new Set(mcpToolsets);
+
+const standaloneToolsetAliases: Partial<Record<string, McpToolset>> = {
+  computer_action: "computer",
+  search_docs: "docs",
+  execute_playwright_code: "playwright",
+  exec_command: "shell",
+};
+
+function isMcpToolset(value: string): value is McpToolset {
+  return mcpToolsetSet.has(value);
+}
+
+function normalizeMcpToolset(value: string): McpToolset | undefined {
+  const token = value.trim().toLowerCase().replace(/-/g, "_");
+  if (isMcpToolset(token)) return token;
+  if (standaloneToolsetAliases[token]) return standaloneToolsetAliases[token];
+
+  const managePrefix = "manage_";
+  if (token.startsWith(managePrefix)) {
+    const managedToolset = token.slice(managePrefix.length);
+    if (isMcpToolset(managedToolset)) return managedToolset;
+  }
+
+  return undefined;
+}
+
+function disabledMcpToolsetsFromEnv() {
+  const raw = process.env.KERNEL_MCP_DISABLED_TOOLSETS;
+  if (!raw?.trim()) return new Set<McpToolset>();
+
+  const disabled = new Set<McpToolset>();
+  let disableAll = false;
+  const unknown: string[] = [];
+
+  for (const value of raw.split(/[,\s]+/)) {
+    const token = value.trim().toLowerCase();
+    if (!token || token === "none") continue;
+    if (token === "all") {
+      disableAll = true;
+      continue;
+    }
+
+    const toolset = normalizeMcpToolset(token);
+    if (toolset) {
+      disabled.add(toolset);
+    } else {
+      unknown.push(value);
+    }
+  }
+
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown KERNEL_MCP_DISABLED_TOOLSETS value(s): ${unknown.join(", ")}. Supported toolsets: ${mcpToolsets.join(", ")}.`,
+    );
+  }
+
+  if (disableAll) return new Set<McpToolset>(mcpToolsets);
+
+  return disabled;
+}
+
+function toolsetEnabled(
+  disabledToolsets: Set<McpToolset>,
+  toolset: McpToolset,
+) {
+  return !disabledToolsets.has(toolset);
+}
+
 export function registerMcpCapabilities(server: McpServer) {
-  registerProfileCapabilities(server);
+  const disabledToolsets = disabledMcpToolsetsFromEnv();
+
   registerKernelPrompts(server);
-  registerDocsTools(server);
-  registerBrowserCapabilities(server);
-  registerProjectCapabilities(server);
-  registerAPIKeyCapabilities(server);
-  registerBrowserPoolCapabilities(server);
-  registerProxyTools(server);
-  registerExtensionTools(server);
-  registerAppCapabilities(server);
-  registerComputerActionTool(server);
-  registerShellTool(server);
-  registerPlaywrightTool(server);
+
+  for (const [toolset, registerToolset] of mcpToolRegistrations) {
+    if (toolsetEnabled(disabledToolsets, toolset)) {
+      registerToolset(server);
+    }
+  }
 }

--- a/src/lib/mcp/register.ts
+++ b/src/lib/mcp/register.ts
@@ -46,15 +46,19 @@ function isMcpToolset(value: string): value is McpToolset {
   return mcpToolsetSet.has(value);
 }
 
+function resolveMcpToolset(token: string): McpToolset | undefined {
+  if (isMcpToolset(token)) return token;
+  return standaloneToolsetAliases[token];
+}
+
 function normalizeMcpToolset(value: string): McpToolset | undefined {
   const token = value.trim().toLowerCase().replace(/-/g, "_");
-  if (isMcpToolset(token)) return token;
-  if (standaloneToolsetAliases[token]) return standaloneToolsetAliases[token];
+  const toolset = resolveMcpToolset(token);
+  if (toolset) return toolset;
 
   const managePrefix = "manage_";
   if (token.startsWith(managePrefix)) {
-    const managedToolset = token.slice(managePrefix.length);
-    if (isMcpToolset(managedToolset)) return managedToolset;
+    return resolveMcpToolset(token.slice(managePrefix.length));
   }
 
   return undefined;

--- a/src/lib/mcp/responses.ts
+++ b/src/lib/mcp/responses.ts
@@ -1,0 +1,29 @@
+type PaginatedPage<T> = {
+  getPaginatedItems(): T[];
+  has_more?: boolean | null;
+  next_offset?: number | null;
+};
+
+export function textResponse(text: string) {
+  return { content: [{ type: "text" as const, text }] };
+}
+
+export function jsonResponse(value: unknown) {
+  return textResponse(JSON.stringify(value, null, 2) ?? String(value));
+}
+
+export function paginatedJsonResponse<T>(page: PaginatedPage<T>) {
+  return jsonResponse({
+    items: page.getPaginatedItems(),
+    has_more: page.has_more,
+    next_offset: page.next_offset,
+  });
+}
+
+export function errorResponse(text: string) {
+  return { ...textResponse(text), isError: true as const };
+}
+
+export function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/lib/mcp/responses.ts
+++ b/src/lib/mcp/responses.ts
@@ -24,6 +24,16 @@ export function errorResponse(text: string) {
   return { ...textResponse(text), isError: true as const };
 }
 
-export function errorMessage(error: unknown) {
+function errorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error);
+}
+
+export function toolErrorResponse(
+  toolName: string,
+  action: string,
+  error: unknown,
+) {
+  return errorResponse(
+    `Error in ${toolName} (${action}): ${errorMessage(error)}`,
+  );
 }

--- a/src/lib/mcp/schemas.ts
+++ b/src/lib/mcp/schemas.ts
@@ -3,12 +3,14 @@ import { z } from "zod";
 export const paginationParams = {
   limit: z
     .number()
+    .int()
     .describe(
       "(list) Max results per page. Defaults to 20; API clamps to 1-100.",
     )
     .optional(),
   offset: z
     .number()
+    .int()
     .describe(
       "(list) Pagination offset. Defaults to 0; API clamps negatives to 0.",
     )

--- a/src/lib/mcp/schemas.ts
+++ b/src/lib/mcp/schemas.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const paginationParams = {
+  limit: z
+    .number()
+    .describe(
+      "(list) Max results per page. Defaults to 20; API clamps to 1-100.",
+    )
+    .optional(),
+  offset: z
+    .number()
+    .describe(
+      "(list) Pagination offset. Defaults to 0; API clamps negatives to 0.",
+    )
+    .optional(),
+};

--- a/src/lib/mcp/tools/api-keys.ts
+++ b/src/lib/mcp/tools/api-keys.ts
@@ -8,6 +8,7 @@ import {
   paginatedJsonResponse,
   textResponse,
 } from "@/lib/mcp/responses";
+import { paginationParams } from "@/lib/mcp/schemas";
 
 export function registerAPIKeyCapabilities(server: McpServer) {
   // manage_api_keys -- Create, list, get, update, and delete Kernel API keys
@@ -40,18 +41,7 @@ export function registerAPIKeyCapabilities(server: McpServer) {
           "(create) Days until expiry, up to 3650. Use null for no expiry.",
         )
         .optional(),
-      limit: z
-        .number()
-        .int()
-        .min(1)
-        .describe("(list) Max results per page.")
-        .optional(),
-      offset: z
-        .number()
-        .int()
-        .min(0)
-        .describe("(list) Pagination offset.")
-        .optional(),
+      ...paginationParams,
     },
     async (params, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");

--- a/src/lib/mcp/tools/api-keys.ts
+++ b/src/lib/mcp/tools/api-keys.ts
@@ -1,0 +1,166 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { createKernelClient } from "@/lib/mcp/kernel-client";
+
+export function registerAPIKeyCapabilities(server: McpServer) {
+  // manage_api_keys -- Create, list, get, update, and delete Kernel API keys
+  server.tool(
+    "manage_api_keys",
+    'Manage Kernel API keys. Use "create" to create an org-wide or project-scoped key, "list" to discover masked keys, "get" to retrieve one masked key, "update" to rename a key, or "delete" to revoke a key. Created keys include the plaintext key once.',
+    {
+      action: z
+        .enum(["create", "list", "get", "update", "delete"])
+        .describe("Operation to perform."),
+      api_key_id: z
+        .string()
+        .describe("API key ID. Required for get, update, and delete.")
+        .optional(),
+      name: z.string().describe("(create, update) API key name.").optional(),
+      project_id: z
+        .string()
+        .nullable()
+        .describe(
+          "(create) Project ID for project-scoped keys. Omit or use null for org-wide keys.",
+        )
+        .optional(),
+      days_to_expire: z
+        .number()
+        .int()
+        .min(1)
+        .max(3650)
+        .nullable()
+        .describe(
+          "(create) Days until expiry, up to 3650. Use null for no expiry.",
+        )
+        .optional(),
+      limit: z.number().describe("(list) Max results per page.").optional(),
+      offset: z.number().describe("(list) Pagination offset.").optional(),
+    },
+    async (params, extra) => {
+      if (!extra.authInfo) throw new Error("Authentication required");
+      const client = createKernelClient(extra.authInfo.token);
+
+      try {
+        switch (params.action) {
+          case "create": {
+            if (!params.name) {
+              return {
+                content: [
+                  { type: "text", text: "Error: name is required for create." },
+                ],
+              };
+            }
+            const createParams: Parameters<typeof client.apiKeys.create>[0] = {
+              name: params.name,
+            };
+            if (params.project_id !== undefined) {
+              createParams.project_id = params.project_id;
+            }
+            if (params.days_to_expire !== undefined) {
+              createParams.days_to_expire = params.days_to_expire;
+            }
+            const apiKey = await client.apiKeys.create(createParams);
+            return {
+              content: [
+                { type: "text", text: JSON.stringify(apiKey, null, 2) },
+              ],
+            };
+          }
+          case "list": {
+            const page = await client.apiKeys.list({
+              ...(params.limit !== undefined && { limit: params.limit }),
+              ...(params.offset !== undefined && { offset: params.offset }),
+            });
+            const items = page.getPaginatedItems();
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    {
+                      items,
+                      has_more: page.has_more,
+                      next_offset: page.next_offset,
+                    },
+                    null,
+                    2,
+                  ),
+                },
+              ],
+            };
+          }
+          case "get": {
+            if (!params.api_key_id) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: "Error: api_key_id is required for get.",
+                  },
+                ],
+              };
+            }
+            const apiKey = await client.apiKeys.retrieve(params.api_key_id);
+            return {
+              content: [
+                { type: "text", text: JSON.stringify(apiKey, null, 2) },
+              ],
+            };
+          }
+          case "update": {
+            if (!params.api_key_id) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: "Error: api_key_id is required for update.",
+                  },
+                ],
+              };
+            }
+            if (!params.name) {
+              return {
+                content: [
+                  { type: "text", text: "Error: name is required for update." },
+                ],
+              };
+            }
+            const apiKey = await client.apiKeys.update(params.api_key_id, {
+              name: params.name,
+            });
+            return {
+              content: [
+                { type: "text", text: JSON.stringify(apiKey, null, 2) },
+              ],
+            };
+          }
+          case "delete": {
+            if (!params.api_key_id) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: "Error: api_key_id is required for delete.",
+                  },
+                ],
+              };
+            }
+            await client.apiKeys.delete(params.api_key_id);
+            return {
+              content: [{ type: "text", text: "API key deleted successfully" }],
+            };
+          }
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error in manage_api_keys (${params.action}): ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+}

--- a/src/lib/mcp/tools/api-keys.ts
+++ b/src/lib/mcp/tools/api-keys.ts
@@ -1,22 +1,13 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { createKernelClient } from "@/lib/mcp/kernel-client";
-
-function textResponse(text: string) {
-  return { content: [{ type: "text" as const, text }] };
-}
-
-function jsonResponse(value: unknown) {
-  return textResponse(JSON.stringify(value, null, 2) ?? String(value));
-}
-
-function errorResponse(text: string) {
-  return { ...textResponse(text), isError: true as const };
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
-}
+import {
+  errorMessage,
+  errorResponse,
+  jsonResponse,
+  paginatedJsonResponse,
+  textResponse,
+} from "@/lib/mcp/responses";
 
 export function registerAPIKeyCapabilities(server: McpServer) {
   // manage_api_keys -- Create, list, get, update, and delete Kernel API keys
@@ -89,12 +80,7 @@ export function registerAPIKeyCapabilities(server: McpServer) {
               ...(params.limit !== undefined && { limit: params.limit }),
               ...(params.offset !== undefined && { offset: params.offset }),
             });
-            const items = page.getPaginatedItems();
-            return jsonResponse({
-              items,
-              has_more: page.has_more,
-              next_offset: page.next_offset,
-            });
+            return paginatedJsonResponse(page);
           }
           case "get": {
             if (!params.api_key_id) {

--- a/src/lib/mcp/tools/api-keys.ts
+++ b/src/lib/mcp/tools/api-keys.ts
@@ -2,6 +2,22 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { createKernelClient } from "@/lib/mcp/kernel-client";
 
+function textResponse(text: string) {
+  return { content: [{ type: "text" as const, text }] };
+}
+
+function jsonResponse(value: unknown) {
+  return textResponse(JSON.stringify(value, null, 2) ?? String(value));
+}
+
+function errorResponse(text: string) {
+  return { ...textResponse(text), isError: true as const };
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export function registerAPIKeyCapabilities(server: McpServer) {
   // manage_api_keys -- Create, list, get, update, and delete Kernel API keys
   server.tool(
@@ -33,8 +49,18 @@ export function registerAPIKeyCapabilities(server: McpServer) {
           "(create) Days until expiry, up to 3650. Use null for no expiry.",
         )
         .optional(),
-      limit: z.number().describe("(list) Max results per page.").optional(),
-      offset: z.number().describe("(list) Pagination offset.").optional(),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .describe("(list) Max results per page.")
+        .optional(),
+      offset: z
+        .number()
+        .int()
+        .min(0)
+        .describe("(list) Pagination offset.")
+        .optional(),
     },
     async (params, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");
@@ -44,11 +70,7 @@ export function registerAPIKeyCapabilities(server: McpServer) {
         switch (params.action) {
           case "create": {
             if (!params.name) {
-              return {
-                content: [
-                  { type: "text", text: "Error: name is required for create." },
-                ],
-              };
+              return errorResponse("Error: name is required for create.");
             }
             const createParams: Parameters<typeof client.apiKeys.create>[0] = {
               name: params.name,
@@ -60,11 +82,7 @@ export function registerAPIKeyCapabilities(server: McpServer) {
               createParams.days_to_expire = params.days_to_expire;
             }
             const apiKey = await client.apiKeys.create(createParams);
-            return {
-              content: [
-                { type: "text", text: JSON.stringify(apiKey, null, 2) },
-              ],
-            };
+            return jsonResponse(apiKey);
           }
           case "list": {
             const page = await client.apiKeys.list({
@@ -72,94 +90,43 @@ export function registerAPIKeyCapabilities(server: McpServer) {
               ...(params.offset !== undefined && { offset: params.offset }),
             });
             const items = page.getPaginatedItems();
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: JSON.stringify(
-                    {
-                      items,
-                      has_more: page.has_more,
-                      next_offset: page.next_offset,
-                    },
-                    null,
-                    2,
-                  ),
-                },
-              ],
-            };
+            return jsonResponse({
+              items,
+              has_more: page.has_more,
+              next_offset: page.next_offset,
+            });
           }
           case "get": {
             if (!params.api_key_id) {
-              return {
-                content: [
-                  {
-                    type: "text",
-                    text: "Error: api_key_id is required for get.",
-                  },
-                ],
-              };
+              return errorResponse("Error: api_key_id is required for get.");
             }
             const apiKey = await client.apiKeys.retrieve(params.api_key_id);
-            return {
-              content: [
-                { type: "text", text: JSON.stringify(apiKey, null, 2) },
-              ],
-            };
+            return jsonResponse(apiKey);
           }
           case "update": {
             if (!params.api_key_id) {
-              return {
-                content: [
-                  {
-                    type: "text",
-                    text: "Error: api_key_id is required for update.",
-                  },
-                ],
-              };
+              return errorResponse("Error: api_key_id is required for update.");
             }
             if (!params.name) {
-              return {
-                content: [
-                  { type: "text", text: "Error: name is required for update." },
-                ],
-              };
+              return errorResponse("Error: name is required for update.");
             }
             const apiKey = await client.apiKeys.update(params.api_key_id, {
               name: params.name,
             });
-            return {
-              content: [
-                { type: "text", text: JSON.stringify(apiKey, null, 2) },
-              ],
-            };
+            return jsonResponse(apiKey);
           }
           case "delete": {
             if (!params.api_key_id) {
-              return {
-                content: [
-                  {
-                    type: "text",
-                    text: "Error: api_key_id is required for delete.",
-                  },
-                ],
-              };
+              return errorResponse("Error: api_key_id is required for delete.");
             }
             await client.apiKeys.delete(params.api_key_id);
-            return {
-              content: [{ type: "text", text: "API key deleted successfully" }],
-            };
+            return textResponse("API key deleted successfully");
           }
         }
       } catch (error) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Error in manage_api_keys (${params.action}): ${error instanceof Error ? error.message : String(error)}`,
-            },
-          ],
-        };
+        return errorResponse(
+          `Error in manage_api_keys (${params.action}): ${errorMessage(error)}`,
+        );
       }
     },
   );

--- a/src/lib/mcp/tools/api-keys.ts
+++ b/src/lib/mcp/tools/api-keys.ts
@@ -43,6 +43,13 @@ export function registerAPIKeyCapabilities(server: McpServer) {
         .optional(),
       ...paginationParams,
     },
+    {
+      title: "Manage Kernel API keys",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     async (params, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");
       const client = createKernelClient(extra.authInfo.token);

--- a/src/lib/mcp/tools/api-keys.ts
+++ b/src/lib/mcp/tools/api-keys.ts
@@ -48,7 +48,7 @@ export function registerAPIKeyCapabilities(server: McpServer) {
       readOnlyHint: false,
       destructiveHint: true,
       idempotentHint: false,
-      openWorldHint: true,
+      openWorldHint: false,
     },
     async (params, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");

--- a/src/lib/mcp/tools/api-keys.ts
+++ b/src/lib/mcp/tools/api-keys.ts
@@ -2,11 +2,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { createKernelClient } from "@/lib/mcp/kernel-client";
 import {
-  errorMessage,
   errorResponse,
   jsonResponse,
   paginatedJsonResponse,
   textResponse,
+  toolErrorResponse,
 } from "@/lib/mcp/responses";
 import { paginationParams } from "@/lib/mcp/schemas";
 
@@ -100,9 +100,7 @@ export function registerAPIKeyCapabilities(server: McpServer) {
           }
         }
       } catch (error) {
-        return errorResponse(
-          `Error in manage_api_keys (${params.action}): ${errorMessage(error)}`,
-        );
+        return toolErrorResponse("manage_api_keys", params.action, error);
       }
     },
   );

--- a/src/lib/mcp/tools/projects.ts
+++ b/src/lib/mcp/tools/projects.ts
@@ -1,6 +1,13 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { createKernelClient } from "@/lib/mcp/kernel-client";
+import {
+  errorMessage,
+  errorResponse,
+  jsonResponse,
+  paginatedJsonResponse,
+  textResponse,
+} from "@/lib/mcp/responses";
 
 export function registerProjectCapabilities(server: McpServer) {
   // manage_projects -- Create, list, get, update, and delete organization projects
@@ -37,18 +44,10 @@ export function registerProjectCapabilities(server: McpServer) {
         switch (params.action) {
           case "create": {
             if (!params.name) {
-              return {
-                content: [
-                  { type: "text", text: "Error: name is required for create." },
-                ],
-              };
+              return errorResponse("Error: name is required for create.");
             }
             const project = await client.projects.create({ name: params.name });
-            return {
-              content: [
-                { type: "text", text: JSON.stringify(project, null, 2) },
-              ],
-            };
+            return jsonResponse(project);
           }
           case "list": {
             const page = await client.projects.list({
@@ -56,62 +55,23 @@ export function registerProjectCapabilities(server: McpServer) {
               ...(params.limit !== undefined && { limit: params.limit }),
               ...(params.offset !== undefined && { offset: params.offset }),
             });
-            const items = page.getPaginatedItems();
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: JSON.stringify(
-                    {
-                      items,
-                      has_more: page.has_more,
-                      next_offset: page.next_offset,
-                    },
-                    null,
-                    2,
-                  ),
-                },
-              ],
-            };
+            return paginatedJsonResponse(page);
           }
           case "get": {
             if (!params.project_id) {
-              return {
-                content: [
-                  {
-                    type: "text",
-                    text: "Error: project_id is required for get.",
-                  },
-                ],
-              };
+              return errorResponse("Error: project_id is required for get.");
             }
             const project = await client.projects.retrieve(params.project_id);
-            return {
-              content: [
-                { type: "text", text: JSON.stringify(project, null, 2) },
-              ],
-            };
+            return jsonResponse(project);
           }
           case "update": {
             if (!params.project_id) {
-              return {
-                content: [
-                  {
-                    type: "text",
-                    text: "Error: project_id is required for update.",
-                  },
-                ],
-              };
+              return errorResponse("Error: project_id is required for update.");
             }
             if (!params.name && !params.status) {
-              return {
-                content: [
-                  {
-                    type: "text",
-                    text: "Error: name or status is required for update.",
-                  },
-                ],
-              };
+              return errorResponse(
+                "Error: name or status is required for update.",
+              );
             }
             const updateParams: Parameters<typeof client.projects.update>[1] =
               {};
@@ -121,38 +81,20 @@ export function registerProjectCapabilities(server: McpServer) {
               params.project_id,
               updateParams,
             );
-            return {
-              content: [
-                { type: "text", text: JSON.stringify(project, null, 2) },
-              ],
-            };
+            return jsonResponse(project);
           }
           case "delete": {
             if (!params.project_id) {
-              return {
-                content: [
-                  {
-                    type: "text",
-                    text: "Error: project_id is required for delete.",
-                  },
-                ],
-              };
+              return errorResponse("Error: project_id is required for delete.");
             }
             await client.projects.delete(params.project_id);
-            return {
-              content: [{ type: "text", text: "Project deleted successfully" }],
-            };
+            return textResponse("Project deleted successfully");
           }
         }
       } catch (error) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Error in manage_projects (${params.action}): ${error instanceof Error ? error.message : String(error)}`,
-            },
-          ],
-        };
+        return errorResponse(
+          `Error in manage_projects (${params.action}): ${errorMessage(error)}`,
+        );
       }
     },
   );

--- a/src/lib/mcp/tools/projects.ts
+++ b/src/lib/mcp/tools/projects.ts
@@ -8,6 +8,7 @@ import {
   paginatedJsonResponse,
   textResponse,
 } from "@/lib/mcp/responses";
+import { paginationParams } from "@/lib/mcp/schemas";
 
 export function registerProjectCapabilities(server: McpServer) {
   // manage_projects -- Create, list, get, update, and delete organization projects
@@ -33,8 +34,7 @@ export function registerProjectCapabilities(server: McpServer) {
           "(list) Case-insensitive substring match against project name.",
         )
         .optional(),
-      limit: z.number().describe("(list) Max results per page.").optional(),
-      offset: z.number().describe("(list) Pagination offset.").optional(),
+      ...paginationParams,
     },
     async (params, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");

--- a/src/lib/mcp/tools/projects.ts
+++ b/src/lib/mcp/tools/projects.ts
@@ -2,11 +2,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { createKernelClient } from "@/lib/mcp/kernel-client";
 import {
-  errorMessage,
   errorResponse,
   jsonResponse,
   paginatedJsonResponse,
   textResponse,
+  toolErrorResponse,
 } from "@/lib/mcp/responses";
 import { paginationParams } from "@/lib/mcp/schemas";
 
@@ -92,9 +92,7 @@ export function registerProjectCapabilities(server: McpServer) {
           }
         }
       } catch (error) {
-        return errorResponse(
-          `Error in manage_projects (${params.action}): ${errorMessage(error)}`,
-        );
+        return toolErrorResponse("manage_projects", params.action, error);
       }
     },
   );


### PR DESCRIPTION
## Summary
- add `manage_api_keys` MCP tool for create/list/get/update/delete
- support project-scoped API-key creation via `project_id` and optional `days_to_expire`
- wire the API-key capability into MCP registration after projects
- centralize MCP text, JSON, paginated JSON, and error responses in `src/lib/mcp/responses.ts`
- share project/API-key list pagination schema in `src/lib/mcp/schemas.ts`, matching the API's backend-clamped pagination behavior
- mark project/API-key validation and SDK failures as MCP error results with `isError: true`

## Agent Experience / Flow

This PR lets agents provision credentials for automation without leaving MCP. The important agent experience detail is that API-key creation returns the plaintext key once, while every later read path returns masked metadata only.

Typical project-scoped flow:

1. Agent resolves the resource boundary with `manage_projects list` or `manage_projects create` and captures `project_id`.
2. Agent calls `manage_api_keys create name=<purposeful-name> project_id=<project_id> days_to_expire=<n>` when a downstream workflow needs a project-scoped key.
3. Agent immediately hands the plaintext key to the caller or stores it only in the explicitly requested destination, because it cannot be retrieved again.
4. Agent verifies key metadata with `manage_api_keys get` or `list`; these return masked values suitable for audit and UI display.
5. Agent uses `manage_api_keys update` for name changes and `delete` for revocation when the workflow is complete.

Typical org-wide flow:

1. Agent calls `manage_api_keys create name=<purposeful-name>` without `project_id` only when org-wide access is explicitly intended.
2. Agent uses `days_to_expire` for temporary automation keys so cleanup does not depend only on manual deletion.
3. Agent lists existing keys before creating a new one to avoid duplicate long-lived credentials.

Agent safety notes:

- Treat the create response as secret material. Do not include plaintext API keys in PR comments, logs, or routine summaries.
- Prefer project-scoped keys when the workflow has a known project boundary.
- Prefer short expirations for smoke tests and one-off automation.
- Invalid tool inputs and caught SDK/API failures now return MCP error results instead of successful plain text, so agents can recover from failures reliably.
- `manage_projects` and `manage_api_keys` now share the same response helpers, pagination envelope, pagination input schema, and failure semantics across the project-to-key workflow.

## Authorization Boundary

MCP forwards the caller's bearer token to the Kernel SDK/API and does not implement a separate API-key authorization policy. The API must remain the source of truth for who may create org-wide keys, create project-scoped keys, read key metadata, update names, or revoke keys.

API-side authorization audit/enforcement is tracked separately in kernel/kernel: https://github.com/kernel/kernel/issues/2297

## Validation
- `bunx prettier --check src/lib/mcp/schemas.ts src/lib/mcp/responses.ts src/lib/mcp/tools/api-keys.ts src/lib/mcp/tools/projects.ts`
- `git diff --check`
- `KERNEL_CLI_PROD_CLIENT_ID=dummy KERNEL_CLI_STAGING_CLIENT_ID=dummy KERNEL_CLI_DEV_CLIENT_ID=dummy NEXT_PUBLIC_CLERK_DOMAIN=example.clerk.accounts.dev NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_ZXhhbXBsZS5jbGVyay5hY2NvdW50cy5kZXYk CLERK_SECRET_KEY=sk_test_dummy REDIS_URL=redis://localhost:6379 bun run build`
- localhost MCP CRUD smoke against `http://127.0.0.1:3002/mcp` with `API_BASE_URL=http://127.0.0.1:3001`: initialized MCP, verified `manage_api_keys` was listed, created a scratch project, created a project-scoped API key, confirmed plaintext key is returned on create only, got/updated/listed/deleted the key, then deleted the scratch project

## Notes
- `bun run format:check` still fails on pre-existing `AGENTS.md` formatting outside this PR scope.
- The first sandboxed `bun run build` attempt failed only because `next/font` could not fetch Google Fonts; the rerun with network access passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces credential lifecycle (create with one-time plaintext, revoke) over MCP; misconfiguration or weak API-side auth would expose high-impact operations despite forwarding the caller's token.
> 
> **Overview**
> Adds **`manage_api_keys`** so agents can create, list, get, update, and delete Kernel API keys via MCP, including optional **project scoping** and **expiry** on create. **Create** is the only path that returns the **plaintext** key; later reads stay masked.
> 
> MCP registration is refactored into a **toolset registry** driven by **`KERNEL_MCP_DISABLED_TOOLSETS`**, so self-hosted deployments can skip registering sensitive tools (e.g. `api_keys` / `manage_api_keys`). Invalid env values fail at startup with a clear error.
> 
> **`manage_projects`** and the new tool share **`responses.ts`** (JSON, paginated lists, **`isError: true`** on validation/SDK failures) and **`schemas.ts`** for list pagination hints aligned with API clamping. README and **`.env.example`** document the new tool count and gating option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8074fb9a2886e8953b656e0ad81ddb1715a8f2ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->