### PR TITLE
Report exec_command and search_docs failures as failures

### DIFF
--- a/src/lib/mcp/tools/docs.test.ts
+++ b/src/lib/mcp/tools/docs.test.ts
@@ -1,0 +1,51 @@
+/// <reference types="bun-types" />
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, beforeEach, expect, test } from "bun:test";
+
+import { registerDocsTools } from "@/lib/mcp/tools/docs";
+
+const configured = {
+  token: process.env.MINTLIFY_ASSISTANT_API_TOKEN,
+  domain: process.env.MINTLIFY_DOMAIN,
+};
+
+beforeEach(() => {
+  delete process.env.MINTLIFY_ASSISTANT_API_TOKEN;
+  delete process.env.MINTLIFY_DOMAIN;
+});
+
+afterEach(() => {
+  if (configured.token)
+    process.env.MINTLIFY_ASSISTANT_API_TOKEN = configured.token;
+  if (configured.domain) process.env.MINTLIFY_DOMAIN = configured.domain;
+});
+
+test("search_docs reports missing configuration as a failure", async () => {
+  const server = new McpServer({ name: "test", version: "0.0.0" });
+  registerDocsTools(server);
+
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+
+  const result = await client.callTool({
+    name: "search_docs",
+    arguments: { query: "how to deploy an app" },
+  });
+  await client.close();
+
+  expect(result.isError).toBe(true);
+  expect(result.content).toEqual([
+    {
+      type: "text",
+      text: "Error: Documentation search is not configured (missing MINTLIFY_ASSISTANT_API_TOKEN or MINTLIFY_DOMAIN).",
+    },
+  ]);
+});

--- a/src/lib/mcp/tools/docs.ts
+++ b/src/lib/mcp/tools/docs.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { errorResponse } from "@/lib/mcp/responses";
 
 interface MintlifySearchResult {
   content: string;
@@ -31,14 +32,9 @@ export function registerDocsTools(server: McpServer) {
         !process.env.MINTLIFY_ASSISTANT_API_TOKEN ||
         !process.env.MINTLIFY_DOMAIN
       ) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: "Error: Documentation search is not configured (missing MINTLIFY_ASSISTANT_API_TOKEN or MINTLIFY_DOMAIN).",
-            },
-          ],
-        };
+        return errorResponse(
+          "Error: Documentation search is not configured (missing MINTLIFY_ASSISTANT_API_TOKEN or MINTLIFY_DOMAIN).",
+        );
       }
 
       try {
@@ -74,14 +70,9 @@ export function registerDocsTools(server: McpServer) {
 
         return { content: [{ type: "text", text: formatted }] };
       } catch (error) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Error searching documentation: ${error instanceof Error ? error.message : "Unknown error"}`,
-            },
-          ],
-        };
+        return errorResponse(
+          `Error searching documentation: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
       }
     },
   );

--- a/src/lib/mcp/tools/shell.ts
+++ b/src/lib/mcp/tools/shell.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { createKernelClient } from "@/lib/mcp/kernel-client";
+import { throwToolError } from "@/lib/mcp/responses";
 
 export function registerShellTool(server: McpServer) {
   // exec_command -- Execute shell commands inside a browser VM
@@ -70,11 +71,7 @@ export function registerShellTool(server: McpServer) {
           ],
         };
       } catch (error) {
-        return {
-          content: [
-            { type: "text", text: `Error executing command: ${error}` },
-          ],
-        };
+        throwToolError("exec_command", "exec", error);
       }
     },
   );


### PR DESCRIPTION
## Summary

Two tools return their error text in a normal content block with no `isError`, so every failure they hit is recorded as a **success**. Same defect as the one fixed for `execute_playwright_code`, in the two remaining places it exists.

Found by cross-checking MCP analytics against the Kernel API's own traces during rollout monitoring: in one hour the API returned **4 × 400 on `/browsers/{id}/process/exec`** while `exec_command` reported **zero** failures. The tool has looked spotless in every check for a week.

```ts
// before
} catch (error) {
  return { content: [{ type: "text", text: `Error executing command: ${error}` }] };
}
```

## Changes

- **`exec_command`** now goes through `throwToolError`, the same funnel every other Kernel API tool uses. It flags the result as an error *and* classifies the API status, so these failures land as `KernelApiError400` / `404` / `429` rather than being invisible.
- **`search_docs`** returns `errorResponse(...)` instead, for both the unconfigured branch and the catch. It calls Mintlify, not the Kernel API, so a Kernel status classification would be wrong; it just needs to report failure as failure.

I swept every other tool: all remaining catch blocks already route through `throwToolError` or `errorResponse`.

## Client-visible change

`exec_command`'s message format changes from `Error executing command: <err>` to `Error in exec_command (exec): <err>`, matching every other tool. Content is otherwise the same and the result stays a text block. `search_docs` messages are byte-identical.

## Effect on the numbers

The reported error rate will rise slightly as these failures stop being counted as successes. That is the fix working, not a regression — the same shift seen when playwright started reporting honestly.

## Tests

`bun test` covers `search_docs`' misconfiguration path end to end: a real MCP client over an in-memory transport asserting `isError` and the exact text. Verified it fails against the pre-fix code. `exec_command`'s path needs a live Kernel API call, so it is verified against the preview deployment rather than in the suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized MCP response handling and observability fixes; no auth or data-model changes, with a minor message format change for `exec_command` errors.
> 
> **Overview**
> **MCP tools were returning failure text as normal success responses** (`isError` unset), which skewed analytics—same issue previously fixed for `execute_playwright_code`.
> 
> **`exec_command`** now routes Kernel API failures through `throwToolError`, so clients get `isError` and errors are classified by HTTP status (e.g. `KernelApiError400`). The user-visible message format becomes `Error in exec_command (exec): …`, aligned with other Kernel tools.
> 
> **`search_docs`** uses `errorResponse` for missing Mintlify env vars and for search failures, since those are not Kernel API errors.
> 
> Adds an in-memory MCP test that **`search_docs`** reports missing configuration with `isError: true` and unchanged error text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b39e59fd5384815e79a2288d5224c2e23e04692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->