### PR TITLE
Add browser session parity options to MCP

### DIFF
--- a/src/lib/mcp/tools/browsers.ts
+++ b/src/lib/mcp/tools/browsers.ts
@@ -30,47 +30,14 @@ type TelemetryParams = {
 
 type BrowserAction = "create" | "update" | "list" | "get" | "delete";
 
-const scopedBrowserFields = [
-  "session_id",
-  "start_url",
-  "chrome_policy",
-  "headless",
-  "gpu",
-  "stealth",
-  "timeout_seconds",
-  "profile_name",
-  "profile_id",
-  "save_profile_changes",
-  "proxy_id",
-  "clear_proxy",
-  "disable_default_proxy",
-  "kiosk_mode",
-  "viewport_width",
-  "viewport_height",
-  "viewport_refresh_rate",
-  "viewport_force",
-  "extension_id",
-  "extension_name",
-  "local_forward",
-  "remote_forward",
-  "status",
-  "limit",
-  "offset",
-  "telemetry_enabled",
-  "telemetry_console",
-  "telemetry_network",
-  "telemetry_page",
-  "telemetry_interaction",
-] as const;
-
-type BrowserToolField = (typeof scopedBrowserFields)[number];
-
 const createActions: readonly BrowserAction[] = ["create"];
 const updateActions: readonly BrowserAction[] = ["update"];
 const createUpdateActions: readonly BrowserAction[] = ["create", "update"];
+const sessionIdActions: readonly BrowserAction[] = ["update", "get", "delete"];
+const listActions: readonly BrowserAction[] = ["list"];
 
-const browserFieldScopes: Record<BrowserToolField, readonly BrowserAction[]> = {
-  session_id: ["update", "get", "delete"],
+const browserFieldScopes = {
+  session_id: sessionIdActions,
   start_url: createActions,
   chrome_policy: createActions,
   headless: createActions,
@@ -92,15 +59,21 @@ const browserFieldScopes: Record<BrowserToolField, readonly BrowserAction[]> = {
   extension_name: createActions,
   local_forward: createActions,
   remote_forward: createActions,
-  status: ["list"],
-  limit: ["list"],
-  offset: ["list"],
+  status: listActions,
+  limit: listActions,
+  offset: listActions,
   telemetry_enabled: createUpdateActions,
   telemetry_console: createUpdateActions,
   telemetry_network: createUpdateActions,
   telemetry_page: createUpdateActions,
   telemetry_interaction: createUpdateActions,
-};
+} satisfies Record<string, readonly BrowserAction[]>;
+
+type BrowserToolField = keyof typeof browserFieldScopes;
+
+const scopedBrowserFields = Object.keys(
+  browserFieldScopes,
+) as BrowserToolField[];
 
 const telemetryCategories = [
   ["telemetry_console", "console"],

--- a/src/lib/mcp/tools/browsers.ts
+++ b/src/lib/mcp/tools/browsers.ts
@@ -573,6 +573,8 @@ export function registerBrowserCapabilities(server: McpServer) {
               params.session_id,
               updateParams,
             );
+            if (!browser)
+              return textResponse("Failed to update browser session");
             return {
               content: [
                 { type: "text", text: JSON.stringify(browser, null, 2) },

--- a/src/lib/mcp/tools/browsers.ts
+++ b/src/lib/mcp/tools/browsers.ts
@@ -28,53 +28,6 @@ type TelemetryParams = {
   telemetry_interaction?: boolean;
 };
 
-type BrowserAction = "create" | "update" | "list" | "get" | "delete";
-
-const createActions: readonly BrowserAction[] = ["create"];
-const updateActions: readonly BrowserAction[] = ["update"];
-const createUpdateActions: readonly BrowserAction[] = ["create", "update"];
-const sessionIdActions: readonly BrowserAction[] = ["update", "get", "delete"];
-const listActions: readonly BrowserAction[] = ["list"];
-
-const browserFieldScopes = {
-  session_id: sessionIdActions,
-  start_url: createActions,
-  chrome_policy: createActions,
-  headless: createActions,
-  gpu: createActions,
-  stealth: createActions,
-  timeout_seconds: createActions,
-  profile_name: createUpdateActions,
-  profile_id: createUpdateActions,
-  save_profile_changes: createUpdateActions,
-  proxy_id: createUpdateActions,
-  clear_proxy: updateActions,
-  disable_default_proxy: updateActions,
-  kiosk_mode: createActions,
-  viewport_width: createUpdateActions,
-  viewport_height: createUpdateActions,
-  viewport_refresh_rate: createUpdateActions,
-  viewport_force: updateActions,
-  extension_id: createActions,
-  extension_name: createActions,
-  local_forward: createActions,
-  remote_forward: createActions,
-  status: listActions,
-  limit: listActions,
-  offset: listActions,
-  telemetry_enabled: createUpdateActions,
-  telemetry_console: createUpdateActions,
-  telemetry_network: createUpdateActions,
-  telemetry_page: createUpdateActions,
-  telemetry_interaction: createUpdateActions,
-} satisfies Record<string, readonly BrowserAction[]>;
-
-type BrowserToolField = keyof typeof browserFieldScopes;
-
-const scopedBrowserFields = Object.keys(
-  browserFieldScopes,
-) as BrowserToolField[];
-
 const telemetryCategories = [
   ["telemetry_console", "console"],
   ["telemetry_network", "network"],
@@ -86,25 +39,8 @@ function textResponse(text: string) {
   return { content: [{ type: "text" as const, text }] };
 }
 
-function formatActionScope(field: BrowserToolField) {
-  return browserFieldScopes[field].join(", ");
-}
-
-function actionFieldError(
-  params: Partial<Record<BrowserToolField, unknown>>,
-  action: BrowserAction,
-) {
-  const unsupportedField = scopedBrowserFields.find(
-    (field) =>
-      params[field] !== undefined &&
-      !browserFieldScopes[field].includes(action),
-  );
-
-  return unsupportedField
-    ? `Error: ${unsupportedField} is only supported for ${formatActionScope(
-        unsupportedField,
-      )}.`
-    : undefined;
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function buildProfile(params: ProfileParams): BrowserCreateParams["profile"] {
@@ -153,12 +89,6 @@ function buildViewportBase(
   };
 }
 
-function buildCreateViewport(
-  params: ViewportParams,
-): BrowserCreateParams["viewport"] {
-  return buildViewportBase(params);
-}
-
 function buildUpdateViewport(
   params: ViewportParams,
 ): BrowserUpdateParams["viewport"] {
@@ -183,7 +113,7 @@ function buildUpdateViewport(
 
 function buildTelemetry(
   params: TelemetryParams,
-): BrowserCreateParams["telemetry"] | BrowserUpdateParams["telemetry"] {
+): BrowserCreateParams["telemetry"] {
   const browser: NonNullable<
     NonNullable<BrowserCreateParams["telemetry"]>["browser"]
   > = {};
@@ -434,27 +364,15 @@ export function registerBrowserCapabilities(server: McpServer) {
       try {
         switch (params.action) {
           case "create": {
-            const scopeError = actionFieldError(params, "create");
-            if (scopeError) return textResponse(scopeError);
             if (params.profile_name && params.profile_id) {
-              return {
-                content: [
-                  {
-                    type: "text",
-                    text: "Error: Cannot specify both profile_name and profile_id.",
-                  },
-                ],
-              };
+              return textResponse(
+                "Error: Cannot specify both profile_name and profile_id.",
+              );
             }
             if (params.extension_id && params.extension_name) {
-              return {
-                content: [
-                  {
-                    type: "text",
-                    text: "Error: Cannot specify both extension_id and extension_name.",
-                  },
-                ],
-              };
+              return textResponse(
+                "Error: Cannot specify both extension_id and extension_name.",
+              );
             }
 
             const createParams: BrowserCreateParams = {};
@@ -473,7 +391,7 @@ export function registerBrowserCapabilities(server: McpServer) {
             if (params.proxy_id) createParams.proxy_id = params.proxy_id;
             const profile = buildProfile(params);
             if (profile) createParams.profile = profile;
-            const viewport = buildCreateViewport(params);
+            const viewport = buildViewportBase(params);
             if (viewport) createParams.viewport = viewport;
             const telemetry = buildTelemetry(params);
             if (telemetry !== undefined) createParams.telemetry = telemetry;
@@ -488,11 +406,7 @@ export function registerBrowserCapabilities(server: McpServer) {
 
             const browser = await client.browsers.create(createParams);
             if (!browser)
-              return {
-                content: [
-                  { type: "text", text: "Failed to create browser session" },
-                ],
-              };
+              return textResponse("Failed to create browser session");
 
             let responseText = JSON.stringify(browser, null, 2);
             if (params.local_forward || params.remote_forward) {
@@ -522,11 +436,9 @@ export function registerBrowserCapabilities(server: McpServer) {
 
               responseText += `\n\nNote: SSH connections alone don't count as browser activity. Set an appropriate timeout or keep the live view open to prevent cleanup.`;
             }
-            return { content: [{ type: "text", text: responseText }] };
+            return textResponse(responseText);
           }
           case "update": {
-            const scopeError = actionFieldError(params, "update");
-            if (scopeError) return textResponse(scopeError);
             if (!params.session_id)
               return textResponse(
                 "Error: session_id is required for update action.",
@@ -534,11 +446,6 @@ export function registerBrowserCapabilities(server: McpServer) {
             if (params.profile_name && params.profile_id) {
               return textResponse(
                 "Error: Cannot specify both profile_name and profile_id.",
-              );
-            }
-            if (params.extension_id || params.extension_name) {
-              return textResponse(
-                "Error: extensions can only be loaded during create.",
               );
             }
             if (params.proxy_id && params.clear_proxy) {
@@ -575,15 +482,9 @@ export function registerBrowserCapabilities(server: McpServer) {
             );
             if (!browser)
               return textResponse("Failed to update browser session");
-            return {
-              content: [
-                { type: "text", text: JSON.stringify(browser, null, 2) },
-              ],
-            };
+            return textResponse(JSON.stringify(browser, null, 2));
           }
           case "list": {
-            const scopeError = actionFieldError(params, "list");
-            if (scopeError) return textResponse(scopeError);
             const page = await client.browsers.list({
               ...(params.status && { status: params.status }),
               ...(params.limit !== undefined && { limit: params.limit }),
@@ -592,83 +493,43 @@ export function registerBrowserCapabilities(server: McpServer) {
             const items = page
               .getPaginatedItems()
               .map((b) => ({ ...b, cdp_ws_url: undefined }));
-            return {
-              content: [
-                {
-                  type: "text",
-                  text:
-                    items.length > 0
-                      ? JSON.stringify(
-                          {
-                            items,
-                            has_more: page.has_more,
-                            next_offset: page.next_offset,
-                          },
-                          null,
-                          2,
-                        )
-                      : "No browsers found",
-                },
-              ],
-            };
+            return textResponse(
+              items.length > 0
+                ? JSON.stringify(
+                    {
+                      items,
+                      has_more: page.has_more,
+                      next_offset: page.next_offset,
+                    },
+                    null,
+                    2,
+                  )
+                : "No browsers found",
+            );
           }
           case "get": {
-            const scopeError = actionFieldError(params, "get");
-            if (scopeError) return textResponse(scopeError);
             if (!params.session_id)
-              return {
-                content: [
-                  {
-                    type: "text",
-                    text: "Error: session_id is required for get action.",
-                  },
-                ],
-              };
+              return textResponse(
+                "Error: session_id is required for get action.",
+              );
             const browser = await client.browsers.retrieve(params.session_id);
             if (!browser)
-              return {
-                content: [
-                  {
-                    type: "text",
-                    text: `Browser session "${params.session_id}" not found`,
-                  },
-                ],
-              };
-            return {
-              content: [
-                { type: "text", text: JSON.stringify(browser, null, 2) },
-              ],
-            };
+              return textResponse(
+                `Browser session "${params.session_id}" not found`,
+              );
+            return textResponse(JSON.stringify(browser, null, 2));
           }
           case "delete": {
-            const scopeError = actionFieldError(params, "delete");
-            if (scopeError) return textResponse(scopeError);
             if (!params.session_id)
-              return {
-                content: [
-                  {
-                    type: "text",
-                    text: "Error: session_id is required for delete action.",
-                  },
-                ],
-              };
+              return textResponse(
+                "Error: session_id is required for delete action.",
+              );
             await client.browsers.deleteByID(params.session_id);
-            return {
-              content: [
-                { type: "text", text: "Browser session deleted successfully" },
-              ],
-            };
+            return textResponse("Browser session deleted successfully");
           }
         }
       } catch (error) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Error in manage_browsers (${params.action}): ${error}`,
-            },
-          ],
-        };
+        return textResponse(`Error: ${errorMessage(error)}`);
       }
     },
   );

--- a/src/lib/mcp/tools/browsers.ts
+++ b/src/lib/mcp/tools/browsers.ts
@@ -28,6 +28,80 @@ type TelemetryParams = {
   telemetry_interaction?: boolean;
 };
 
+type BrowserAction = "create" | "update" | "list" | "get" | "delete";
+
+const scopedBrowserFields = [
+  "session_id",
+  "start_url",
+  "chrome_policy",
+  "headless",
+  "gpu",
+  "stealth",
+  "timeout_seconds",
+  "profile_name",
+  "profile_id",
+  "save_profile_changes",
+  "proxy_id",
+  "clear_proxy",
+  "disable_default_proxy",
+  "kiosk_mode",
+  "viewport_width",
+  "viewport_height",
+  "viewport_refresh_rate",
+  "viewport_force",
+  "extension_id",
+  "extension_name",
+  "local_forward",
+  "remote_forward",
+  "status",
+  "limit",
+  "offset",
+  "telemetry_enabled",
+  "telemetry_console",
+  "telemetry_network",
+  "telemetry_page",
+  "telemetry_interaction",
+] as const;
+
+type BrowserToolField = (typeof scopedBrowserFields)[number];
+
+const createActions: readonly BrowserAction[] = ["create"];
+const updateActions: readonly BrowserAction[] = ["update"];
+const createUpdateActions: readonly BrowserAction[] = ["create", "update"];
+
+const browserFieldScopes: Record<BrowserToolField, readonly BrowserAction[]> = {
+  session_id: ["update", "get", "delete"],
+  start_url: createActions,
+  chrome_policy: createActions,
+  headless: createActions,
+  gpu: createActions,
+  stealth: createActions,
+  timeout_seconds: createActions,
+  profile_name: createUpdateActions,
+  profile_id: createUpdateActions,
+  save_profile_changes: createUpdateActions,
+  proxy_id: createUpdateActions,
+  clear_proxy: updateActions,
+  disable_default_proxy: updateActions,
+  kiosk_mode: createActions,
+  viewport_width: createUpdateActions,
+  viewport_height: createUpdateActions,
+  viewport_refresh_rate: createUpdateActions,
+  viewport_force: updateActions,
+  extension_id: createActions,
+  extension_name: createActions,
+  local_forward: createActions,
+  remote_forward: createActions,
+  status: ["list"],
+  limit: ["list"],
+  offset: ["list"],
+  telemetry_enabled: createUpdateActions,
+  telemetry_console: createUpdateActions,
+  telemetry_network: createUpdateActions,
+  telemetry_page: createUpdateActions,
+  telemetry_interaction: createUpdateActions,
+};
+
 const telemetryCategories = [
   ["telemetry_console", "console"],
   ["telemetry_network", "network"],
@@ -35,24 +109,29 @@ const telemetryCategories = [
   ["telemetry_interaction", "interaction"],
 ] as const;
 
-const createOnlyFields = [
-  "start_url",
-  "chrome_policy",
-  "gpu",
-  "headless",
-  "stealth",
-  "timeout_seconds",
-  "kiosk_mode",
-] as const;
-
-const updateOnlyFields = [
-  "clear_proxy",
-  "disable_default_proxy",
-  "viewport_force",
-] as const;
-
 function textResponse(text: string) {
   return { content: [{ type: "text" as const, text }] };
+}
+
+function formatActionScope(field: BrowserToolField) {
+  return browserFieldScopes[field].join(", ");
+}
+
+function actionFieldError(
+  params: Partial<Record<BrowserToolField, unknown>>,
+  action: BrowserAction,
+) {
+  const unsupportedField = scopedBrowserFields.find(
+    (field) =>
+      params[field] !== undefined &&
+      !browserFieldScopes[field].includes(action),
+  );
+
+  return unsupportedField
+    ? `Error: ${unsupportedField} is only supported for ${formatActionScope(
+        unsupportedField,
+      )}.`
+    : undefined;
 }
 
 function buildProfile(params: ProfileParams): BrowserCreateParams["profile"] {
@@ -75,17 +154,15 @@ function buildProfile(params: ProfileParams): BrowserCreateParams["profile"] {
   };
 }
 
-function buildViewport(
+function buildViewportBase(
   params: ViewportParams,
-  options?: { includeForce?: boolean },
-): BrowserCreateParams["viewport"] | BrowserUpdateParams["viewport"] {
-  const hasWidth = params.viewport_width !== undefined;
-  const hasHeight = params.viewport_height !== undefined;
+): NonNullable<BrowserCreateParams["viewport"]> | undefined {
+  const width = params.viewport_width;
+  const height = params.viewport_height;
+  const hasWidth = width !== undefined;
+  const hasHeight = height !== undefined;
   const hasViewportOptions =
-    hasWidth ||
-    hasHeight ||
-    params.viewport_refresh_rate !== undefined ||
-    (options?.includeForce && params.viewport_force !== undefined);
+    hasWidth || hasHeight || params.viewport_refresh_rate !== undefined;
 
   if (!hasViewportOptions) return undefined;
   if (!hasWidth || !hasHeight) {
@@ -95,13 +172,39 @@ function buildViewport(
   }
 
   return {
-    width: params.viewport_width!,
-    height: params.viewport_height!,
+    width,
+    height,
     ...(params.viewport_refresh_rate !== undefined && {
       refresh_rate: params.viewport_refresh_rate,
     }),
-    ...(options?.includeForce &&
-      params.viewport_force !== undefined && { force: params.viewport_force }),
+  };
+}
+
+function buildCreateViewport(
+  params: ViewportParams,
+): BrowserCreateParams["viewport"] {
+  return buildViewportBase(params);
+}
+
+function buildUpdateViewport(
+  params: ViewportParams,
+): BrowserUpdateParams["viewport"] {
+  const viewport = buildViewportBase(params);
+
+  if (!viewport) {
+    if (params.viewport_force !== undefined) {
+      throw new Error(
+        "viewport_width and viewport_height must be provided when viewport_force is set.",
+      );
+    }
+    return undefined;
+  }
+
+  return {
+    ...viewport,
+    ...(params.viewport_force !== undefined && {
+      force: params.viewport_force,
+    }),
   };
 }
 
@@ -187,7 +290,7 @@ export function registerBrowserCapabilities(server: McpServer) {
     throw new Error(`Invalid browser URI: ${uriString}`);
   });
 
-  // manage_browsers -- Create, list, get, and delete browser sessions
+  // manage_browsers -- Create, update, list, get, and delete browser sessions
   server.tool(
     "manage_browsers",
     'Manage browser sessions in the Kernel platform. Use action "create" to launch a new browser, "update" to modify supported session settings, "list" to see existing sessions, "get" to retrieve details about a specific session, or "delete" to terminate one. Created browsers run in isolated VMs and support headless/stealth modes, profiles, proxies, viewports, extensions, Chrome policy overrides, telemetry, start URLs, and SSH tunneling.',
@@ -237,16 +340,20 @@ export function registerBrowserCapabilities(server: McpServer) {
       profile_name: z
         .string()
         .describe(
-          "(create) Profile name to load saved cookies/logins. Cannot use with profile_id.",
+          "(create, update) Profile name to load saved cookies/logins. Cannot use with profile_id.",
         )
         .optional(),
       profile_id: z
         .string()
-        .describe("(create) Profile ID to load. Cannot use with profile_name.")
+        .describe(
+          "(create, update) Profile ID to load. Cannot use with profile_name.",
+        )
         .optional(),
       save_profile_changes: z
         .boolean()
-        .describe("(create) Save session changes back to profile on close.")
+        .describe(
+          "(create, update) Save session changes back to profile on close.",
+        )
         .optional(),
       proxy_id: z
         .string()
@@ -271,13 +378,13 @@ export function registerBrowserCapabilities(server: McpServer) {
       viewport_width: z
         .number()
         .describe(
-          "(create) Window width in pixels. Must pair with viewport_height.",
+          "(create, update) Window width in pixels. Must pair with viewport_height.",
         )
         .optional(),
       viewport_height: z
         .number()
         .describe(
-          "(create) Window height in pixels. Must pair with viewport_width.",
+          "(create, update) Window height in pixels. Must pair with viewport_width.",
         )
         .optional(),
       viewport_refresh_rate: z
@@ -354,6 +461,8 @@ export function registerBrowserCapabilities(server: McpServer) {
       try {
         switch (params.action) {
           case "create": {
+            const scopeError = actionFieldError(params, "create");
+            if (scopeError) return textResponse(scopeError);
             if (params.profile_name && params.profile_id) {
               return {
                 content: [
@@ -374,14 +483,6 @@ export function registerBrowserCapabilities(server: McpServer) {
                 ],
               };
             }
-            const updateOnlyField = updateOnlyFields.find(
-              (field) => params[field] !== undefined,
-            );
-            if (updateOnlyField) {
-              return textResponse(
-                `Error: ${updateOnlyField} is only supported for update.`,
-              );
-            }
 
             const createParams: BrowserCreateParams = {};
             if (params.headless !== undefined)
@@ -399,7 +500,7 @@ export function registerBrowserCapabilities(server: McpServer) {
             if (params.proxy_id) createParams.proxy_id = params.proxy_id;
             const profile = buildProfile(params);
             if (profile) createParams.profile = profile;
-            const viewport = buildViewport(params);
+            const viewport = buildCreateViewport(params);
             if (viewport) createParams.viewport = viewport;
             const telemetry = buildTelemetry(params);
             if (telemetry !== undefined) createParams.telemetry = telemetry;
@@ -451,6 +552,8 @@ export function registerBrowserCapabilities(server: McpServer) {
             return { content: [{ type: "text", text: responseText }] };
           }
           case "update": {
+            const scopeError = actionFieldError(params, "update");
+            if (scopeError) return textResponse(scopeError);
             if (!params.session_id)
               return textResponse(
                 "Error: session_id is required for update action.",
@@ -463,14 +566,6 @@ export function registerBrowserCapabilities(server: McpServer) {
             if (params.extension_id || params.extension_name) {
               return textResponse(
                 "Error: extensions can only be loaded during create.",
-              );
-            }
-            const createOnlyField = createOnlyFields.find(
-              (field) => params[field] !== undefined,
-            );
-            if (createOnlyField) {
-              return textResponse(
-                `Error: ${createOnlyField} is only supported for create.`,
               );
             }
             if (params.proxy_id && params.clear_proxy) {
@@ -490,7 +585,7 @@ export function registerBrowserCapabilities(server: McpServer) {
             }
             const profile = buildProfile(params);
             if (profile) updateParams.profile = profile;
-            const viewport = buildViewport(params, { includeForce: true });
+            const viewport = buildUpdateViewport(params);
             if (viewport) updateParams.viewport = viewport;
             const telemetry = buildTelemetry(params);
             if (telemetry !== undefined) updateParams.telemetry = telemetry;
@@ -512,6 +607,8 @@ export function registerBrowserCapabilities(server: McpServer) {
             };
           }
           case "list": {
+            const scopeError = actionFieldError(params, "list");
+            if (scopeError) return textResponse(scopeError);
             const page = await client.browsers.list({
               ...(params.status && { status: params.status }),
               ...(params.limit !== undefined && { limit: params.limit }),
@@ -541,6 +638,8 @@ export function registerBrowserCapabilities(server: McpServer) {
             };
           }
           case "get": {
+            const scopeError = actionFieldError(params, "get");
+            if (scopeError) return textResponse(scopeError);
             if (!params.session_id)
               return {
                 content: [
@@ -567,6 +666,8 @@ export function registerBrowserCapabilities(server: McpServer) {
             };
           }
           case "delete": {
+            const scopeError = actionFieldError(params, "delete");
+            if (scopeError) return textResponse(scopeError);
             if (!params.session_id)
               return {
                 content: [

--- a/src/lib/mcp/tools/browsers.ts
+++ b/src/lib/mcp/tools/browsers.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { createKernelClient, type KernelClient } from "@/lib/mcp/kernel-client";
+import { textResponse, toolErrorResponse } from "@/lib/mcp/responses";
 
 type BrowserCreateParams = NonNullable<
   Parameters<KernelClient["browsers"]["create"]>[0]
@@ -34,14 +35,6 @@ const telemetryCategories = [
   ["telemetry_page", "page"],
   ["telemetry_interaction", "interaction"],
 ] as const;
-
-function textResponse(text: string) {
-  return { content: [{ type: "text" as const, text }] };
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
-}
 
 function buildProfile(params: ProfileParams): BrowserCreateParams["profile"] {
   if (
@@ -529,7 +522,7 @@ export function registerBrowserCapabilities(server: McpServer) {
           }
         }
       } catch (error) {
-        return textResponse(`Error: ${errorMessage(error)}`);
+        return toolErrorResponse("manage_browsers", params.action, error);
       }
     },
   );

--- a/src/lib/mcp/tools/browsers.ts
+++ b/src/lib/mcp/tools/browsers.ts
@@ -1,6 +1,143 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { createKernelClient } from "@/lib/mcp/kernel-client";
+import { createKernelClient, type KernelClient } from "@/lib/mcp/kernel-client";
+
+type BrowserCreateParams = NonNullable<
+  Parameters<KernelClient["browsers"]["create"]>[0]
+>;
+type BrowserUpdateParams = Parameters<KernelClient["browsers"]["update"]>[1];
+
+type ProfileParams = {
+  profile_name?: string;
+  profile_id?: string;
+  save_profile_changes?: boolean;
+};
+
+type ViewportParams = {
+  viewport_width?: number;
+  viewport_height?: number;
+  viewport_refresh_rate?: number;
+  viewport_force?: boolean;
+};
+
+type TelemetryParams = {
+  telemetry_enabled?: boolean;
+  telemetry_console?: boolean;
+  telemetry_network?: boolean;
+  telemetry_page?: boolean;
+  telemetry_interaction?: boolean;
+};
+
+const telemetryCategories = [
+  ["telemetry_console", "console"],
+  ["telemetry_network", "network"],
+  ["telemetry_page", "page"],
+  ["telemetry_interaction", "interaction"],
+] as const;
+
+const createOnlyFields = [
+  "start_url",
+  "chrome_policy",
+  "gpu",
+  "headless",
+  "stealth",
+  "timeout_seconds",
+  "kiosk_mode",
+] as const;
+
+const updateOnlyFields = [
+  "clear_proxy",
+  "disable_default_proxy",
+  "viewport_force",
+] as const;
+
+function textResponse(text: string) {
+  return { content: [{ type: "text" as const, text }] };
+}
+
+function buildProfile(params: ProfileParams): BrowserCreateParams["profile"] {
+  if (
+    params.save_profile_changes !== undefined &&
+    !params.profile_name &&
+    !params.profile_id
+  ) {
+    throw new Error(
+      "profile_name or profile_id is required when save_profile_changes is set.",
+    );
+  }
+  if (!params.profile_name && !params.profile_id) return undefined;
+  return {
+    ...(params.profile_name && { name: params.profile_name }),
+    ...(params.profile_id && { id: params.profile_id }),
+    ...(params.save_profile_changes !== undefined && {
+      save_changes: params.save_profile_changes,
+    }),
+  };
+}
+
+function buildViewport(
+  params: ViewportParams,
+  options?: { includeForce?: boolean },
+): BrowserCreateParams["viewport"] | BrowserUpdateParams["viewport"] {
+  const hasWidth = params.viewport_width !== undefined;
+  const hasHeight = params.viewport_height !== undefined;
+  const hasViewportOptions =
+    hasWidth ||
+    hasHeight ||
+    params.viewport_refresh_rate !== undefined ||
+    (options?.includeForce && params.viewport_force !== undefined);
+
+  if (!hasViewportOptions) return undefined;
+  if (!hasWidth || !hasHeight) {
+    throw new Error(
+      "viewport_width and viewport_height must be provided together.",
+    );
+  }
+
+  return {
+    width: params.viewport_width!,
+    height: params.viewport_height!,
+    ...(params.viewport_refresh_rate !== undefined && {
+      refresh_rate: params.viewport_refresh_rate,
+    }),
+    ...(options?.includeForce &&
+      params.viewport_force !== undefined && { force: params.viewport_force }),
+  };
+}
+
+function buildTelemetry(
+  params: TelemetryParams,
+): BrowserCreateParams["telemetry"] | BrowserUpdateParams["telemetry"] {
+  const browser: NonNullable<
+    NonNullable<BrowserCreateParams["telemetry"]>["browser"]
+  > = {};
+  let hasBrowserCategories = false;
+
+  for (const [paramKey, category] of telemetryCategories) {
+    const enabled = params[paramKey];
+    if (enabled !== undefined) {
+      browser[category] = { enabled };
+      hasBrowserCategories = true;
+    }
+  }
+
+  if (params.telemetry_enabled === false && hasBrowserCategories) {
+    throw new Error(
+      "telemetry_enabled=false cannot be combined with telemetry category settings.",
+    );
+  }
+
+  if (params.telemetry_enabled === undefined && !hasBrowserCategories) {
+    return undefined;
+  }
+
+  return {
+    ...(params.telemetry_enabled !== undefined && {
+      enabled: params.telemetry_enabled,
+    }),
+    ...(hasBrowserCategories && { browser }),
+  };
+}
 
 export function registerBrowserCapabilities(server: McpServer) {
   server.resource("browsers", "browsers://", async (uri, extra) => {
@@ -53,18 +190,39 @@ export function registerBrowserCapabilities(server: McpServer) {
   // manage_browsers -- Create, list, get, and delete browser sessions
   server.tool(
     "manage_browsers",
-    'Manage browser sessions in the Kernel platform. Use action "create" to launch a new browser, "list" to see existing sessions, "get" to retrieve details about a specific session, or "delete" to terminate one. Created browsers run in isolated VMs and support headless/stealth modes, profiles, proxies, viewports, extensions, and SSH tunneling.',
+    'Manage browser sessions in the Kernel platform. Use action "create" to launch a new browser, "update" to modify supported session settings, "list" to see existing sessions, "get" to retrieve details about a specific session, or "delete" to terminate one. Created browsers run in isolated VMs and support headless/stealth modes, profiles, proxies, viewports, extensions, Chrome policy overrides, telemetry, start URLs, and SSH tunneling.',
     {
       action: z
-        .enum(["create", "list", "get", "delete"])
+        .enum(["create", "update", "list", "get", "delete"])
         .describe("Operation to perform."),
       session_id: z
         .string()
-        .describe("Browser session ID. Required for get and delete actions.")
+        .describe(
+          "Browser session ID. Required for update, get, and delete actions.",
+        )
+        .optional(),
+      start_url: z
+        .string()
+        .url()
+        .describe(
+          "(create) URL to open when the browser is created. Navigation is best-effort.",
+        )
+        .optional(),
+      chrome_policy: z
+        .record(z.string(), z.unknown())
+        .describe(
+          "(create) Chrome enterprise policy overrides. Kernel-managed policies such as extensions, proxy, CDP, and automation are blocked by the API.",
+        )
         .optional(),
       headless: z
         .boolean()
         .describe("(create) Launch without GUI. Faster but no live view.")
+        .optional(),
+      gpu: z
+        .boolean()
+        .describe(
+          "(create) Enable GPU acceleration. Requires Start-Up or Enterprise plan and headless=false.",
+        )
         .optional(),
       stealth: z
         .boolean()
@@ -92,7 +250,19 @@ export function registerBrowserCapabilities(server: McpServer) {
         .optional(),
       proxy_id: z
         .string()
-        .describe("(create) Proxy ID for traffic routing.")
+        .describe(
+          "(create, update) Proxy ID for traffic routing. For update, omit to leave unchanged.",
+        )
+        .optional(),
+      clear_proxy: z
+        .boolean()
+        .describe("(update) Remove the current proxy from the browser session.")
+        .optional(),
+      disable_default_proxy: z
+        .boolean()
+        .describe(
+          "(update) For stealth browsers, connect directly instead of using the default stealth proxy.",
+        )
         .optional(),
       kiosk_mode: z
         .boolean()
@@ -112,7 +282,13 @@ export function registerBrowserCapabilities(server: McpServer) {
         .optional(),
       viewport_refresh_rate: z
         .number()
-        .describe("(create) Display refresh rate in Hz.")
+        .describe("(create, update) Display refresh rate in Hz.")
+        .optional(),
+      viewport_force: z
+        .boolean()
+        .describe(
+          "(update) Force viewport changes even when live view or recording is active.",
+        )
         .optional(),
       extension_id: z
         .string()
@@ -144,6 +320,32 @@ export function registerBrowserCapabilities(server: McpServer) {
         .number()
         .describe("(list) Pagination offset. Default 0.")
         .optional(),
+      telemetry_enabled: z
+        .boolean()
+        .describe(
+          "(create, update) Enable telemetry with VM defaults, or disable telemetry when false.",
+        )
+        .optional(),
+      telemetry_console: z
+        .boolean()
+        .describe("(create, update) Enable or disable console telemetry.")
+        .optional(),
+      telemetry_network: z
+        .boolean()
+        .describe("(create, update) Enable or disable network telemetry.")
+        .optional(),
+      telemetry_page: z
+        .boolean()
+        .describe(
+          "(create, update) Enable or disable page lifecycle telemetry.",
+        )
+        .optional(),
+      telemetry_interaction: z
+        .boolean()
+        .describe(
+          "(create, update) Enable or disable user interaction telemetry.",
+        )
+        .optional(),
     },
     async (params, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");
@@ -172,48 +374,35 @@ export function registerBrowserCapabilities(server: McpServer) {
                 ],
               };
             }
-            if (
-              (params.viewport_width && !params.viewport_height) ||
-              (!params.viewport_width && params.viewport_height)
-            ) {
-              return {
-                content: [
-                  {
-                    type: "text",
-                    text: "Error: viewport_width and viewport_height must be provided together.",
-                  },
-                ],
-              };
+            const updateOnlyField = updateOnlyFields.find(
+              (field) => params[field] !== undefined,
+            );
+            if (updateOnlyField) {
+              return textResponse(
+                `Error: ${updateOnlyField} is only supported for update.`,
+              );
             }
 
-            const createParams: Record<string, unknown> = {};
+            const createParams: BrowserCreateParams = {};
             if (params.headless !== undefined)
               createParams.headless = params.headless;
+            if (params.gpu !== undefined) createParams.gpu = params.gpu;
             if (params.stealth !== undefined)
               createParams.stealth = params.stealth;
             if (params.timeout_seconds !== undefined)
               createParams.timeout_seconds = params.timeout_seconds;
             if (params.kiosk_mode !== undefined)
               createParams.kiosk_mode = params.kiosk_mode;
+            if (params.start_url) createParams.start_url = params.start_url;
+            if (params.chrome_policy)
+              createParams.chrome_policy = params.chrome_policy;
             if (params.proxy_id) createParams.proxy_id = params.proxy_id;
-            if (params.profile_name || params.profile_id) {
-              createParams.profile = {
-                ...(params.profile_name && { name: params.profile_name }),
-                ...(params.profile_id && { id: params.profile_id }),
-                ...(params.save_profile_changes !== undefined && {
-                  save_changes: params.save_profile_changes,
-                }),
-              };
-            }
-            if (params.viewport_width && params.viewport_height) {
-              createParams.viewport = {
-                width: params.viewport_width,
-                height: params.viewport_height,
-                ...(params.viewport_refresh_rate && {
-                  refresh_rate: params.viewport_refresh_rate,
-                }),
-              };
-            }
+            const profile = buildProfile(params);
+            if (profile) createParams.profile = profile;
+            const viewport = buildViewport(params);
+            if (viewport) createParams.viewport = viewport;
+            const telemetry = buildTelemetry(params);
+            if (telemetry !== undefined) createParams.telemetry = telemetry;
             if (params.extension_id || params.extension_name) {
               createParams.extensions = [
                 {
@@ -223,9 +412,7 @@ export function registerBrowserCapabilities(server: McpServer) {
               ];
             }
 
-            const browser = await client.browsers.create(
-              createParams as Parameters<typeof client.browsers.create>[0],
-            );
+            const browser = await client.browsers.create(createParams);
             if (!browser)
               return {
                 content: [
@@ -262,6 +449,67 @@ export function registerBrowserCapabilities(server: McpServer) {
               responseText += `\n\nNote: SSH connections alone don't count as browser activity. Set an appropriate timeout or keep the live view open to prevent cleanup.`;
             }
             return { content: [{ type: "text", text: responseText }] };
+          }
+          case "update": {
+            if (!params.session_id)
+              return textResponse(
+                "Error: session_id is required for update action.",
+              );
+            if (params.profile_name && params.profile_id) {
+              return textResponse(
+                "Error: Cannot specify both profile_name and profile_id.",
+              );
+            }
+            if (params.extension_id || params.extension_name) {
+              return textResponse(
+                "Error: extensions can only be loaded during create.",
+              );
+            }
+            const createOnlyField = createOnlyFields.find(
+              (field) => params[field] !== undefined,
+            );
+            if (createOnlyField) {
+              return textResponse(
+                `Error: ${createOnlyField} is only supported for create.`,
+              );
+            }
+            if (params.proxy_id && params.clear_proxy) {
+              return textResponse(
+                "Error: Cannot specify both proxy_id and clear_proxy.",
+              );
+            }
+
+            const updateParams: BrowserUpdateParams = {};
+            if (params.disable_default_proxy !== undefined) {
+              updateParams.disable_default_proxy = params.disable_default_proxy;
+            }
+            if (params.clear_proxy) {
+              updateParams.proxy_id = "";
+            } else if (params.proxy_id !== undefined) {
+              updateParams.proxy_id = params.proxy_id;
+            }
+            const profile = buildProfile(params);
+            if (profile) updateParams.profile = profile;
+            const viewport = buildViewport(params, { includeForce: true });
+            if (viewport) updateParams.viewport = viewport;
+            const telemetry = buildTelemetry(params);
+            if (telemetry !== undefined) updateParams.telemetry = telemetry;
+
+            if (Object.keys(updateParams).length === 0) {
+              return textResponse(
+                "Error: at least one update field is required.",
+              );
+            }
+
+            const browser = await client.browsers.update(
+              params.session_id,
+              updateParams,
+            );
+            return {
+              content: [
+                { type: "text", text: JSON.stringify(browser, null, 2) },
+              ],
+            };
           }
           case "list": {
             const page = await client.browsers.list({

--- a/src/lib/mcp/tools/browsers.ts
+++ b/src/lib/mcp/tools/browsers.ts
@@ -1,7 +1,11 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { createKernelClient, type KernelClient } from "@/lib/mcp/kernel-client";
-import { textResponse, toolErrorResponse } from "@/lib/mcp/responses";
+import {
+  errorResponse,
+  textResponse,
+  toolErrorResponse,
+} from "@/lib/mcp/responses";
 
 type BrowserCreateParams = NonNullable<
   Parameters<KernelClient["browsers"]["create"]>[0]
@@ -111,18 +115,20 @@ function buildTelemetry(
     NonNullable<BrowserCreateParams["telemetry"]>["browser"]
   > = {};
   let hasBrowserCategories = false;
+  let hasEnabledBrowserCategories = false;
 
   for (const [paramKey, category] of telemetryCategories) {
     const enabled = params[paramKey];
     if (enabled !== undefined) {
       browser[category] = { enabled };
       hasBrowserCategories = true;
+      if (enabled) hasEnabledBrowserCategories = true;
     }
   }
 
-  if (params.telemetry_enabled === false && hasBrowserCategories) {
+  if (params.telemetry_enabled === false && hasEnabledBrowserCategories) {
     throw new Error(
-      "telemetry_enabled=false cannot be combined with telemetry category settings.",
+      "telemetry_enabled=false cannot be combined with enabled telemetry categories.",
     );
   }
 
@@ -358,12 +364,12 @@ export function registerBrowserCapabilities(server: McpServer) {
         switch (params.action) {
           case "create": {
             if (params.profile_name && params.profile_id) {
-              return textResponse(
+              return errorResponse(
                 "Error: Cannot specify both profile_name and profile_id.",
               );
             }
             if (params.extension_id && params.extension_name) {
-              return textResponse(
+              return errorResponse(
                 "Error: Cannot specify both extension_id and extension_name.",
               );
             }
@@ -399,7 +405,7 @@ export function registerBrowserCapabilities(server: McpServer) {
 
             const browser = await client.browsers.create(createParams);
             if (!browser)
-              return textResponse("Failed to create browser session");
+              return errorResponse("Failed to create browser session");
 
             let responseText = JSON.stringify(browser, null, 2);
             if (params.local_forward || params.remote_forward) {
@@ -433,16 +439,16 @@ export function registerBrowserCapabilities(server: McpServer) {
           }
           case "update": {
             if (!params.session_id)
-              return textResponse(
+              return errorResponse(
                 "Error: session_id is required for update action.",
               );
             if (params.profile_name && params.profile_id) {
-              return textResponse(
+              return errorResponse(
                 "Error: Cannot specify both profile_name and profile_id.",
               );
             }
             if (params.proxy_id && params.clear_proxy) {
-              return textResponse(
+              return errorResponse(
                 "Error: Cannot specify both proxy_id and clear_proxy.",
               );
             }
@@ -464,7 +470,7 @@ export function registerBrowserCapabilities(server: McpServer) {
             if (telemetry !== undefined) updateParams.telemetry = telemetry;
 
             if (Object.keys(updateParams).length === 0) {
-              return textResponse(
+              return errorResponse(
                 "Error: at least one update field is required.",
               );
             }
@@ -474,7 +480,7 @@ export function registerBrowserCapabilities(server: McpServer) {
               updateParams,
             );
             if (!browser)
-              return textResponse("Failed to update browser session");
+              return errorResponse("Failed to update browser session");
             return textResponse(JSON.stringify(browser, null, 2));
           }
           case "list": {
@@ -502,19 +508,19 @@ export function registerBrowserCapabilities(server: McpServer) {
           }
           case "get": {
             if (!params.session_id)
-              return textResponse(
+              return errorResponse(
                 "Error: session_id is required for get action.",
               );
             const browser = await client.browsers.retrieve(params.session_id);
             if (!browser)
-              return textResponse(
+              return errorResponse(
                 `Browser session "${params.session_id}" not found`,
               );
             return textResponse(JSON.stringify(browser, null, 2));
           }
           case "delete": {
             if (!params.session_id)
-              return textResponse(
+              return errorResponse(
                 "Error: session_id is required for delete action.",
               );
             await client.browsers.deleteByID(params.session_id);


### PR DESCRIPTION
## Summary
- extend `manage_browsers` create with SDK 0.58 browser-session options: `start_url`, `chrome_policy`, `gpu`, and telemetry category controls
- add `manage_browsers` update for supported session settings: `disable_default_proxy`, proxy/profile updates, viewport updates, and telemetry updates
- replace the previous untyped create params object with SDK-derived request types and small builders for profile, viewport, and telemetry payloads
- move MCP text/error response formatting into a shared helper while preserving `manage_browsers` action context in caught errors

## Agent Experience / Flow

This PR makes `manage_browsers` a practical session-control surface for agents instead of only a launch/delete tool. Agents can now create a browser with the right initial context, then mutate safe runtime settings without throwing away the session.

Typical flow:

1. Agent calls `manage_browsers create` with the launch-time intent: `start_url` for the first page, optional `profile_name`/`profile_id` for saved auth, optional `proxy_id`, viewport settings, and telemetry categories when it expects to debug page/network/console behavior.
2. Agent receives the browser session payload and uses `session_id` for follow-on tools such as `execute_playwright_code`, `computer_action`, and the browser utilities from PR 111.
3. If the workflow needs a runtime adjustment, agent calls `manage_browsers update session_id=<id>` instead of recreating the browser. Supported updates include proxy changes, profile save settings, viewport changes, and telemetry changes.
4. Agent uses `manage_browsers get` to verify the session state after important create/update steps, or `list` to recover active sessions when it lost the ID.
5. Agent calls `manage_browsers delete session_id=<id>` when the task is done so short-lived automation does not leak sessions.

Agent ergonomics:

- Flat schema descriptions mark which fields belong to each action, while each action branch only forwards the SDK params it supports. This matches the sibling `manage_*` tools and avoids a second hand-maintained action-scope map.
- `update` now returns a clear failure message if the SDK does not return a browser object, rather than emitting a malformed MCP text response.
- Caught helper/SDK errors keep the tool and action context, e.g. `Error in manage_browsers (update): ...`, so agents can diagnose which request path failed.
- Telemetry controls are opt-in and scoped to the browser categories the agent actually needs, so normal browser creation stays simple.

## Validation
- `bunx prettier --write src/lib/mcp/responses.ts src/lib/mcp/tools/browsers.ts`
- `git diff --check`
- `bunx tsc --noEmit`
- `KERNEL_CLI_PROD_CLIENT_ID=dummy KERNEL_CLI_STAGING_CLIENT_ID=dummy KERNEL_CLI_DEV_CLIENT_ID=dummy NEXT_PUBLIC_CLERK_DOMAIN=example.clerk.accounts.dev NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_ZXhhbXBsZS5jbGVyay5hY2NvdW50cy5kZXYk CLERK_SECRET_KEY=sk_test_dummy REDIS_URL=redis://localhost:6379 bun run build`
- localhost MCP smoke against `http://127.0.0.1:3002/mcp` with `API_BASE_URL=http://127.0.0.1:3001`: initialized MCP, verified `manage_browsers` was listed, created a short-lived headless browser with `start_url`, `chrome_policy`, telemetry, and viewport options, updated telemetry/viewport through the new `update` action, retrieved it, and deleted it

## Notes
- Attempting `disable_default_proxy: true` through the same localhost MCP path reached the API but the local backend returned `500 proxy swap did not complete`; browser cleanup succeeded. The MCP request wiring is present, but that backend behavior was not green in local smoke.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live browser-session control (proxies, policies, telemetry) exposed to MCP agents; mistakes could misconfigure running sessions but scope is limited to the MCP tool layer.
> 
> **Overview**
> Extends the MCP **`manage_browsers`** tool so agents can tune browser sessions to match newer Kernel SDK options instead of only create/list/get/delete.
> 
> **Create** gains **`start_url`**, **`chrome_policy`**, **`gpu`**, and granular **telemetry** flags; profile, viewport, and telemetry inputs are assembled via small **typed builders** derived from the SDK client types rather than an untyped `Record`.
> 
> Adds an **`update`** action (requires **`session_id`**) for runtime changes: proxy swap/clear, **`disable_default_proxy`**, profile save settings, viewport (including **`viewport_force`**), and telemetry— with validation for conflicting fields and empty update payloads.
> 
> Tool outcomes now go through shared **`errorResponse` / `textResponse` / `toolErrorResponse`** helpers so validation and caught SDK errors return consistent MCP text (and errors include the action name).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa60da44a29ad6c60b4e8290ebd813dbc1884170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->