### PR TITLE
Split screenshot into its own read-only tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,9 +278,10 @@ Self-hosted deployments can hide sensitive tool families by setting `KERNEL_MCP_
 
 ### Standalone tools
 
-- `computer_action` - Mouse, keyboard, clipboard, and screenshot controls for browser sessions (click, type, press_key, scroll, move, get_position, read_clipboard, write_clipboard, screenshot).
+- `execute_playwright_code` - Execute Playwright/TypeScript code against an existing browser session. The primary way to drive a browser. Does not create or delete browsers - use `manage_browsers` for session lifecycle.
+- `screenshot` - Capture a PNG of what a browser session currently displays, optionally cropped to a region. Read-only.
+- `computer_action` - Mouse, keyboard, and clipboard input at screen coordinates (click, type, press_key, scroll, move, drag, get_position, read_clipboard, write_clipboard). Fallback for surfaces Playwright selectors can't reach, such as canvas apps and embedded PDFs; it depends on the model being able to locate targets in a screenshot, so prefer `execute_playwright_code`.
 - `browser_curl` - Send HTTP requests through an existing browser session's Chrome network stack.
-- `execute_playwright_code` - Execute Playwright/TypeScript code against an existing browser session. Does not create or delete browsers - use `manage_browsers` for session lifecycle.
 - `exec_command` - Run shell commands inside a browser VM. Returns decoded stdout/stderr.
 - `search_docs` - Search Kernel platform documentation and guides.
 

--- a/src/lib/mcp/prompts.ts
+++ b/src/lib/mcp/prompts.ts
@@ -129,7 +129,7 @@ kernel browsers process --help
 kernel browsers playwright --help
 \`\`\`
 
-**MCP Exceptions:** The \`computer_action\` MCP tool with action "screenshot" is useful since it returns images directly to the agent, and \`manage_browsers\` with action "get_telemetry" reads structured telemetry events (see below).
+**MCP Exceptions:** The \`screenshot\` MCP tool is useful since it returns images directly to the agent, and \`manage_browsers\` with action "get_telemetry" reads structured telemetry events (see below).
 
 ---
 
@@ -152,7 +152,7 @@ ${TELEMETRY_EVENT_CATALOG}
 kernel browsers get ${session_id}
 \`\`\`
 
-### Take a screenshot (or use MCP computer_action with action "screenshot")
+### Take a screenshot (or use the MCP screenshot tool)
 \`\`\`bash
 kernel browsers screenshot ${session_id}
 \`\`\`

--- a/src/lib/mcp/register.ts
+++ b/src/lib/mcp/register.ts
@@ -16,6 +16,7 @@ import { registerProfileCapabilities } from "@/lib/mcp/tools/profiles";
 import { registerProjectCapabilities } from "@/lib/mcp/tools/projects";
 import { registerProxyTools } from "@/lib/mcp/tools/proxies";
 import { registerReplayTools } from "@/lib/mcp/tools/replays";
+import { registerScreenshotTool } from "@/lib/mcp/tools/screenshot";
 import { registerShellTool } from "@/lib/mcp/tools/shell";
 
 type RegisterMcpToolset = (server: McpServer) => void;
@@ -31,6 +32,7 @@ const mcpToolRegistrations = [
   ["proxies", registerProxyTools],
   ["extensions", registerExtensionTools],
   ["apps", registerAppCapabilities],
+  ["screenshot", registerScreenshotTool],
   ["computer", registerComputerActionTool],
   ["shell", registerShellTool],
   ["playwright", registerPlaywrightTool],

--- a/src/lib/mcp/tools/browser-pools.ts
+++ b/src/lib/mcp/tools/browser-pools.ts
@@ -451,7 +451,7 @@ export function registerBrowserPoolCapabilities(server: McpServer) {
             return jsonResponse({
               browser: summarizeAcquiredBrowser(browser),
               next_actions: [
-                `Use computer_action with session_id "${browser.session_id}" to control this browser.`,
+                `Use execute_playwright_code with session_id "${browser.session_id}" to drive this browser, and screenshot to see what it currently shows.`,
                 `When finished, use manage_browser_pools with action "release", id_or_name "${poolId}", and session_id "${browser.session_id}".`,
                 `Use manage_browsers with action "get" and session_id "${browser.session_id}" for full browser details.`,
               ],

--- a/src/lib/mcp/tools/browsers.ts
+++ b/src/lib/mcp/tools/browsers.ts
@@ -266,7 +266,7 @@ async function readBrowserTelemetry(
 
 function browserSessionNextActions(sessionId: string) {
   return [
-    `Use computer_action with session_id "${sessionId}" to inspect or control the browser.`,
+    `Use execute_playwright_code with session_id "${sessionId}" to drive the browser, and screenshot to see what it currently shows.`,
     `Use manage_browsers with action "get" and session_id "${sessionId}" for full browser details.`,
     `Use manage_browsers with action "delete" and session_id "${sessionId}" when the session is no longer needed.`,
   ];

--- a/src/lib/mcp/tools/computer-action.ts
+++ b/src/lib/mcp/tools/computer-action.ts
@@ -26,7 +26,6 @@ const computerActionSchema = z.object({
       "sleep",
       "write_clipboard",
       "read_clipboard",
-      "screenshot",
       "get_mouse_position",
     ])
     .describe("Action type."),
@@ -107,26 +106,11 @@ const computerActionSchema = z.object({
     })
     .describe("Params for write_clipboard action.")
     .optional(),
-  screenshot: z
-    .object({
-      region: z
-        .object({
-          x: z.number(),
-          y: z.number(),
-          width: z.number().int().min(1),
-          height: z.number().int().min(1),
-        })
-        .optional(),
-    })
-    .describe(
-      "Params for screenshot action. Omit or pass {} for full-page screenshot.",
-    )
-    .optional(),
 });
 
 type ComputerActionParams = z.infer<typeof computerActionSchema>;
 type TerminalAction = ComputerActionParams & {
-  type: "screenshot" | "get_mouse_position" | "read_clipboard";
+  type: "get_mouse_position" | "read_clipboard";
 };
 type WriteClipboardAction = ComputerActionParams & { type: "write_clipboard" };
 type PrefixExecutionResult =
@@ -137,9 +121,7 @@ function isTerminalAction(
   action: ComputerActionParams | undefined,
 ): action is TerminalAction {
   return (
-    action?.type === "screenshot" ||
-    action?.type === "get_mouse_position" ||
-    action?.type === "read_clipboard"
+    action?.type === "get_mouse_position" || action?.type === "read_clipboard"
   );
 }
 
@@ -250,7 +232,7 @@ export function registerComputerActionTool(server: McpServer) {
   // computer_action -- Execute one or more computer actions on a browser session
   server.tool(
     "computer_action",
-    "Execute computer actions on a browser session. Pass a single action for simple operations (e.g. one click or one screenshot), or pass multiple actions to batch them into a single request for lower latency (e.g. click, type, press_key in one call). Use sleep actions between steps when the page needs time to react (e.g. after a click that triggers navigation or animation). IMPORTANT: Always include a screenshot as the last action so you can see the result of your actions. Action types: click_mouse, move_mouse, type_text, press_key, scroll, drag_mouse, set_cursor, sleep, write_clipboard, read_clipboard, screenshot, get_mouse_position. screenshot, read_clipboard, and get_mouse_position return data, so they must be the last action if included.",
+    "Drive a browser session with raw mouse and keyboard input at screen coordinates. Prefer execute_playwright_code for anything a selector can reach -- it is faster, deterministic, and does not depend on the model's ability to locate targets in an image. Reach for this tool only when there is no selector to target: canvas apps, embedded PDFs, native dialogs, drag interactions. Coordinates come from a screenshot tool call, and screen coordinates are only as accurate as the model's pixel grounding, so verify with screenshot after acting. Pass a single action, or several to batch them into one request for lower latency (e.g. click, type, press_key). Use sleep actions between steps when the page needs time to react. Action types: click_mouse, move_mouse, type_text, press_key, scroll, drag_mouse, set_cursor, sleep, write_clipboard, read_clipboard, get_mouse_position. read_clipboard and get_mouse_position return data, so they must be the last action if included.",
     {
       session_id: z.string().describe("Browser session ID."),
       actions: z
@@ -261,7 +243,7 @@ export function registerComputerActionTool(server: McpServer) {
         ),
     },
     {
-      title: "Control browser (mouse, keyboard, screenshot)",
+      title: "Control browser (mouse, keyboard)",
       readOnlyHint: false,
       destructiveHint: true,
       idempotentHint: false,
@@ -287,45 +269,6 @@ export function registerComputerActionTool(server: McpServer) {
         if (!prefixResult.ok) return errorResponse(prefixResult.error);
 
         const { executedActionCount } = prefixResult;
-
-        if (terminalAction?.type === "screenshot") {
-          const screenshotParams = terminalAction.screenshot;
-          const screenshotOpts = screenshotParams?.region
-            ? { region: screenshotParams.region }
-            : undefined;
-          const [screenshotResponse, browserInfo] = await Promise.all([
-            client.browsers.computer.captureScreenshot(
-              session_id,
-              screenshotOpts,
-            ),
-            client.browsers.retrieve(session_id),
-          ]);
-          const blob = await screenshotResponse.blob();
-          const buffer = Buffer.from(await blob.arrayBuffer());
-          const viewport = browserInfo.viewport;
-          const content: Array<
-            | { type: "text"; text: string }
-            | { type: "image"; data: string; mimeType: string }
-          > = [];
-          if (executedActionCount > 0) {
-            content.push({
-              type: "text",
-              text: `Executed ${executedActionCount} action(s), then captured screenshot.`,
-            });
-          }
-          content.push({
-            type: "text",
-            text: viewport
-              ? `Viewport: ${viewport.width}x${viewport.height}. Use these dimensions as the coordinate space for click, scroll, and move actions.`
-              : "Could not determine viewport dimensions. Use manage_browsers with action 'get' to check the browser's viewport.",
-          });
-          content.push({
-            type: "image",
-            data: buffer.toString("base64"),
-            mimeType: "image/png",
-          });
-          return { content };
-        }
 
         if (terminalAction?.type === "get_mouse_position") {
           const position =

--- a/src/lib/mcp/tools/playwright.ts
+++ b/src/lib/mcp/tools/playwright.ts
@@ -6,7 +6,7 @@ export function registerPlaywrightTool(server: McpServer) {
   // execute_playwright_code -- Run Playwright/TypeScript code against a browser
   server.tool(
     "execute_playwright_code",
-    "Execute Playwright/TypeScript automation code against an existing Kernel browser session. Does not create or delete browsers -- use manage_browsers to manage session lifecycle.",
+    "Execute Playwright/TypeScript automation code against an existing Kernel browser session. This is the primary way to drive a browser: navigation, clicks, form fills, and extraction should all go through here rather than raw coordinate input, and `await page.locator('main').ariaSnapshot()` gives you the accessibility tree to locate elements without needing a screenshot. Does not create or delete browsers -- use manage_browsers to manage session lifecycle.",
     {
       code: z
         .string()

--- a/src/lib/mcp/tools/screenshot.ts
+++ b/src/lib/mcp/tools/screenshot.ts
@@ -38,7 +38,10 @@ export function registerScreenshotTool(server: McpServer) {
     "screenshot",
     "Capture a PNG screenshot of what a browser session currently displays. Read-only: it observes the session without changing it. Use it to see page state, confirm what an automation did, or diagnose a stuck flow. To act on the page, prefer execute_playwright_code.",
     {
-      session_id: z.string().describe("Browser session ID."),
+      session_id: z
+        .string()
+        .min(1, "session_id is required")
+        .describe("Browser session ID."),
       region: regionSchema
         .describe(
           "Crop to this screen region. Omit to capture the full screen.",

--- a/src/lib/mcp/tools/screenshot.ts
+++ b/src/lib/mcp/tools/screenshot.ts
@@ -1,0 +1,86 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { createKernelClient } from "@/lib/mcp/kernel-client";
+import { toolErrorResponse } from "@/lib/mcp/responses";
+
+const regionSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  width: z.number().int().min(1),
+  height: z.number().int().min(1),
+});
+
+type Region = z.infer<typeof regionSchema>;
+
+async function coordinateSpaceText(
+  client: ReturnType<typeof createKernelClient>,
+  sessionId: string,
+  region: Region | undefined,
+) {
+  if (region) {
+    // The image is cropped, so its top-left is the region origin, not the screen
+    // origin. Computer actions take screen coordinates, so spell out the offset
+    // rather than leaving the model to guess which space it's looking at.
+    return `Cropped region ${region.width}x${region.height} at screen offset (${region.x}, ${region.y}). Image coordinates start at the crop, so add the offset to get screen coordinates: screen_x = ${region.x} + image_x, screen_y = ${region.y} + image_y.`;
+  }
+
+  const { viewport } = await client.browsers.retrieve(sessionId);
+  if (!viewport) {
+    return "Could not determine viewport dimensions. Use manage_browsers with action 'get' to check the browser's viewport.";
+  }
+
+  return `Full screen ${viewport.width}x${viewport.height}. Image coordinates are screen coordinates.`;
+}
+
+export function registerScreenshotTool(server: McpServer) {
+  // screenshot -- Capture what a browser session currently shows
+  server.tool(
+    "screenshot",
+    "Capture a PNG screenshot of what a browser session currently displays. Read-only: it observes the session without changing it. Use it to see page state, confirm what an automation did, or diagnose a stuck flow. To act on the page, prefer execute_playwright_code.",
+    {
+      session_id: z.string().describe("Browser session ID."),
+      region: regionSchema
+        .describe(
+          "Crop to this screen region. Omit to capture the full screen.",
+        )
+        .optional(),
+    },
+    {
+      title: "Screenshot browser session",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    async ({ session_id, region }, extra) => {
+      if (!extra.authInfo) throw new Error("Authentication required");
+      const client = createKernelClient(extra.authInfo.token);
+
+      try {
+        const [screenshotResponse, spaceText] = await Promise.all([
+          client.browsers.computer.captureScreenshot(
+            session_id,
+            region ? { region } : undefined,
+          ),
+          coordinateSpaceText(client, session_id, region),
+        ]);
+
+        const blob = await screenshotResponse.blob();
+        const buffer = Buffer.from(await blob.arrayBuffer());
+
+        return {
+          content: [
+            { type: "text" as const, text: spaceText },
+            {
+              type: "image" as const,
+              data: buffer.toString("base64"),
+              mimeType: "image/png",
+            },
+          ],
+        };
+      } catch (error) {
+        return toolErrorResponse("screenshot", "capture", error);
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary

`screenshot` was a terminal action inside `computer_action`. That bundled the one browser capability every multimodal model can use with the one that only works on models with pixel grounding, and it put a read-only capture behind a tool marked `destructiveHint: true` — so clients with per-tool approval prompt on taking a screenshot.

This splits `screenshot` out as a standalone tool and repositions the remaining tools:

- **`screenshot`** — new, read-only (`readOnlyHint: true`, `idempotentHint: true`), optional region crop. Registered as its own toolset so it can be enabled/disabled independently of `computer`.
- **`execute_playwright_code`** — description now states it's the primary way to drive a browser, and points at `ariaSnapshot()` for locating elements without an image.
- **`computer_action`** — no longer handles screenshots. Description reframes it as the fallback for surfaces a selector can't reach (canvas, embedded PDFs, native dialogs, drag), and notes that coordinate accuracy depends on the calling model's grounding.
- `next_actions` hints from `manage_browsers` and `manage_browser_pools` now suggest `execute_playwright_code` + `screenshot` instead of `computer_action`.

## Bug fixed along the way

Region screenshots returned a cropped image but reported `Viewport: WxH. Use these dimensions as the coordinate space`. The image origin is the crop origin, not the screen origin, so a caller converting image coordinates to screen coordinates for a subsequent click had no way to know it needed to add `region.x/y`. The new tool reports the crop offset and the conversion explicitly.

Also drops a redundant `browsers.retrieve` call — viewport dimensions are only needed for the uncropped case.

## Breaking change

`computer_action` no longer accepts `screenshot` as an action type. Callers batching `click, ..., screenshot` in one request now need two calls. That trade is deliberate: the batching win applies to the flow we're steering away from, and keeping a duplicate screenshot path in both tools would leave the destructive-hint problem half-fixed. Clients re-read the tool list on connect, so this lands on reconnect.

## Not included

No screenshot downscaling. Pixel-grounding accuracy degrades above roughly 1024px wide, and the usual fix is to downscale server-side and rescale returned coordinates back up. That changes coordinate semantics for `computer_action` and is worth doing separately if we keep investing in the coordinate path.

## Testing

`tsc --noEmit` clean, `prettier --check` clean on changed files, `next build` compiles (full build needs Clerk/CLI env vars this checkout doesn't have). Verified tool registration by instantiating the server and listing tools: `screenshot` registers, `computer_action` no longer advertises a screenshot action, and `KERNEL_MCP_DISABLED_TOOLSETS=screenshot,computer` removes both. The repo has no test suite, so there are no automated tests to add or run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking MCP contract: `computer_action` no longer supports `screenshot`, so existing clients must migrate; behavior change is limited to tool surface and agent guidance, not auth or data paths.
> 
> **Overview**
> **Screenshot** moves out of `computer_action` into a dedicated **`screenshot`** MCP tool (`readOnlyHint: true`, optional region crop, its own `screenshot` toolset). **`computer_action`** no longer accepts a `screenshot` action type—callers that batched clicks plus screenshot need separate tool calls.
> 
> Tool guidance is updated so **`execute_playwright_code`** is described as the primary browser driver (including `ariaSnapshot()` for element discovery), **`computer_action`** is framed as a coordinate fallback for non-selector surfaces, and **`manage_browsers` / `manage_browser_pools`** `next_actions` point to Playwright + `screenshot` instead of `computer_action`. README and the debug prompt reference the new tool.
> 
> **Region screenshots** now explain crop offset vs screen coordinates (fixing misleading full-viewport wording on cropped images); full-screen captures still report viewport size. Screenshot handling is removed from `computer-action.ts` and implemented in `src/lib/mcp/tools/screenshot.ts`, registered in `register.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d5645835fbe2a00dd6da0f4eaafabd03278d4e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->