### PR TITLE
Add tool annotations to remaining MCP tools

### DIFF
--- a/src/lib/mcp/tools/apps.ts
+++ b/src/lib/mcp/tools/apps.ts
@@ -102,6 +102,13 @@ export function registerAppCapabilities(server: McpServer) {
         .describe("(list_apps, list_deployments) Pagination offset. Default 0.")
         .optional(),
     },
+    {
+      title: "Manage Kernel apps and invocations",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     async (params, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");
       const client = createKernelClient(extra.authInfo.token);

--- a/src/lib/mcp/tools/browser-curl.ts
+++ b/src/lib/mcp/tools/browser-curl.ts
@@ -41,6 +41,13 @@ export function registerBrowserCurlTool(server: McpServer) {
         .describe("Request timeout in milliseconds.")
         .optional(),
     },
+    {
+      title: "Send HTTP request via browser",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     async (params, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");
       const client = createKernelClient(extra.authInfo.token);

--- a/src/lib/mcp/tools/browser-pools.ts
+++ b/src/lib/mcp/tools/browser-pools.ts
@@ -115,6 +115,13 @@ export function registerBrowserPoolCapabilities(server: McpServer) {
         .describe("(release) Reuse browser instance or recreate. Default true.")
         .optional(),
     },
+    {
+      title: "Manage Kernel browser pools",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     async (params, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");
       const client = createKernelClient(extra.authInfo.token);

--- a/src/lib/mcp/tools/browsers.ts
+++ b/src/lib/mcp/tools/browsers.ts
@@ -356,6 +356,13 @@ export function registerBrowserCapabilities(server: McpServer) {
         )
         .optional(),
     },
+    {
+      title: "Manage Kernel browser sessions",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     async (params, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");
       const client = createKernelClient(extra.authInfo.token);

--- a/src/lib/mcp/tools/computer-action.ts
+++ b/src/lib/mcp/tools/computer-action.ts
@@ -254,6 +254,13 @@ export function registerComputerActionTool(server: McpServer) {
           "Ordered list of actions. Use one action for simple operations or multiple for batched sequences.",
         ),
     },
+    {
+      title: "Control browser (mouse, keyboard, screenshot)",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     async ({ session_id, actions }, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");
       const client = createKernelClient(extra.authInfo.token);

--- a/src/lib/mcp/tools/docs.ts
+++ b/src/lib/mcp/tools/docs.ts
@@ -19,6 +19,13 @@ export function registerDocsTools(server: McpServer) {
           'Natural language search query (e.g., "how to deploy an app", "browser automation examples").',
         ),
     },
+    {
+      title: "Search Kernel documentation",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     async ({ query }, extra) => {
       if (
         !process.env.MINTLIFY_ASSISTANT_API_TOKEN ||

--- a/src/lib/mcp/tools/extensions.ts
+++ b/src/lib/mcp/tools/extensions.ts
@@ -14,6 +14,13 @@ export function registerExtensionTools(server: McpServer) {
         .describe("(delete) Extension ID or name to delete.")
         .optional(),
     },
+    {
+      title: "Manage Kernel browser extensions",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     async (params, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");
       const client = createKernelClient(extra.authInfo.token);

--- a/src/lib/mcp/tools/playwright.ts
+++ b/src/lib/mcp/tools/playwright.ts
@@ -20,6 +20,13 @@ export function registerPlaywrightTool(server: McpServer) {
         )
         .optional(),
     },
+    {
+      title: "Execute Playwright code",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     async ({ code, session_id }, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");
       const client = createKernelClient(extra.authInfo.token);

--- a/src/lib/mcp/tools/profiles.ts
+++ b/src/lib/mcp/tools/profiles.ts
@@ -79,6 +79,13 @@ export function registerProfileCapabilities(server: McpServer) {
         .describe("(setup) If true, update existing profile. Default false.")
         .optional(),
     },
+    {
+      title: "Manage Kernel browser profiles",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     async (params, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");
       const client = createKernelClient(extra.authInfo.token);

--- a/src/lib/mcp/tools/projects.ts
+++ b/src/lib/mcp/tools/projects.ts
@@ -36,6 +36,13 @@ export function registerProjectCapabilities(server: McpServer) {
         .optional(),
       ...paginationParams,
     },
+    {
+      title: "Manage Kernel projects",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     async (params, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");
       const client = createKernelClient(extra.authInfo.token);

--- a/src/lib/mcp/tools/proxies.ts
+++ b/src/lib/mcp/tools/proxies.ts
@@ -48,6 +48,13 @@ export function registerProxyTools(server: McpServer) {
         .describe("(create, custom type) Auth password.")
         .optional(),
     },
+    {
+      title: "Manage Kernel proxy configurations",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     async (params, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");
       const client = createKernelClient(extra.authInfo.token);

--- a/src/lib/mcp/tools/shell.ts
+++ b/src/lib/mcp/tools/shell.ts
@@ -23,6 +23,13 @@ export function registerShellTool(server: McpServer) {
         .optional(),
       as_root: z.boolean().describe("Run with root privileges.").optional(),
     },
+    {
+      title: "Run shell command in browser VM",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     async ({ session_id, command, args, cwd, timeout_sec, as_root }, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");
       const client = createKernelClient(extra.authInfo.token);


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`title` + behavior hints) to the 12 tools that were missing them. Previously only 4 of 16 tools (`manage_api_keys`, `manage_credentials`, `manage_credential_providers`, `manage_auth_connections`) declared annotations; the rest passed `schema → callback` with no annotations object.

Every tool now declares a `title` and the applicable `readOnlyHint`/`destructiveHint` (plus `idempotentHint`/`openWorldHint`), matching the existing pattern. MCP clients use these to label tools in the UI and to gate destructive actions.

## Hints applied

| Tool | readOnly | destructive | openWorld | rationale |
|------|----------|-------------|-----------|-----------|
| `search_docs` | ✅ | – | ❌ | read-only search over first-party docs |
| `manage_apps` | ❌ | ❌ | ✅ | invokes apps against external sites; no delete op |
| `manage_browsers` | ❌ | ✅ | ❌ | `delete` terminates sessions; Kernel-API only |
| `manage_profiles` | ❌ | ✅ | ✅ | `delete` removes profiles; setup drives live login |
| `manage_browser_pools` | ❌ | ✅ | ❌ | `delete`/`flush` destroy browsers |
| `manage_projects` | ❌ | ✅ | ❌ | `delete` removes projects |
| `manage_extensions` | ❌ | ✅ | ❌ | `delete` removes extensions |
| `manage_proxies` | ❌ | ✅ | ❌ | `delete` removes proxies |
| `execute_playwright_code` | ❌ | ✅ | ✅ | runs arbitrary code against the open web |
| `exec_command` | ❌ | ✅ | ✅ | runs arbitrary shell commands |
| `browser_curl` | ❌ | ✅ | ✅ | issues arbitrary HTTP (incl. POST/DELETE) |
| `computer_action` | ❌ | ✅ | ✅ | arbitrary mouse/keyboard actuation |

`openWorldHint` follows the existing convention: `true` for tools that touch external systems / the open web, `false` for Kernel-API-only management (consistent with `manage_credentials` = false, `manage_auth_connections` = true).

## Test plan

- [x] `tsc --noEmit` passes
- [x] `prettier --check` clean on all changed files
- [ ] Confirm the running server advertises annotations via `tools/list` (requires deployed/authed instance)

> Context: this brings every tool in line with the Connector Directory submission requirement that all tools declare a title and the applicable read-only/destructive hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only changes to MCP tool registration with no handler or API logic modified.
> 
> **Overview**
> Adds MCP **tool annotation** metadata (`title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) to the 12 Kernel MCP tools that previously registered only schema + handler. Tool behavior is unchanged; registrations now pass the annotations object between the Zod schema and the callback, consistent with tools like `manage_api_keys`.
> 
> Hints are set per tool: **`search_docs`** is read-only and idempotent; Kernel-only management tools (browsers, pools, projects, extensions, proxies) mark **`openWorldHint: false`** and **`destructiveHint: true`** where delete/flush/terminate applies; **`manage_apps`** is non-destructive but **`openWorldHint: true`** for app invokes; automation tools (`execute_playwright_code`, `exec_command`, `browser_curl`, `computer_action`, profile setup) are marked destructive and open-world where they can act on arbitrary sites or commands.
> 
> This completes annotation coverage for Connector Directory / `tools/list` consumers that use titles and hints for UI labeling and gating destructive actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44e6140e27a2741d1c043bc2f903760c1bb9bb9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->