### PR TITLE
Add timeouts and bounded reconnect to Redis client

### DIFF
--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -9,9 +9,22 @@ if (redisTlsServerName && parsedRedisUrl?.protocol !== "rediss:") {
   throw new Error("REDIS_TLS_SERVER_NAME requires REDIS_URL to use rediss://");
 }
 
-// Modest backoff to smooth over first-hit cold connections
-const reconnectStrategy = (retries: number) =>
-  Math.min(500 + retries * 100, 2000);
+// Upper bound on connecting and on any single command, so an unreachable Redis
+// surfaces as an error instead of blocking the caller (e.g. OAuth token exchange).
+const CONNECT_TIMEOUT_MS = 5000;
+const COMMAND_TIMEOUT_MS = 5000;
+
+// Modest backoff to smooth over first-hit cold connections, but give up after a
+// bounded number of attempts rather than retrying forever while Redis is down.
+const MAX_RECONNECT_ATTEMPTS = 10;
+const reconnectStrategy = (retries: number) => {
+  if (retries > MAX_RECONNECT_ATTEMPTS) {
+    return new Error(
+      `Redis unavailable after ${MAX_RECONNECT_ATTEMPTS} reconnect attempts`,
+    );
+  }
+  return Math.min(500 + retries * 100, 2000);
+};
 
 // Connect on first use
 let isConnected = false;
@@ -24,9 +37,11 @@ const client = createClient({
         host: parsedRedisUrl!.hostname,
         tls: true,
         servername: redisTlsServerName,
+        connectTimeout: CONNECT_TIMEOUT_MS,
         reconnectStrategy,
       }
     : {
+        connectTimeout: CONNECT_TIMEOUT_MS,
         reconnectStrategy,
       },
 });
@@ -179,14 +194,32 @@ function isTransientSocketError(error: unknown): boolean {
   );
 }
 
+async function withTimeout<T>(operation: () => Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          new Error(`Redis command timed out after ${COMMAND_TIMEOUT_MS}ms`),
+        ),
+      COMMAND_TIMEOUT_MS,
+    );
+  });
+  try {
+    return await Promise.race([operation(), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 async function withReconnect<T>(operation: () => Promise<T>): Promise<T> {
   try {
-    return await operation();
+    return await withTimeout(operation);
   } catch (err) {
     if (isTransientSocketError(err)) {
       isConnected = false;
       await ensureConnected();
-      return await operation();
+      return await withTimeout(operation);
     }
     throw err;
   }

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -26,8 +26,7 @@ const reconnectStrategy = (retries: number) => {
   return Math.min(500 + retries * 100, 2000);
 };
 
-// Connect on first use
-let isConnected = false;
+// Connect on first use; client.isReady is the source of truth for connection state
 let connectPromise: Promise<void> | null = null;
 
 const client = createClient({
@@ -47,22 +46,25 @@ const client = createClient({
 });
 
 client.on("error", (err) => {
-  // Reset connection state so the next command will re-connect
-  isConnected = false;
   console.error("Redis Client Error", err);
 });
-client.on("end", () => {
-  isConnected = false;
-});
-client.on("ready", () => {
-  isConnected = true;
-});
+
+// node-redis leaves the socket flagged open after a connect fully fails or a
+// command stalls, so a plain reconnect would throw "Socket already opened".
+// Tear the client down to a known-clean state; destroy() throws when the socket
+// is already closed, which is exactly the state we want, so ignore that.
+function resetClient(): void {
+  if (client.isOpen) {
+    try {
+      client.destroy();
+    } catch {}
+  }
+}
 
 async function ensureConnected(): Promise<void> {
-  // Prefer the client's readiness state when available
-  // @ts-ignore node-redis exposes isReady at runtime
-  if ((client as any).isReady) return;
-  if (client.isOpen && isConnected) return;
+  if (client.isReady) return;
+  // A single in-flight connect is shared so concurrent callers don't each open
+  // (and later tear down) the singleton socket out from under one another.
   if (connectPromise) return await connectPromise;
   connectPromise = connectWithTimeout().finally(() => {
     connectPromise = null;
@@ -74,6 +76,8 @@ async function ensureConnected(): Promise<void> {
 // for the whole reconnect budget. Cap the wait so callers fail within the same
 // ceiling as a command instead of after every reconnect attempt.
 async function connectWithTimeout(): Promise<void> {
+  // Clear any half-open socket from a prior failed connect before retrying.
+  if (client.isOpen) resetClient();
   let timer: ReturnType<typeof setTimeout> | undefined;
   const connect = client.connect();
   connect.catch(() => {}); // swallow a late rejection if the deadline wins
@@ -89,11 +93,7 @@ async function connectWithTimeout(): Promise<void> {
   try {
     await Promise.race([connect, deadline]);
   } catch (err) {
-    isConnected = false;
-    // Stop the in-flight reconnect loop so the next call starts from a clean socket
-    try {
-      client.destroy();
-    } catch {}
+    resetClient();
     throw err;
   } finally {
     if (timer) clearTimeout(timer);
@@ -215,6 +215,8 @@ function isTransientSocketError(error: unknown): boolean {
   );
 }
 
+class RedisCommandTimeoutError extends Error {}
+
 async function withTimeout<T>(operation: () => Promise<T>): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const op = operation();
@@ -223,7 +225,9 @@ async function withTimeout<T>(operation: () => Promise<T>): Promise<T> {
     timer = setTimeout(
       () =>
         reject(
-          new Error(`Redis command timed out after ${COMMAND_TIMEOUT_MS}ms`),
+          new RedisCommandTimeoutError(
+            `Redis command timed out after ${COMMAND_TIMEOUT_MS}ms`,
+          ),
         ),
       COMMAND_TIMEOUT_MS,
     );
@@ -239,8 +243,13 @@ async function withReconnect<T>(operation: () => Promise<T>): Promise<T> {
   try {
     return await withTimeout(operation);
   } catch (err) {
-    if (isTransientSocketError(err)) {
-      isConnected = false;
+    // A timed-out command leaves a stalled socket that still reports ready, so
+    // reset before retrying to force a fresh connection rather than reusing it.
+    if (
+      isTransientSocketError(err) ||
+      err instanceof RedisCommandTimeoutError
+    ) {
+      resetClient();
       await ensureConnected();
       return await withTimeout(operation);
     }

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -9,18 +9,20 @@ if (redisTlsServerName && parsedRedisUrl?.protocol !== "rediss:") {
   throw new Error("REDIS_TLS_SERVER_NAME requires REDIS_URL to use rediss://");
 }
 
-// Upper bound on connecting and on any single command, so an unreachable Redis
-// surfaces as an error instead of blocking the caller (e.g. OAuth token exchange).
-const CONNECT_TIMEOUT_MS = 5000;
+// Upper bound on any single command, so an unreachable Redis surfaces as an
+// error instead of blocking the caller (e.g. OAuth token exchange).
 const COMMAND_TIMEOUT_MS = 5000;
 
-// Modest backoff to smooth over first-hit cold connections, but give up after a
-// bounded number of attempts rather than retrying forever while Redis is down.
-const MAX_RECONNECT_ATTEMPTS = 10;
+// connect() makes one attempt per connectTimeout and consults reconnectStrategy
+// between attempts. Bounding both caps how long connect() can block: an
+// unreachable Redis fails after ~MAX_CONNECT_ATTEMPTS x CONNECT_TIMEOUT_MS
+// instead of retrying forever, while a healthy connect still returns in <1s.
+const CONNECT_TIMEOUT_MS = 3000;
+const MAX_CONNECT_ATTEMPTS = 2;
 const reconnectStrategy = (retries: number) => {
-  if (retries >= MAX_RECONNECT_ATTEMPTS) {
+  if (retries >= MAX_CONNECT_ATTEMPTS - 1) {
     return new Error(
-      `Redis unavailable after ${MAX_RECONNECT_ATTEMPTS} reconnect attempts`,
+      `Redis unavailable after ${MAX_CONNECT_ATTEMPTS} connect attempts`,
     );
   }
   return Math.min(500 + retries * 100, 2000);
@@ -66,37 +68,22 @@ async function ensureConnected(): Promise<void> {
   // A single in-flight connect is shared so concurrent callers don't each open
   // (and later tear down) the singleton socket out from under one another.
   if (connectPromise) return await connectPromise;
-  connectPromise = connectWithTimeout().finally(() => {
+  connectPromise = openConnection().finally(() => {
     connectPromise = null;
   });
   return await connectPromise;
 }
 
-// connect() drives the reconnect loop, so against an unreachable Redis it blocks
-// for the whole reconnect budget. Cap the wait so callers fail within the same
-// ceiling as a command instead of after every reconnect attempt.
-async function connectWithTimeout(): Promise<void> {
-  // Clear any half-open socket from a prior failed connect before retrying.
+async function openConnection(): Promise<void> {
+  // A prior failed connect leaves the socket flagged open; clear it first so
+  // connect() doesn't throw "Socket already opened". connect() bounds itself via
+  // connectTimeout and reconnectStrategy, so no external deadline is needed.
   if (client.isOpen) resetClient();
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const connect = client.connect();
-  connect.catch(() => {}); // swallow a late rejection if the deadline wins
-  const deadline = new Promise<never>((_, reject) => {
-    timer = setTimeout(
-      () =>
-        reject(
-          new Error(`Redis connect timed out after ${CONNECT_TIMEOUT_MS}ms`),
-        ),
-      CONNECT_TIMEOUT_MS,
-    );
-  });
   try {
-    await Promise.race([connect, deadline]);
+    await client.connect();
   } catch (err) {
     resetClient();
     throw err;
-  } finally {
-    if (timer) clearTimeout(timer);
   }
 }
 

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -18,7 +18,7 @@ const COMMAND_TIMEOUT_MS = 5000;
 // bounded number of attempts rather than retrying forever while Redis is down.
 const MAX_RECONNECT_ATTEMPTS = 10;
 const reconnectStrategy = (retries: number) => {
-  if (retries > MAX_RECONNECT_ATTEMPTS) {
+  if (retries >= MAX_RECONNECT_ATTEMPTS) {
     return new Error(
       `Redis unavailable after ${MAX_RECONNECT_ATTEMPTS} reconnect attempts`,
     );
@@ -64,19 +64,40 @@ async function ensureConnected(): Promise<void> {
   if ((client as any).isReady) return;
   if (client.isOpen && isConnected) return;
   if (connectPromise) return await connectPromise;
-  connectPromise = client
-    .connect()
-    .then(() => {
-      // 'ready' event will flip isConnected when the client can process commands
-    })
-    .catch((err) => {
-      isConnected = false;
-      throw err;
-    })
-    .finally(() => {
-      connectPromise = null;
-    });
+  connectPromise = connectWithTimeout().finally(() => {
+    connectPromise = null;
+  });
   return await connectPromise;
+}
+
+// connect() drives the reconnect loop, so against an unreachable Redis it blocks
+// for the whole reconnect budget. Cap the wait so callers fail within the same
+// ceiling as a command instead of after every reconnect attempt.
+async function connectWithTimeout(): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const connect = client.connect();
+  connect.catch(() => {}); // swallow a late rejection if the deadline wins
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          new Error(`Redis connect timed out after ${CONNECT_TIMEOUT_MS}ms`),
+        ),
+      CONNECT_TIMEOUT_MS,
+    );
+  });
+  try {
+    await Promise.race([connect, deadline]);
+  } catch (err) {
+    isConnected = false;
+    // Stop the in-flight reconnect loop so the next call starts from a clean socket
+    try {
+      client.destroy();
+    } catch {}
+    throw err;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 // Hash JWT using HMAC-SHA256 with CLERK_SECRET_KEY for secure Redis storage
@@ -196,6 +217,8 @@ function isTransientSocketError(error: unknown): boolean {
 
 async function withTimeout<T>(operation: () => Promise<T>): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
+  const op = operation();
+  op.catch(() => {}); // if the timeout wins, the command may still settle later
   const timeout = new Promise<never>((_, reject) => {
     timer = setTimeout(
       () =>
@@ -206,7 +229,7 @@ async function withTimeout<T>(operation: () => Promise<T>): Promise<T> {
     );
   });
   try {
-    return await Promise.race([operation(), timeout]);
+    return await Promise.race([op, timeout]);
   } finally {
     if (timer) clearTimeout(timer);
   }


### PR DESCRIPTION
## Summary
The Redis client retried reconnecting forever with no connect or command timeout. When Redis was unreachable, any command (e.g. the OAuth org-context writes in `/token`) blocked until the serverless function limit instead of throwing — so `kernel login` hung after the browser showed "authentication successful" rather than failing with an error.

This bounds the failure:
- **Bounded reconnect** — `reconnectStrategy` now returns an `Error` after `MAX_RECONNECT_ATTEMPTS` (10) instead of retrying indefinitely, so queued commands reject when Redis stays down.
- **Connect timeout** — `connectTimeout` (5s) on the socket so a black-holed connection fails fast.
- **Per-command timeout** — every op runs through `withTimeout` (5s ceiling) so a stalled-but-connected command surfaces as an error.

Net effect: a Redis outage returns a clean error in seconds instead of hanging the caller.

## Test plan
- [x] `tsc --noEmit` passes
- [x] prettier clean
- [ ] Manual: confirm normal OAuth login still succeeds against a healthy Redis (behavior unchanged on the happy path)

Follow-up companion PR on `kernel/cli` adds a timeout on the CLI token exchange so it also fails fast.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all Redis-backed org-context paths used during token exchange; mis-tuned timeouts could cause false failures under slow Redis, though happy-path behavior should stay the same.
> 
> **Overview**
> **Redis failures now surface in seconds instead of hanging OAuth/token handlers** (e.g. `/token` org-context writes and `kernel login` after the browser succeeds).
> 
> The shared `redis` client adds a **5s per-command ceiling** via `withTimeout`, **3s socket `connectTimeout`**, and a **reconnect strategy that stops after two connect attempts** (returns an error instead of retrying forever). Connection handling drops the manual `isConnected` / event listeners in favor of **`client.isReady`**, shares one in-flight `connect()` via `openConnection`, and introduces **`resetClient()`** (`destroy()` on a stuck open socket) so failed connects, command timeouts, and transient socket errors can retry on a clean client instead of hitting “Socket already opened.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ff018b3e2bc65f26a66f91da7e12c58ff1b7f9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->