### PR TITLE
Flag failed playwright executions as tool errors

### DIFF
--- a/src/lib/mcp/tools/playwright.ts
+++ b/src/lib/mcp/tools/playwright.ts
@@ -56,6 +56,9 @@ export function registerPlaywrightTool(server: McpServer) {
           ],
         };
       } catch (error) {
+        // The code never ran -- the session was gone, unleased, or the request failed.
+        // Distinct from code that ran and threw, which comes back as a 200 with
+        // success: false so the agent can read the failure and adjust.
         return {
           content: [
             {
@@ -70,6 +73,7 @@ export function registerPlaywrightTool(server: McpServer) {
               ),
             },
           ],
+          isError: true,
         };
       }
     },

--- a/src/lib/mcp/tools/playwright.ts
+++ b/src/lib/mcp/tools/playwright.ts
@@ -11,7 +11,7 @@ export function registerPlaywrightTool(server: McpServer) {
       code: z
         .string()
         .describe(
-          "Playwright/TypeScript code with `page`, `context`, and `browser` objects in scope; the value you `return` is sent back. Example: `await page.goto('https://example.com'); return await page.title();` Return only what you need — prefer a targeted selector (e.g. `await page.locator('h1').innerText()`) or a region-scoped snapshot (e.g. `await page.locator('main').ariaSnapshot()`) rather than dumping the whole page.",
+          'Playwright/TypeScript code with `page`, `context`, and `browser` objects in scope; the value you `return` is sent back. Example: `await page.goto(\'https://example.com\'); return await page.title();` Return only what you need — prefer a targeted selector (e.g. `await page.locator(\'h1\').innerText()`) or a region-scoped snapshot (e.g. `await page.locator(\'main\').ariaSnapshot()`) rather than dumping the whole page.',
         ),
       session_id: z
         .string()

--- a/src/lib/mcp/tools/playwright.ts
+++ b/src/lib/mcp/tools/playwright.ts
@@ -11,7 +11,7 @@ export function registerPlaywrightTool(server: McpServer) {
       code: z
         .string()
         .describe(
-          'Playwright/TypeScript code with `page`, `context`, and `browser` objects in scope; the value you `return` is sent back. Example: `await page.goto(\'https://example.com\'); return await page.title();` Return only what you need — prefer a targeted selector (e.g. `await page.locator(\'h1\').innerText()`) or a region-scoped snapshot (e.g. `await page.locator(\'main\').ariaSnapshot()`) rather than dumping the whole page.',
+          "Playwright/TypeScript code with `page`, `context`, and `browser` objects in scope; the value you `return` is sent back. Example: `await page.goto('https://example.com'); return await page.title();` Return only what you need — prefer a targeted selector (e.g. `await page.locator('h1').innerText()`) or a region-scoped snapshot (e.g. `await page.locator('main').ariaSnapshot()`) rather than dumping the whole page.",
         ),
       session_id: z
         .string()
@@ -56,9 +56,9 @@ export function registerPlaywrightTool(server: McpServer) {
           ],
         };
       } catch (error) {
-        // The code never ran -- the session was gone, unleased, or the request failed.
-        // Distinct from code that ran and threw, which comes back as a 200 with
-        // success: false so the agent can read the failure and adjust.
+        // No normal API response came back -- the session was gone, unleased, the request
+        // was rejected, or it timed out. Distinct from code that ran and threw, which comes
+        // back as a 200 with success: false so the agent can read the failure and adjust.
         return {
           content: [
             {


### PR DESCRIPTION
## Summary

`execute_playwright_code` returned its failure payload without `isError`, so a request that never reached the browser was recorded as a successful tool call. This sets `isError: true` on that path.

The response body is unchanged — same `{ success: false, error }` shape — so anything parsing it keeps working.

## Why

Over a 21-hour window the tool made 3,769 API calls with 83 failures (34 × 400, 48 × 499, 1 × 500), and reported 5. It is ~81% of all MCP tool traffic, so error-rate monitoring for the whole server was effectively blind to its busiest path.

## Scope: only failures where the code never ran

The catch block covers requests that failed outright. The API's 400s on this route are all lifecycle or protocol problems — *missing body*, *session has already been deleted*, *session is not currently leased*, *browser not found* — plus 5xx.

Code that ran and threw inside the browser still comes back as a 200 with `success: false` and is **not** flagged. A selector that didn't match is a normal result an agent should read and adapt to; marking it a tool error would invite retry loops and drown the real signal.

## Verification

Ran the route locally against a failing call and confirmed the captured analytics event flips to `$mcp_is_error = true` (previously `false` for the same failure), with no message, parameters, or response captured.

`tsc --noEmit` passes. Note `prettier --check` already fails on this file on `main`; the pre-existing formatting is left alone rather than reformatted in this diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to MCP tool metadata on an existing error path; response body unchanged and in-browser `success: false` behavior is untouched.
> 
> **Overview**
> **`execute_playwright_code`** now returns **`isError: true`** when the Kernel API call fails in the `catch` path (session missing/unleased, bad request, timeout, etc.), so MCP analytics and error monitoring treat those outcomes as failed tool calls instead of successes.
> 
> The JSON body is unchanged (`{ success: false, error }`). **In-browser** failures that still return HTTP 200 with `success: false` are intentionally **not** flagged—only cases where no normal API response came back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9702e40ba4524d7e9fabeb5810d4ce1af6f8281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->