### PR TITLE
Fix broken _snapshotForAI() tip in execute_playwright_code

### DIFF
--- a/src/lib/mcp/tools/playwright.ts
+++ b/src/lib/mcp/tools/playwright.ts
@@ -11,7 +11,7 @@ export function registerPlaywrightTool(server: McpServer) {
       code: z
         .string()
         .describe(
-          'Playwright/TypeScript code with a `page` object in scope. Example: "await page.goto(\\"https://example.com\\"); return await page.title();" Tip: Use `await page._snapshotForAI()` for a comprehensive page state snapshot.',
+          'Playwright/TypeScript code with a `page` object in scope. Example: "await page.goto(\\"https://example.com\\"); return await page.title();" Tip: Use `await page.locator("body").ariaSnapshot()` for a comprehensive accessibility-tree snapshot of the page.',
         ),
       session_id: z
         .string()


### PR DESCRIPTION
## Summary

The `execute_playwright_code` tool description tells users:

> Tip: Use `await page._snapshotForAI()` for a comprehensive page state snapshot.

That method does not exist in the browser runtime — calling it throws `TypeError: page._snapshotForAI is not a function`. The runtime drives the browser through a stealth-patched Playwright engine, which strips the internal `_snapshotForAI()` binding (and `page.accessibility.snapshot()`).

This updates the hint to the supported public API, `page.locator("body").ariaSnapshot()`, which returns the page accessibility tree and works in the current runtime.

## Verification

Ran against a live browser session:
- `page._snapshotForAI()` → `TypeError: page._snapshotForAI is not a function`
- `page.accessibility.snapshot()` → `TypeError` (namespace absent)
- `page.locator("body").ariaSnapshot()` → returns the aria/accessibility tree ✅

Description-only change; no runtime behavior affected.

## Follow-ups (not in this PR)
- The public docs mirror the same tip: `kernel/docs → reference/mcp-server/tools/execute-playwright-code.mdx`
- Several example repos still call `_snapshotForAI()` in their own code (e.g. `kernel-ai-sdk-agent`, `ImmortalBard`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation string change on an MCP tool schema only; no execution or security impact.
> 
> **Overview**
> Updates the **`execute_playwright_code`** MCP tool’s `code` parameter description so the snapshot tip points at **`page.locator("body").ariaSnapshot()`** instead of **`page._snapshotForAI()`**, which is not available in Kernel’s browser runtime.
> 
> This is a **description-only** change; tool execution and Playwright behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c42b42153a7995d24a1f1c09f1b6e9304a865503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->