### PR TITLE
Classify Kernel API failures on tool errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,6 @@ jobs:
 
       - name: Type check
         run: bunx tsc --noEmit
+
+      - name: Test
+        run: bun test

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.11",
+        "@types/bun": "^1.3.14",
         "@types/jszip": "^3.4.1",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -201,6 +202,8 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.11", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.1.11", "@tailwindcss/oxide": "4.1.11", "postcss": "^8.4.41", "tailwindcss": "4.1.11" } }, "sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
 
     "@types/jszip": ["@types/jszip@3.4.1", "", { "dependencies": { "jszip": "*" } }, "sha512-TezXjmf3lj+zQ651r6hPqvSScqBLvyPI9FxdXBqpEwBijNGQ2NXpaFW/7joGzveYkKQUil7iiDHLo6LV71Pc0A=="],
@@ -228,6 +231,8 @@
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "builtin-modules": ["builtin-modules@5.0.0", "", {}, "sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -33,11 +33,11 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.11",
-        "@types/bun": "^1.3.14",
         "@types/jszip": "^3.4.1",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "bun-types": "^1.3.14",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.11",
       },
@@ -201,8 +201,6 @@
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.1.11", "", { "os": "win32", "cpu": "x64" }, "sha512-YfHoggn1j0LK7wR82TOucWc5LDCguHnoS879idHekmmiR7g9HUtMw9MI0NHatS28u/Xlkfi9w5RJWgz2Dl+5Qg=="],
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.11", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.1.11", "@tailwindcss/oxide": "4.1.11", "postcss": "^8.4.41", "tailwindcss": "4.1.11" } }, "sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA=="],
-
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build": "next build",
     "start": "next start -p 3002",
     "lint": "next lint",
+    "test": "bun test",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md}\""
   },
@@ -57,6 +58,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",
+    "@types/bun": "^1.3.14",
     "@types/jszip": "^3.4.1",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/package.json
+++ b/package.json
@@ -58,11 +58,11 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",
-    "@types/bun": "^1.3.14",
     "@types/jszip": "^3.4.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "bun-types": "^1.3.14",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11"
   }

--- a/src/lib/mcp/responses.test.ts
+++ b/src/lib/mcp/responses.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="bun-types" />
+
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";

--- a/src/lib/mcp/responses.test.ts
+++ b/src/lib/mcp/responses.test.ts
@@ -1,0 +1,114 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  APIConnectionError,
+  APIConnectionTimeoutError,
+  APIError,
+  APIUserAbortError,
+} from "@onkernel/sdk";
+import { describe, expect, test } from "bun:test";
+
+import { errorResponse, throwToolError } from "@/lib/mcp/responses";
+
+function apiError(status: number, message: string) {
+  return APIError.generate(status, undefined, message, new Headers());
+}
+
+function caught(error: unknown) {
+  try {
+    throwToolError("manage_browsers", "get", error);
+  } catch (thrown) {
+    return thrown as Error;
+  }
+  throw new Error("throwToolError did not throw");
+}
+
+describe("throwToolError classification", () => {
+  test("names Kernel API failures after their status", () => {
+    expect(caught(apiError(404, "not found")).name).toBe("KernelApiError404");
+    expect(caught(apiError(429, "too many requests")).name).toBe(
+      "KernelApiError429",
+    );
+    expect(caught(apiError(502, "bad gateway")).name).toBe("KernelApiError502");
+  });
+
+  test("names transport failures without relying on class names", () => {
+    // The SDK's error classes are minified in the production bundle, so
+    // constructor.name reads as a mangled identifier there. These come from
+    // instanceof checks instead.
+    expect(caught(new APIConnectionTimeoutError({})).name).toBe(
+      "KernelApiTimeout",
+    );
+    expect(
+      caught(new APIConnectionError({ message: "socket hang up" })).name,
+    ).toBe("KernelApiConnectionError");
+    expect(caught(new APIUserAbortError({})).name).toBe("KernelApiAborted");
+  });
+
+  test("falls back to a generic name for everything else", () => {
+    expect(caught(new Error("boom")).name).toBe("Error");
+    expect(caught(new TypeError("bad arg")).name).toBe("TypeError");
+    expect(caught("plain string").name).toBe("Error");
+  });
+
+  test("keeps the message the tool already produced", () => {
+    expect(caught(apiError(404, "not found")).message).toBe(
+      "Error in manage_browsers (get): 404 not found",
+    );
+    expect(caught("plain string").message).toBe(
+      "Error in manage_browsers (get): plain string",
+    );
+  });
+});
+
+describe("what the client receives", () => {
+  async function callTool(name: string) {
+    const server = new McpServer({ name: "test", version: "0.0.0" });
+
+    server.tool("api_failure", {}, async () => {
+      throwToolError(
+        "manage_browsers",
+        "get",
+        apiError(404, "browser session not found"),
+      );
+    });
+
+    server.tool("input_guard", {}, async () =>
+      errorResponse("Error: session_id is required for get action."),
+    );
+
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+
+    const result = await client.callTool({ name, arguments: {} });
+    await client.close();
+    return result;
+  }
+
+  test("a thrown API failure still arrives as an isError text result", async () => {
+    const result = await callTool("api_failure");
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: "Error in manage_browsers (get): 404 browser session not found",
+      },
+    ]);
+  });
+
+  test("input guards are unchanged", async () => {
+    const result = await callTool("input_guard");
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      { type: "text", text: "Error: session_id is required for get action." },
+    ]);
+  });
+});

--- a/src/lib/mcp/responses.ts
+++ b/src/lib/mcp/responses.ts
@@ -1,4 +1,9 @@
-import { APIError } from "@onkernel/sdk";
+import {
+  APIConnectionError,
+  APIConnectionTimeoutError,
+  APIError,
+  APIUserAbortError,
+} from "@onkernel/sdk";
 
 type PaginatedPage<T> = {
   getPaginatedItems(): T[];
@@ -77,10 +82,18 @@ class ToolCallError extends Error {
 }
 
 function errorName(error: unknown) {
-  if (error instanceof APIError && typeof error.status === "number") {
-    return `KernelApiError${error.status}`;
+  if (error instanceof APIError) {
+    if (typeof error.status === "number") {
+      return `KernelApiError${error.status}`;
+    }
+    // No status means the request never got a response. Classified by instance
+    // rather than class name, which the production bundle minifies.
+    if (error instanceof APIConnectionTimeoutError) return "KernelApiTimeout";
+    if (error instanceof APIConnectionError) return "KernelApiConnectionError";
+    if (error instanceof APIUserAbortError) return "KernelApiAborted";
+    return "KernelApiError";
   }
-  return error instanceof Error ? error.constructor.name : "Error";
+  return error instanceof Error ? error.name : "Error";
 }
 
 /**

--- a/src/lib/mcp/responses.ts
+++ b/src/lib/mcp/responses.ts
@@ -1,3 +1,5 @@
+import { APIError } from "@onkernel/sdk";
+
 type PaginatedPage<T> = {
   getPaginatedItems(): T[];
   has_more?: boolean | null;
@@ -64,12 +66,38 @@ function errorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error);
 }
 
-export function toolErrorResponse(
+// Named after what the API said, so a stale session id (404) is distinguishable from an
+// org hitting its limits (429) or a fault on our side (5xx). Status codes only; the
+// message stays out.
+class ToolCallError extends Error {
+  constructor(name: string, message: string) {
+    super(message);
+    this.name = name;
+  }
+}
+
+function errorName(error: unknown) {
+  if (error instanceof APIError && typeof error.status === "number") {
+    return `KernelApiError${error.status}`;
+  }
+  return error instanceof Error ? error.constructor.name : "Error";
+}
+
+/**
+ * Fails a tool call that a Kernel API request rejected.
+ *
+ * Throws rather than returning an isError result: analytics reads the error category
+ * from a thrown error's name, while a returned result only ever coerces to a generic
+ * "Error". The MCP SDK turns the throw back into the same isError text result the client
+ * saw before, so agents see no difference.
+ */
+export function throwToolError(
   toolName: string,
   action: string,
   error: unknown,
-) {
-  return errorResponse(
+): never {
+  throw new ToolCallError(
+    errorName(error),
     `Error in ${toolName} (${action}): ${errorMessage(error)}`,
   );
 }

--- a/src/lib/mcp/tools/api-keys.ts
+++ b/src/lib/mcp/tools/api-keys.ts
@@ -6,7 +6,7 @@ import {
   jsonResponse,
   paginatedJsonResponse,
   textResponse,
-  toolErrorResponse,
+  throwToolError,
 } from "@/lib/mcp/responses";
 import { paginationParams } from "@/lib/mcp/schemas";
 
@@ -107,7 +107,7 @@ export function registerAPIKeyCapabilities(server: McpServer) {
           }
         }
       } catch (error) {
-        return toolErrorResponse("manage_api_keys", params.action, error);
+        throwToolError("manage_api_keys", params.action, error);
       }
     },
   );

--- a/src/lib/mcp/tools/apps.ts
+++ b/src/lib/mcp/tools/apps.ts
@@ -7,7 +7,7 @@ import {
   jsonResponse,
   paginatedJsonResponse,
   textResponse,
-  toolErrorResponse,
+  throwToolError,
 } from "@/lib/mcp/responses";
 import { paginationParams } from "@/lib/mcp/schemas";
 
@@ -206,7 +206,7 @@ export function registerAppCapabilities(server: McpServer) {
           }
         }
       } catch (error) {
-        return toolErrorResponse("manage_apps", params.action, error);
+        throwToolError("manage_apps", params.action, error);
       }
     },
   );

--- a/src/lib/mcp/tools/auth-connections.ts
+++ b/src/lib/mcp/tools/auth-connections.ts
@@ -6,7 +6,7 @@ import {
   jsonResponse,
   paginatedJsonResponse,
   textResponse,
-  toolErrorResponse,
+  throwToolError,
 } from "@/lib/mcp/responses";
 import { paginationParams } from "@/lib/mcp/schemas";
 
@@ -255,11 +255,7 @@ export function registerAuthConnectionTools(server: McpServer) {
           }
         }
       } catch (error) {
-        return toolErrorResponse(
-          "manage_auth_connections",
-          params.action,
-          error,
-        );
+        throwToolError("manage_auth_connections", params.action, error);
       }
     },
   );

--- a/src/lib/mcp/tools/browser-curl.ts
+++ b/src/lib/mcp/tools/browser-curl.ts
@@ -4,7 +4,7 @@ import { createKernelClient, type KernelClient } from "@/lib/mcp/kernel-client";
 import {
   errorResponse,
   jsonResponse,
-  toolErrorResponse,
+  throwToolError,
 } from "@/lib/mcp/responses";
 
 type BrowserCurlParams = Parameters<KernelClient["browsers"]["curl"]>[1];
@@ -74,7 +74,7 @@ export function registerBrowserCurlTool(server: McpServer) {
         const response = await client.browsers.curl(session_id, curlParams);
         return jsonResponse(response);
       } catch (error) {
-        return toolErrorResponse("browser_curl", "request", error);
+        throwToolError("browser_curl", "request", error);
       }
     },
   );

--- a/src/lib/mcp/tools/browser-pools.ts
+++ b/src/lib/mcp/tools/browser-pools.ts
@@ -12,7 +12,7 @@ import {
   errorResponse,
   paginatedJsonResponse,
   textResponse,
-  toolErrorResponse,
+  throwToolError,
 } from "@/lib/mcp/responses";
 import { paginationParams } from "@/lib/mcp/schemas";
 
@@ -474,7 +474,7 @@ export function registerBrowserPoolCapabilities(server: McpServer) {
           }
         }
       } catch (error) {
-        return toolErrorResponse("manage_browser_pools", params.action, error);
+        throwToolError("manage_browser_pools", params.action, error);
       }
     },
   );

--- a/src/lib/mcp/tools/browsers.ts
+++ b/src/lib/mcp/tools/browsers.ts
@@ -13,7 +13,7 @@ import {
   jsonResponse,
   paginatedJsonResponse,
   textResponse,
-  toolErrorResponse,
+  throwToolError,
 } from "@/lib/mcp/responses";
 import { paginationParams } from "@/lib/mcp/schemas";
 import {
@@ -695,7 +695,7 @@ export function registerBrowserCapabilities(server: McpServer) {
           }
         }
       } catch (error) {
-        return toolErrorResponse("manage_browsers", params.action, error);
+        throwToolError("manage_browsers", params.action, error);
       }
     },
   );

--- a/src/lib/mcp/tools/computer-action.ts
+++ b/src/lib/mcp/tools/computer-action.ts
@@ -5,7 +5,7 @@ import {
   errorResponse,
   jsonResponse,
   textResponse,
-  toolErrorResponse,
+  throwToolError,
 } from "@/lib/mcp/responses";
 
 type ComputerClient = KernelClient["browsers"]["computer"];
@@ -353,7 +353,7 @@ export function registerComputerActionTool(server: McpServer) {
           `Executed ${executedActionCount} action(s) successfully`,
         );
       } catch (error) {
-        return toolErrorResponse("computer_action", "actions", error);
+        throwToolError("computer_action", "actions", error);
       }
     },
   );

--- a/src/lib/mcp/tools/credential-providers.ts
+++ b/src/lib/mcp/tools/credential-providers.ts
@@ -6,7 +6,7 @@ import {
   jsonResponse,
   paginatedJsonResponse,
   textResponse,
-  toolErrorResponse,
+  throwToolError,
 } from "@/lib/mcp/responses";
 import { paginationParams } from "@/lib/mcp/schemas";
 
@@ -164,11 +164,7 @@ export function registerCredentialProviderTools(server: McpServer) {
           }
         }
       } catch (error) {
-        return toolErrorResponse(
-          "manage_credential_providers",
-          params.action,
-          error,
-        );
+        throwToolError("manage_credential_providers", params.action, error);
       }
     },
   );

--- a/src/lib/mcp/tools/credentials.ts
+++ b/src/lib/mcp/tools/credentials.ts
@@ -6,7 +6,7 @@ import {
   jsonResponse,
   paginatedJsonResponse,
   textResponse,
-  toolErrorResponse,
+  throwToolError,
 } from "@/lib/mcp/responses";
 import { paginationParams } from "@/lib/mcp/schemas";
 
@@ -152,7 +152,7 @@ export function registerCredentialTools(server: McpServer) {
           }
         }
       } catch (error) {
-        return toolErrorResponse("manage_credentials", params.action, error);
+        throwToolError("manage_credentials", params.action, error);
       }
     },
   );

--- a/src/lib/mcp/tools/extensions.ts
+++ b/src/lib/mcp/tools/extensions.ts
@@ -5,7 +5,7 @@ import {
   errorResponse,
   paginatedJsonResponse,
   textResponse,
-  toolErrorResponse,
+  throwToolError,
 } from "@/lib/mcp/responses";
 import { paginationParams } from "@/lib/mcp/schemas";
 
@@ -53,7 +53,7 @@ export function registerExtensionTools(server: McpServer) {
           }
         }
       } catch (error) {
-        return toolErrorResponse("manage_extensions", params.action, error);
+        throwToolError("manage_extensions", params.action, error);
       }
     },
   );

--- a/src/lib/mcp/tools/profiles.ts
+++ b/src/lib/mcp/tools/profiles.ts
@@ -8,7 +8,7 @@ import {
   jsonResponse,
   paginatedJsonResponse,
   textResponse,
-  toolErrorResponse,
+  throwToolError,
 } from "@/lib/mcp/responses";
 import { paginationParams } from "@/lib/mcp/schemas";
 
@@ -214,7 +214,7 @@ export function registerProfileCapabilities(server: McpServer) {
           }
         }
       } catch (error) {
-        return toolErrorResponse("manage_profiles", params.action, error);
+        throwToolError("manage_profiles", params.action, error);
       }
     },
   );

--- a/src/lib/mcp/tools/projects.ts
+++ b/src/lib/mcp/tools/projects.ts
@@ -6,7 +6,7 @@ import {
   jsonResponse,
   paginatedJsonResponse,
   textResponse,
-  toolErrorResponse,
+  throwToolError,
 } from "@/lib/mcp/responses";
 import { paginationParams } from "@/lib/mcp/schemas";
 
@@ -175,7 +175,7 @@ export function registerProjectCapabilities(server: McpServer) {
           }
         }
       } catch (error) {
-        return toolErrorResponse("manage_projects", params.action, error);
+        throwToolError("manage_projects", params.action, error);
       }
     },
   );

--- a/src/lib/mcp/tools/proxies.ts
+++ b/src/lib/mcp/tools/proxies.ts
@@ -6,7 +6,7 @@ import {
   jsonResponse,
   paginatedJsonResponse,
   textResponse,
-  toolErrorResponse,
+  throwToolError,
 } from "@/lib/mcp/responses";
 import { paginationParams } from "@/lib/mcp/schemas";
 
@@ -169,7 +169,7 @@ export function registerProxyTools(server: McpServer) {
           }
         }
       } catch (error) {
-        return toolErrorResponse("manage_proxies", params.action, error);
+        throwToolError("manage_proxies", params.action, error);
       }
     },
   );

--- a/src/lib/mcp/tools/replays.ts
+++ b/src/lib/mcp/tools/replays.ts
@@ -6,7 +6,7 @@ import {
   itemsJsonResponse,
   jsonResponse,
   textResponse,
-  toolErrorResponse,
+  throwToolError,
 } from "@/lib/mcp/responses";
 
 export function registerReplayTools(server: McpServer) {
@@ -90,7 +90,7 @@ export function registerReplayTools(server: McpServer) {
           }
         }
       } catch (error) {
-        return toolErrorResponse("manage_replays", params.action, error);
+        throwToolError("manage_replays", params.action, error);
       }
     },
   );


### PR DESCRIPTION
## Summary

Every failed MCP tool call currently records `$mcp_error_type = "Error"`, so a stale session id, an org hitting its concurrency limit, and a fault on our side are indistinguishable in analytics. This names them.

`toolErrorResponse` becomes `throwToolError`, which throws instead of returning an `isError` result. The thrown error's `name` carries the Kernel API status — `KernelApiError404`, `KernelApiError429`, `KernelApiError502` — or a fixed name for transport failures that never got a response (`KernelApiTimeout`, `KernelApiConnectionError`, `KernelApiAborted`).

## Why this works

The analytics SDK reads the error category from a **thrown** error's `name`. A returned `isError` result has no error object, so it coerces from the result text and always lands as a generic `Error`. That's why the existing data has exactly one error type.

Because `throwToolError` is the single funnel for caught API errors, the split falls out with no per-call-site logic:

- `KernelApiError<status>` — the Kernel API rejected the request.
- `Error` — the tool itself rejected the call (missing `session_id`, conflicting arguments, invalid config), which never reaches the API.

## Agents see no change

The MCP SDK converts a thrown error back into the same `isError` text result, and the message string is byte-identical to what the helper produced before. Verified against the real API:

- `manage_browsers` `get` with an unknown session id → `Error in manage_browsers (get): 404 browser session '...' not found`, `isError: true`
- `manage_browsers` `get` with no session id → `Error: session_id is required for get action.`, `isError: true`

## Privacy

Status codes only. No message, parameters, or response are captured — confirmed on the captured events — and no `$exception` events are emitted. `$mcp_error_type` is already on the send allow-list, so nothing new is added to what leaves the server.

## Verification

Ran the route locally against the production API and checked the captured events:

| call | `$mcp_error_type` | duration | message / params / response captured |
| --- | --- | --- | --- |
| API 404 on unknown session | `KernelApiError404` | 1983 ms | none |
| input guard, no `session_id` | `Error` | 2 ms | none |

`tsc --noEmit` and `prettier --check` pass on every touched file.

## Tests

`bun test` (no new runner, bun is already the package manager) covering the classification table, message preservation, and what the client actually receives over an in-memory MCP transport. Wired into CI as a step after the type check -- this is the repo's first test, so the harness comes with it.

Writing the transport case found a bug in the first version of this PR. `errorName` fell back to `error.constructor.name`, and the SDK's error classes are bundled and minified in the production build (`APIConnectionTimeoutError` is emitted as `fN`), so a timeout would have been recorded as `$mcp_error_type = "fN"`. Transport failures are now classified by `instanceof` and the last-resort fallback reads `error.name`, which can never be a mangled identifier. The status path was always safe -- it reads `error.status`, not a class name.

## Follow-up, deliberately not here

The generic `Error` bucket still mixes several kinds of tool-side rejection (missing argument vs conflicting arguments vs invalid config). Naming those too is mechanical but touches ~95 call sites, so it belongs in its own change if the split turns out to be worth it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide change to error handling on every MCP tool path; behavior for agents should be unchanged but analytics and throw semantics differ from returned errors.
> 
> **Overview**
> Replaces **`toolErrorResponse`** with **`throwToolError`**, which **throws** a `ToolCallError` whose **`name`** encodes the failure kind (`KernelApiError404`, `KernelApiError429`, transport types via `instanceof`, etc.) so PostHog **`$mcp_error_type`** is no longer always generic **`Error`**. MCP clients still get the same **`isError`** text—the SDK maps the throw back to the prior shape.
> 
> All Kernel API tool **`catch`** blocks now call **`throwToolError`** instead of returning an error result. Input validation keeps **`errorResponse`**.
> 
> Adds **`bun test`** ( **`responses.test.ts`** ), **`bun-types`**, a **`test`** script, and a **CI** step after typecheck.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d70afc76b1bd9a4c9e7cf1b51802e9ef448a25b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->