### PR TITLE
Update @onkernel/sdk to 0.78

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@clerk/themes": "^2.4.19",
         "@mcp-ui/server": "^5.10.0",
         "@modelcontextprotocol/sdk": "1.26.0",
-        "@onkernel/sdk": "^0.60.0",
+        "@onkernel/sdk": "^0.78.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/redis": "^4.0.11",
         "builtin-modules": "^5.0.0",
@@ -20,7 +20,7 @@
         "jszip": "^3.10.1",
         "lucide-react": "^0.534.0",
         "mcp-handler": "^1.1.0",
-        "next": "16.2.6",
+        "next": "^16.2.6",
         "next-themes": "^0.4.4",
         "playwright": "^1.49.1",
         "prettier": "^3.6.2",
@@ -145,7 +145,7 @@
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA=="],
 
-    "@onkernel/sdk": ["@onkernel/sdk@0.60.0", "", {}, "sha512-z9POhDK6uanj9FJ5GS/ff7MaqYjCOWP5605pbuUYEH9EuX5bthD89y/XPqwcC9xpgr9RLjlFVJ73ORAiAXfuPw=="],
+    "@onkernel/sdk": ["@onkernel/sdk@0.78.0", "", {}, "sha512-VrGEDcuSwO6AKe6oYTNaQsAHnOAVeqehmStDTM0EFd3u8+WhITYxhU+jNFq+9yEt0N/nrn2COsk/ThQ+dxWBlw=="],
 
     "@redis/bloom": ["@redis/bloom@5.6.0", "", { "peerDependencies": { "@redis/client": "^5.6.0" } }, "sha512-l13/d6BaZDJzogzZJEphIeZ8J0hpQpjkMiozomTm6nJiMNYkoPsNOBOOQua4QsG0fFjyPmLMDJFPAp5FBQtTXg=="],
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@clerk/themes": "^2.4.19",
     "@mcp-ui/server": "^5.10.0",
     "@modelcontextprotocol/sdk": "1.26.0",
-    "@onkernel/sdk": "^0.60.0",
+    "@onkernel/sdk": "^0.78.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/redis": "^4.0.11",
     "builtin-modules": "^5.0.0",

--- a/src/lib/mcp/responses.ts
+++ b/src/lib/mcp/responses.ts
@@ -9,7 +9,9 @@ type JsonItemsResponseOptions<T, U = T> = {
   note?: string;
 };
 
-type PaginatedJsonResponseOptions<T, U = T> = JsonItemsResponseOptions<T, U>;
+type PaginatedJsonResponseOptions<T, U = T> = JsonItemsResponseOptions<T, U> & {
+  emptyText?: string;
+};
 
 type ItemsJsonResponseOptions<T, U = T> = JsonItemsResponseOptions<T, U> & {
   emptyText?: string;
@@ -47,10 +49,8 @@ export function paginatedJsonResponse<T, U = T>(
   page: PaginatedPage<T>,
   options: PaginatedJsonResponseOptions<T, U> = {},
 ) {
-  const { mapItem, note } = options;
   return itemsJsonResponse(page.getPaginatedItems(), {
-    mapItem,
-    note,
+    ...options,
     has_more: page.has_more,
     next_offset: page.next_offset,
   });

--- a/src/lib/mcp/tools/browser-pools.ts
+++ b/src/lib/mcp/tools/browser-pools.ts
@@ -164,7 +164,6 @@ export function registerBrowserPoolCapabilities(server: McpServer) {
     }
 
     const client = createKernelClient(extra.authInfo.token);
-    // Resources take no pagination params, so collect every page.
     const pools = [];
     for await (const pool of client.browserPools.list()) {
       pools.push(pool);

--- a/src/lib/mcp/tools/browser-pools.ts
+++ b/src/lib/mcp/tools/browser-pools.ts
@@ -10,9 +10,11 @@ import { registerJsonResourceTemplate } from "@/lib/mcp/resource-templates";
 import {
   jsonResponse,
   errorResponse,
+  paginatedJsonResponse,
   textResponse,
   toolErrorResponse,
 } from "@/lib/mcp/responses";
+import { paginationParams } from "@/lib/mcp/schemas";
 
 type BrowserPoolCreateParams = Parameters<
   KernelClient["browserPools"]["create"]
@@ -27,7 +29,10 @@ type BrowserPoolAcquireResponse = Awaited<
   ReturnType<KernelClient["browserPools"]["acquire"]>
 >;
 
-type PoolConfigParams = BrowserCreateConfigParams & {
+type PoolConfigParams = Omit<
+  BrowserCreateConfigParams,
+  "save_profile_changes"
+> & {
   size?: number;
   name?: string;
   headless?: boolean;
@@ -159,14 +164,18 @@ export function registerBrowserPoolCapabilities(server: McpServer) {
     }
 
     const client = createKernelClient(extra.authInfo.token);
-    const pools = await client.browserPools.list();
+    // Resources take no pagination params, so collect every page.
+    const pools = [];
+    for await (const pool of client.browserPools.list()) {
+      pools.push(pool);
+    }
     return {
       contents: [
         {
           uri: uri.toString(),
           mimeType: "application/json",
           text:
-            pools && pools.length > 0
+            pools.length > 0
               ? JSON.stringify(pools.map(summarizeBrowserPool), null, 2)
               : "No browser pools found",
         },
@@ -243,12 +252,6 @@ export function registerBrowserPoolCapabilities(server: McpServer) {
         .string()
         .describe(
           "(create, update) Profile ID to load into pool browsers. Cannot use with profile_name.",
-        )
-        .optional(),
-      save_profile_changes: z
-        .boolean()
-        .describe(
-          "(create, update) Save browser changes back to the selected profile when sessions end.",
         )
         .optional(),
       proxy_id: z
@@ -335,6 +338,7 @@ export function registerBrowserPoolCapabilities(server: McpServer) {
         .boolean()
         .describe("(release) Reuse browser instance or recreate. Default true.")
         .optional(),
+      ...paginationParams,
     },
     {
       title: "Manage Kernel browser pools",
@@ -391,13 +395,14 @@ export function registerBrowserPoolCapabilities(server: McpServer) {
             });
           }
           case "list": {
-            const pools = (await client.browserPools.list()) ?? [];
-            return pools.length > 0
-              ? jsonResponse({
-                  items: pools.map(summarizeBrowserPool),
-                  note: 'Use action "get" with id_or_name for full pool details.',
-                })
-              : textResponse("No browser pools found");
+            const page = await client.browserPools.list({
+              ...(params.limit !== undefined && { limit: params.limit }),
+              ...(params.offset !== undefined && { offset: params.offset }),
+            });
+            return paginatedJsonResponse(page, {
+              mapItem: summarizeBrowserPool,
+              note: 'Use action "get" with id_or_name for full pool details.',
+            });
           }
           case "get": {
             if (!params.id_or_name)

--- a/src/lib/mcp/tools/browser-pools.ts
+++ b/src/lib/mcp/tools/browser-pools.ts
@@ -402,6 +402,7 @@ export function registerBrowserPoolCapabilities(server: McpServer) {
             return paginatedJsonResponse(page, {
               mapItem: summarizeBrowserPool,
               note: 'Use action "get" with id_or_name for full pool details.',
+              emptyText: "No browser pools found",
             });
           }
           case "get": {

--- a/src/lib/mcp/tools/credential-providers.ts
+++ b/src/lib/mcp/tools/credential-providers.ts
@@ -4,9 +4,11 @@ import { createKernelClient } from "@/lib/mcp/kernel-client";
 import {
   errorResponse,
   jsonResponse,
+  paginatedJsonResponse,
   textResponse,
   toolErrorResponse,
 } from "@/lib/mcp/responses";
+import { paginationParams } from "@/lib/mcp/schemas";
 
 export function registerCredentialProviderTools(server: McpServer) {
   // manage_credential_providers -- Manage external credential providers
@@ -31,6 +33,7 @@ export function registerCredentialProviderTools(server: McpServer) {
           "(get, update, delete, list_items, test) Credential provider ID.",
         )
         .optional(),
+      ...paginationParams,
       name: z
         .string()
         .describe("(create, update) Human-readable name (unique per org).")
@@ -80,8 +83,11 @@ export function registerCredentialProviderTools(server: McpServer) {
       try {
         switch (params.action) {
           case "list": {
-            const providers = await client.credentialProviders.list();
-            return jsonResponse(providers);
+            const page = await client.credentialProviders.list({
+              ...(params.limit !== undefined && { limit: params.limit }),
+              ...(params.offset !== undefined && { offset: params.offset }),
+            });
+            return paginatedJsonResponse(page);
           }
           case "get": {
             if (!params.id)

--- a/src/lib/mcp/tools/credentials.ts
+++ b/src/lib/mcp/tools/credentials.ts
@@ -37,7 +37,7 @@ export function registerCredentialTools(server: McpServer) {
         )
         .optional(),
       values: z
-        .record(z.string())
+        .record(z.string(), z.string())
         .describe(
           "(create, update) Field name to value mapping (e.g. username, password). On update, merged with existing values.",
         )

--- a/src/lib/mcp/tools/extensions.ts
+++ b/src/lib/mcp/tools/extensions.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { createKernelClient } from "@/lib/mcp/kernel-client";
 import {
   errorResponse,
-  itemsJsonResponse,
+  paginatedJsonResponse,
   textResponse,
   toolErrorResponse,
 } from "@/lib/mcp/responses";
@@ -40,9 +40,7 @@ export function registerExtensionTools(server: McpServer) {
               ...(params.limit !== undefined && { limit: params.limit }),
               ...(params.offset !== undefined && { offset: params.offset }),
             });
-            return itemsJsonResponse(page.getPaginatedItems(), {
-              has_more: page.has_more,
-              next_offset: page.next_offset,
+            return paginatedJsonResponse(page, {
               emptyText: "No extensions found",
             });
           }

--- a/src/lib/mcp/tools/extensions.ts
+++ b/src/lib/mcp/tools/extensions.ts
@@ -7,6 +7,7 @@ import {
   textResponse,
   toolErrorResponse,
 } from "@/lib/mcp/responses";
+import { paginationParams } from "@/lib/mcp/schemas";
 
 export function registerExtensionTools(server: McpServer) {
   // manage_extensions -- List and delete browser extensions
@@ -19,6 +20,7 @@ export function registerExtensionTools(server: McpServer) {
         .string()
         .describe("(delete) Extension ID or name to delete.")
         .optional(),
+      ...paginationParams,
     },
     {
       title: "Manage Kernel browser extensions",
@@ -34,10 +36,13 @@ export function registerExtensionTools(server: McpServer) {
       try {
         switch (params.action) {
           case "list": {
-            const extensions = await client.extensions.list();
-            return itemsJsonResponse(extensions ?? [], {
-              has_more: false,
-              next_offset: null,
+            const page = await client.extensions.list({
+              ...(params.limit !== undefined && { limit: params.limit }),
+              ...(params.offset !== undefined && { offset: params.offset }),
+            });
+            return itemsJsonResponse(page.getPaginatedItems(), {
+              has_more: page.has_more,
+              next_offset: page.next_offset,
               emptyText: "No extensions found",
             });
           }

--- a/src/lib/mcp/tools/proxies.ts
+++ b/src/lib/mcp/tools/proxies.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 import { createKernelClient } from "@/lib/mcp/kernel-client";
 import {
   errorResponse,
-  itemsJsonResponse,
   jsonResponse,
+  paginatedJsonResponse,
   textResponse,
   toolErrorResponse,
 } from "@/lib/mcp/responses";
@@ -140,9 +140,7 @@ export function registerProxyTools(server: McpServer) {
               ...(params.limit !== undefined && { limit: params.limit }),
               ...(params.offset !== undefined && { offset: params.offset }),
             });
-            return itemsJsonResponse(page.getPaginatedItems(), {
-              has_more: page.has_more,
-              next_offset: page.next_offset,
+            return paginatedJsonResponse(page, {
               emptyText: "No proxies found",
             });
           }

--- a/src/lib/mcp/tools/proxies.ts
+++ b/src/lib/mcp/tools/proxies.ts
@@ -8,6 +8,7 @@ import {
   textResponse,
   toolErrorResponse,
 } from "@/lib/mcp/responses";
+import { paginationParams } from "@/lib/mcp/schemas";
 
 const httpUrlSchema = z
   .string()
@@ -77,6 +78,7 @@ export function registerProxyTools(server: McpServer) {
         .string()
         .describe("(create, custom type) Auth password.")
         .optional(),
+      ...paginationParams,
     },
     {
       title: "Manage Kernel proxy configurations",
@@ -134,10 +136,13 @@ export function registerProxyTools(server: McpServer) {
             return jsonResponse(proxy);
           }
           case "list": {
-            const proxies = await client.proxies.list();
-            return itemsJsonResponse(proxies ?? [], {
-              has_more: false,
-              next_offset: null,
+            const page = await client.proxies.list({
+              ...(params.limit !== undefined && { limit: params.limit }),
+              ...(params.offset !== undefined && { offset: params.offset }),
+            });
+            return itemsJsonResponse(page.getPaginatedItems(), {
+              has_more: page.has_more,
+              next_offset: page.next_offset,
               emptyText: "No proxies found",
             });
           }


### PR DESCRIPTION
## summary

- update `@onkernel/sdk` from `^0.60.0` to `^0.78.0`
- migrate browser pool, extension, proxy, and credential-provider list calls to paginated SDK responses
- expose `limit`/`offset` and return `has_more`/`next_offset` for those list tools
- remove the unsupported browser-pool `save_profile_changes` input
- keep the fixed browser-pools resource exhaustive by iterating all pages

This isolates the SDK migration from feature PRs that need newer SDK endpoints. It supersedes the dependency migration in #117.

## verification

- `bun install --frozen-lockfile`
- `bunx tsc --noEmit`
- Prettier check on changed source and package files

The lockfile's `next` spec normalization (`16.2.6` to `^16.2.6`) matches the existing `package.json`; the resolved Next.js version is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> SDK upgrade plus changed list response shapes may break agents that assumed full arrays or the removed pool field; pagination behavior is a contract change across multiple tools.
> 
> **Overview**
> **Bumps `@onkernel/sdk` from `^0.60.0` to `^0.78.0`** (lockfile only normalizes `next` to `^16.2.6`; resolved Next version unchanged).
> 
> **List operations** on browser pools, extensions, proxies, and credential providers now call the SDK’s paginated `list({ limit, offset })` APIs and return results via `paginatedJsonResponse` with **`has_more` / `next_offset`**. Those tools accept shared **`limit` / `offset`** from `paginationParams`. `paginatedJsonResponse` forwards **`emptyText`** and other options into the uniform `{ items, has_more, next_offset }` JSON shape.
> 
> The **`browser-pools://` resource** still returns a full inventory by **async-iterating** all pages from `browserPools.list()`, while the **`list` tool** stays page-sized.
> 
> **Browser pool create/update** drops the **`save_profile_changes`** MCP input (omitted from `PoolConfigParams`) because the newer SDK/API no longer supports it.
> 
> **`manage_credentials`** tightens the **`values`** schema to `z.record(z.string(), z.string())` for Zod/SDK alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c02b14976c49d9b30c2d3cca95d91cbb35246814. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->