### PR TITLE
Report capability gaps agents hit, on our own wording

### DIFF
--- a/src/lib/mcp/analytics.ts
+++ b/src/lib/mcp/analytics.ts
@@ -67,6 +67,25 @@ const INTENT_ARGUMENT_DESCRIPTION =
 // stream a payload or a prompt into an event property.
 const INTENT_MAX_LENGTH = 300;
 
+// The intent descriptions ask agents to leave specifics out, and the agent writing the string
+// is the only thing holding them to it. These cover the shapes that are unambiguous when one
+// does slip through. They are not a substitute for the instruction: no pattern can tell that a
+// plain noun is a customer's name, so an intent still has to be treated as agent-written prose.
+const INTENT_REDACTIONS: readonly [RegExp, string][] = [
+  [/[^\s@]+@[^\s@]+\.[^\s@]+/g, "[email]"],
+  [/[a-z][a-z0-9+.-]*:\/\/\S+/gi, "[url]"],
+  [/\b[A-Za-z0-9_-]{32,}\b/g, "[token]"],
+];
+
+function sanitizeIntent(intent: string) {
+  const redacted = INTENT_REDACTIONS.reduce(
+    (text, [pattern, replacement]) => text.replace(pattern, replacement),
+    intent.trim(),
+  );
+
+  return redacted.slice(0, INTENT_MAX_LENGTH);
+}
+
 // Must stay the SDK's default name: reportMissing advertises a tool under this name and
 // dispatches calls to it as capability reports, and the name is what ties the two together.
 const MISSING_CAPABILITY_TOOL_NAME = "get_more_tools";
@@ -150,12 +169,25 @@ export function instrumentMcpAnalytics(server: McpServer) {
         if (!SENT_PROPERTIES.has(key)) delete properties[key];
       }
 
+      // Only a string is an intent. Anything else is a client sending an object or an array
+      // through the argument, which would land in PostHog as a serialized payload.
       const intent = properties[PostHogMCPAnalyticsProperty.Intent];
-      if (typeof intent === "string" && intent.length > INTENT_MAX_LENGTH) {
-        properties[PostHogMCPAnalyticsProperty.Intent] = intent.slice(
-          0,
-          INTENT_MAX_LENGTH,
-        );
+      const sanitized =
+        typeof intent === "string" ? sanitizeIntent(intent) : "";
+      if (sanitized) {
+        properties[PostHogMCPAnalyticsProperty.Intent] = sanitized;
+      } else {
+        delete properties[PostHogMCPAnalyticsProperty.Intent];
+      }
+
+      // The SDK answers a get_more_tools call before the registered schema validates it, so a
+      // report can arrive with no usable context: missing, blank, or not a string. The reported
+      // gap is the entire event, so drop the ones that don't carry one rather than count them.
+      if (
+        event.event === PostHogMCPAnalyticsEvent.MissingCapability &&
+        !sanitized
+      ) {
+        return null;
       }
 
       return event;

--- a/src/lib/mcp/analytics.ts
+++ b/src/lib/mcp/analytics.ts
@@ -1,5 +1,6 @@
 import {
   encodeSessionId,
+  getMoreToolsResult,
   instrument,
   MCP_SESSION_HEADER,
   newSessionId,
@@ -8,6 +9,7 @@ import {
 } from "@posthog/mcp";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { PostHog } from "posthog-node";
+import { z } from "zod";
 
 const projectToken = process.env.POSTHOG_PROJECT_TOKEN;
 
@@ -65,14 +67,60 @@ const INTENT_ARGUMENT_DESCRIPTION =
 // stream a payload or a prompt into an event property.
 const INTENT_MAX_LENGTH = 300;
 
+// Must stay the SDK's default name: reportMissing advertises a tool under this name and
+// dispatches calls to it as capability reports, and the name is what ties the two together.
+const MISSING_CAPABILITY_TOOL_NAME = "get_more_tools";
+
+const MISSING_CAPABILITY_CONTEXT_DESCRIPTION =
+  "The capability that is missing and what the user was trying to do, in 15-25 words, third " +
+  "person. Used for product analytics. Name the capability, not the specifics: never include " +
+  "credentials, tokens, URLs, domain or account names, file contents, or personal data. " +
+  'Example: "Wanted to run one automation across several sessions at once; no tool exposes ' +
+  'fan-out over a pool."';
+
+/**
+ * Advertises `get_more_tools`, which agents call when no tool covers what they were asked
+ * to do. Registered here rather than left to `reportMissing` alone, which injects its own
+ * descriptor only when no tool of this name exists: the SDK asks for "a description of
+ * your goal" and skips the `context` description configured below, and this is the one
+ * intent field describing the user's original ask, so it's the likeliest to carry a target
+ * site or an account. The tool description itself is the SDK's — it's what gets an agent to
+ * report a gap instead of giving up.
+ *
+ * The callback is the fallback path. `instrument` answers a call to this tool itself, with
+ * this same result, and records `$mcp_missing_capability` instead of a tool call.
+ */
+function registerMissingCapabilityTool(server: McpServer) {
+  server.tool(
+    MISSING_CAPABILITY_TOOL_NAME,
+    "Check for additional tools whenever your task might benefit from specialized capabilities - even if existing tools could work as a fallback.",
+    {
+      context: z.string().describe(MISSING_CAPABILITY_CONTEXT_DESCRIPTION),
+    },
+    {
+      title: "Get more tools",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    async () => getMoreToolsResult(),
+  );
+}
+
 /**
  * Captures every tool call, tools/list, and initialize handled by the server as a
- * `$mcp_*` PostHog event. No-op when POSTHOG_PROJECT_TOKEN is unset.
+ * `$mcp_*` PostHog event, and advertises the tool agents use to report a capability the
+ * server doesn't have. No-op when POSTHOG_PROJECT_TOKEN is unset.
  */
 export function instrumentMcpAnalytics(server: McpServer) {
   if (!posthog) return;
 
   instrument(server, posthog, {
+    // Records a `$mcp_missing_capability` event, carrying the reported gap as $mcp_intent,
+    // when an agent calls the tool registered by registerMissingCapabilityTool.
+    reportMissing: true,
+    missingCapabilityToolName: MISSING_CAPABILITY_TOOL_NAME,
     // Adds a required `context` argument to every advertised tool, which the agent fills
     // with why it is making the call. Recorded as $mcp_intent. The description replaces
     // the SDK default: it repeats per tool in every tools/list response, so it stays
@@ -113,6 +161,8 @@ export function instrumentMcpAnalytics(server: McpServer) {
       return event;
     },
   });
+
+  registerMissingCapabilityTool(server);
 }
 
 type InitializeRequestBody = {

--- a/src/lib/mcp/analytics.ts
+++ b/src/lib/mcp/analytics.ts
@@ -71,10 +71,22 @@ const INTENT_MAX_LENGTH = 300;
 // is the only thing holding them to it. These cover the shapes that are unambiguous when one
 // does slip through. They are not a substitute for the instruction: no pattern can tell that a
 // plain noun is a customer's name, so an intent still has to be treated as agent-written prose.
+//
+// A capability gap is often named as a long snake_case or kebab-case identifier, and that name
+// is the whole point of the report, so length alone can't stand in for a credential. What marks
+// one is either a vendor prefix (Kernel API keys are sk_*) or an unbroken high-entropy run:
+// mixed case with a digit, or hex. Separator-joined lowercase names match none of those.
 const INTENT_REDACTIONS: readonly [RegExp, string][] = [
   [/[^\s@]+@[^\s@]+\.[^\s@]+/g, "[email]"],
   [/[a-z][a-z0-9+.-]*:\/\/\S+/gi, "[url]"],
-  [/\b[A-Za-z0-9_-]{32,}\b/g, "[token]"],
+  [
+    /\b(?=[A-Za-z0-9]*\d)(?=[A-Za-z0-9]*[a-z])(?=[A-Za-z0-9]*[A-Z])[A-Za-z0-9]{20,}\b/g,
+    "[token]",
+  ],
+  [
+    /\b(?:[0-9a-f]{32,}|(?:sk|pk|rk|whsec|ghp|glpat|github_pat|xox[abprs])[_-][A-Za-z0-9_-]{8,})\b/gi,
+    "[token]",
+  ],
 ];
 
 function sanitizeIntent(intent: string) {


### PR DESCRIPTION
## Summary

Turns on PostHog's missing-capability signal: agents that can't find a tool for what they were asked to do now call `get_more_tools`, which records a `$mcp_missing_capability` event carrying a short description of the gap. Today an agent in that position either gives up silently or invents a tool name, and we see nothing.

## What changed

`src/lib/mcp/analytics.ts` only:

- `reportMissing: true` on the `instrument()` call, plus an explicit `missingCapabilityToolName` so the advertised name and the detected name come from one constant.
- We register the `get_more_tools` tool ourselves instead of letting `reportMissing` inject its descriptor (it only injects when no tool of that name exists). The reason is the `context` argument: the SDK's own descriptor asks for "a description of your goal and what kind of tool would help", and the SDK deliberately skips the hardened `context` description this server configures for every other tool. That field is the one intent value describing the user's *original ask*, so it's the likeliest to name a target site or an account — exactly what the rest of this integration is written to avoid capturing. Our version asks for the capability, not the specifics, and names what must never go in it.
- The tool description itself is kept as the SDK's wording, since that's the text that gets an agent to report a gap rather than give up. The callback returns the SDK's canned acknowledgement, and only runs if `instrument()` ever stops answering the call itself.

No new env var, no dependency change, and no allow-list change: `$mcp_intent` was already permitted, so the new event inherits the existing `beforeSend` — arguments are dropped and the intent is truncated at 300 chars.

## Verification

No test harness in this repo, so this was checked by hand against `bun run dev` with `POSTHOG_HOST` pointed at a local sink that decodes the capture payloads:

- `tools/list` returns exactly one `get_more_tools`, carrying our `context` description; every other tool keeps the existing per-call intent description.
- Calling it returns the acknowledgement and emits `$mcp_missing_capability` (not `$mcp_tool_call`), with `$mcp_intent`, `$mcp_intent_source: context_parameter`, and `$mcp_resource_name: get_more_tools`.
- An extra unexpected argument alongside `context` does not appear in the event — no `$mcp_parameters` survives `beforeSend`.
- A 500-char context is captured truncated to 300. A call with no `context` records an empty intent rather than erroring.

## Note

The tool is only advertised when `POSTHOG_PROJECT_TOKEN` is set, so a deployment without analytics doesn't get a tool that reports nowhere. It isn't wired into `KERNEL_MCP_DISABLED_TOOLSETS`, since it belongs to the analytics integration rather than a Kernel toolset.

The signal is only worth the tool slot if someone triages it — expect some reports where a tool does exist but was named or described badly, which is useful input of a different kind.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes in one file; no auth or data-path changes, and capability reporting is gated on PostHog being configured.
> 
> **Overview**
> Enables PostHog **missing-capability** tracking so agents can report tool gaps via **`get_more_tools`**, emitting **`$mcp_missing_capability`** with **`$mcp_intent`** instead of failing silently.
> 
> In **`instrumentMcpAnalytics`**, **`reportMissing: true`** and a shared **`missingCapabilityToolName`** tie into a **custom-registered** `get_more_tools` tool (SDK description kept; **`context`** uses hardened copy that avoids sites/accounts). **`beforeSend`** now runs **`sanitizeIntent`** (email/URL/token redaction plus 300-char cap), drops non-string intents, and **suppresses** missing-capability events with no usable context. The tool is only registered when **`POSTHOG_PROJECT_TOKEN`** is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbdf3db19d10f5d64967115cdc0852d112ff105d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->