### PR TITLE
Capture why agents call each tool

### DIFF
--- a/src/lib/mcp/analytics.ts
+++ b/src/lib/mcp/analytics.ts
@@ -29,8 +29,8 @@ const posthog = projectToken
 // Every property this integration sends. An allow-list rather than a deny-list so a
 // property the pinned SDK doesn't emit today — a renamed payload field, a new one —
 // can't start flowing on an upgrade. Deliberately absent: $mcp_parameters and
-// $mcp_response (call payloads), $mcp_error_message (the text a failed tool returned),
-// and $mcp_intent / $mcp_intent_source (agent-written, and intent capture is off).
+// $mcp_response (call payloads), and $mcp_error_message (the text a failed tool
+// returned).
 const SENT_PROPERTIES = new Set<string>([
   "$groups",
   "$process_person_profile",
@@ -38,6 +38,8 @@ const SENT_PROPERTIES = new Set<string>([
   PostHogMCPAnalyticsProperty.ClientVersion,
   PostHogMCPAnalyticsProperty.DurationMs,
   PostHogMCPAnalyticsProperty.ErrorType,
+  PostHogMCPAnalyticsProperty.Intent,
+  PostHogMCPAnalyticsProperty.IntentSource,
   PostHogMCPAnalyticsProperty.IsError,
   PostHogMCPAnalyticsProperty.ListedToolNames,
   PostHogMCPAnalyticsProperty.ProtocolVersion,
@@ -51,6 +53,18 @@ const SENT_PROPERTIES = new Set<string>([
   PostHogMCPAnalyticsProperty.ToolName,
 ]);
 
+const INTENT_ARGUMENT_DESCRIPTION =
+  "Why this tool is being called and how it fits the user's overall goal, in 15-25 words, " +
+  "third person. Used for product analytics. Never restate argument values, and never " +
+  "include credentials, tokens, URLs, file contents, or personal data. Example: " +
+  '"Inspecting a running browser session to diagnose a checkout automation that stopped ' +
+  'responding partway through the flow."';
+
+// Intent is the only free-form text this captures, and an agent writes it. Long enough for
+// the 15-25 words asked for, short enough that a client ignoring the instruction can't
+// stream a payload or a prompt into an event property.
+const INTENT_MAX_LENGTH = 300;
+
 /**
  * Captures every tool call, tools/list, and initialize handled by the server as a
  * `$mcp_*` PostHog event. No-op when POSTHOG_PROJECT_TOKEN is unset.
@@ -59,9 +73,11 @@ export function instrumentMcpAnalytics(server: McpServer) {
   if (!posthog) return;
 
   instrument(server, posthog, {
-    // Intent capture injects a required `context` argument into every tool schema.
-    // Left off so the public tool surface is unchanged.
-    context: false,
+    // Adds a required `context` argument to every advertised tool, which the agent fills
+    // with why it is making the call. Recorded as $mcp_intent. The description replaces
+    // the SDK default: it repeats per tool in every tools/list response, so it stays
+    // short, and it names the arguments agents must not copy into it.
+    context: { description: INTENT_ARGUMENT_DESCRIPTION },
     // A failed tool call otherwise fans out into a second `$exception` event whose
     // `$exception_list` is built from the text the tool returned.
     enableExceptionAutocapture: false,
@@ -84,6 +100,14 @@ export function instrumentMcpAnalytics(server: McpServer) {
 
       for (const key of Object.keys(properties)) {
         if (!SENT_PROPERTIES.has(key)) delete properties[key];
+      }
+
+      const intent = properties[PostHogMCPAnalyticsProperty.Intent];
+      if (typeof intent === "string" && intent.length > INTENT_MAX_LENGTH) {
+        properties[PostHogMCPAnalyticsProperty.Intent] = intent.slice(
+          0,
+          INTENT_MAX_LENGTH,
+        );
       }
 
       return event;


### PR DESCRIPTION
## Summary

Turns on intent capture, which was deliberately left off when analytics landed. Every advertised tool now carries a required `context` argument the agent fills with why it is making the call, recorded as `$mcp_intent`.

This is the one signal the existing data can't produce. Today we know `manage_browsers` fails 10% of the time; we don't know what agents were trying to do when it did. Same for the two toolsets that are advertised and never called — no way to tell whether agents don't want them or don't understand them.

## What changes on the tool surface

`tools/list` gains one string property per tool, in `required`. Verified against the running route: all 17 tools get it, no tool is skipped, and `manage_browsers` comes back with `required: ["action", "context"]`.

A client that ignores it is not broken. The argument is injected into the advertised schema only, so a call with no `context` validates and runs exactly as before — it just records no intent. Confirmed with the same tool called both ways.

## The description is ours, not the SDK's

The default is ~600 characters and repeats per tool, which is ~9 KB added to every `tools/list` response on a server that answers thousands a day. The replacement is roughly half that, and names the things agents must not copy in:

> Why this tool is being called and how it fits the user's overall goal, in 15-25 words, third person. Used for product analytics. Never restate argument values, and never include credentials, tokens, URLs, file contents, or personal data. Example: "Inspecting a running browser session to diagnose a checkout automation that stopped responding partway through the flow."

## Privacy

Intent is the only free-form text this integration captures, and a model writes it rather than it being user data copied verbatim. Two guards:

- `$mcp_intent` and `$mcp_intent_source` are added to the send allow-list explicitly. Everything else stays excluded — arguments, results, and error text are still dropped.
- Intent is truncated at 300 characters in `beforeSend`. 15-25 words fits comfortably; a client that ignores the instruction can't stream a payload or a prompt into an event property.

## Verification

Ran the route locally against the staging project and checked the captured events:

| call | `$mcp_intent_source` | intent length | params / response / error message captured |
| --- | --- | --- | --- |
| `manage_profiles` with `context` | `context_parameter` | 109 | none |
| `manage_profiles` with no `context` | none | — | none |
| `manage_browsers` with a 2,000-char `context` | `context_parameter` | 300 (truncated) | none |

No `$exception` events, and no property outside the allow-list. `tsc --noEmit` and `prettier --check` pass.

## Note for whoever is watching the rollout

The rollout checks currently treat any `$mcp_intent` as a leak and page RED on it, since capture was off. That threshold needs to flip to expecting intent on tool calls when this deploys.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds agent-written free-form text to analytics and changes every tool schema in `tools/list`; rollout alerts must expect `$mcp_intent` instead of treating it as a leak.
> 
> **Overview**
> **Enables MCP tool-call intent analytics** so product can see *why* agents invoke tools, not only which tools fail or go unused.
> 
> PostHog instrumentation turns on SDK **context** capture with a **custom, shorter** `context` argument description (replaces the default that bloats every `tools/list`). Each advertised tool gains a required **`context`** field in the schema; values flow to **`$mcp_intent`** and **`$mcp_intent_source`** after those properties are added to the send **allow-list**. Calls without `context` still run; they simply omit intent.
> 
> **Privacy guardrails** stay tight: call payloads and error text remain excluded. **`beforeSend`** now **truncates** intent strings to **300** characters so oversized agent text cannot flood event properties.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 866f1b43c1a062b159df9146b863031fa58dbbaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## One discrepancy with PostHog's docs

The docs say the SDK "strips that argument before your handler runs, so your tool implementation never sees it." In `0.10.1` it doesn't — `context` is excluded from the captured parameters, but it's still on the request handed to the tool. Our handlers are unaffected because every tool parses arguments through a plain `z.object`, which drops unknown keys, and no tool forwards raw arguments to the Kernel API. Worth knowing before anyone adds a `.passthrough()` schema or a tool that spreads its arguments into a request.
