### PR TITLE
Advertise the Kernel server name on initialize

### DIFF
--- a/src/app/[transport]/route.ts
+++ b/src/app/[transport]/route.ts
@@ -12,6 +12,7 @@ import {
   mintMcpSessionId,
 } from "@/lib/mcp/analytics";
 import { registerMcpCapabilities } from "@/lib/mcp/register";
+import { name, version } from "../../../server.json";
 
 export async function OPTIONS(_req: NextRequest): Promise<Response> {
   return new Response(null, {
@@ -49,10 +50,15 @@ function createAuthErrorResponse(
 }
 
 // Create MCP handler with tools
-const handler = createMcpHandler((server) => {
-  instrumentMcpAnalytics(server);
-  registerMcpCapabilities(server);
-});
+const handler = createMcpHandler(
+  (server) => {
+    instrumentMcpAnalytics(server);
+    registerMcpCapabilities(server);
+  },
+  // Identity returned on initialize. Taken from server.json so the handshake and the
+  // registry entry can't disagree; without it mcp-handler advertises its own default.
+  { serverInfo: { name, version } },
+);
 
 async function handleAuthenticatedRequest(req: NextRequest): Promise<Response> {
   const authHeader = req.headers.get("Authorization");


### PR DESCRIPTION
## Summary

The MCP server was identifying itself to every client as `mcp-typescript server on vercel` — `mcp-handler`'s default `serverInfo`, which we never overrode. `server.json` already declares the server as `com.onkernel/kernel-mcp-server`, so the registry entry and the runtime handshake disagreed.

This passes `serverInfo` through to `createMcpHandler`, sourced from `server.json` so the two can't drift apart again.

Clients now see:

```json
"serverInfo": { "name": "com.onkernel/kernel-mcp-server", "version": "1.0.0" }
```

`serverInfo.name` is the programmatic identifier (per spec, clients prefer an optional `title` for display and fall back to `name`); `mcp-handler`'s `ServerOptions` type only accepts `name` and `version`, so `title` is out of scope here.

## Why it matters beyond cosmetics

- Registry consumers and bundle tooling expect the manifest name to match the `serverInfo.name` returned by `initialize`.
- The name is recorded on captured analytics events, so every event to date is attributed to a generic default rather than to this server.

## Verification

Ran the real route locally and probed `POST /mcp`:

- `initialize` returns `serverInfo: { name: "com.onkernel/kernel-mcp-server", version: "1.0.0" }`.
- With a project token set, the captured `$mcp_initialize` and `$mcp_tools_list` events carry `$mcp_server_name = com.onkernel/kernel-mcp-server` and `$mcp_server_version = 1.0.0`, grouped in one session with client name and version intact.

`tsc --noEmit` and `prettier --check` pass. No behavior change to tools, auth, or transport.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change to MCP initialize `serverInfo`; no auth, tool, or transport behavior changes.
> 
> **Overview**
> **MCP `initialize` now reports the Kernel server identity** instead of `mcp-handler`'s default (`mcp-typescript server on vercel`).
> 
> The route passes **`serverInfo: { name, version }`** into `createMcpHandler`, with **`name` and `version` imported from `server.json`** so the MCP handshake matches the registry manifest and they stay in sync.
> 
> No changes to tools, auth, or transport—only what clients and analytics see for server name/version on initialize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37fc68739c0043c34a83737d7e3b01cb4a67e9d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->