### PR TITLE
Add project-scoped OAuth authorization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,6 @@ POSTHOG_HOST=https://us.i.posthog.com
 KERNEL_CLI_PROD_CLIENT_ID=<x>
 KERNEL_CLI_STAGING_CLIENT_ID=<x>
 KERNEL_CLI_DEV_CLIENT_ID=<x>
+
+# Optional comma-separated allowlist for known legacy OAuth clients that cannot use S256 PKCE.
+# OAUTH_LEGACY_NON_PKCE_CLIENT_IDS=<client_id>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The Kernel MCP Server bridges AI assistants (like Claude, Cursor, or other MCP-c
 
 **Open-source & fully-managed** — the complete codebase is available here, and we run the production instance so you don't need to deploy anything.
 
-The server uses OAuth 2.0 authentication via [Clerk](https://clerk.com) to ensure secure access to your Kernel resources.
+The server uses OAuth 2.0 authentication via [Clerk](https://clerk.com) to ensure secure access to your Kernel resources. During authorization, users can grant organization-wide access or restrict the resulting access and refresh tokens to one Kernel project. Project-scoped tokens cannot switch projects; organization-wide authorization remains available for existing workflows.
 
 For a deeper dive into why and how we built this server, see our blog post: [Introducing Kernel MCP Server](https://blog.onkernel.com/p/introducing-kernel-mcp-server).
 

--- a/src/app/authorize/route.test.ts
+++ b/src/app/authorize/route.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+import type { AuthorizeDependencies } from "./route";
+
+process.env.KERNEL_CLI_PROD_CLIENT_ID ??= "cli_prod";
+process.env.KERNEL_CLI_STAGING_CLIENT_ID ??= "cli_staging";
+process.env.KERNEL_CLI_DEV_CLIENT_ID ??= "cli_dev";
+process.env.NEXT_PUBLIC_CLERK_DOMAIN ??= "clerk.example.test";
+
+const { authorizeRequest } = await import("./route");
+
+function request(query: string) {
+  return new NextRequest(`https://auth.example.test/authorize?${query}`);
+}
+
+function dependencies({
+  userId = "user_1",
+  orgId = "org_1",
+}: { userId?: string | null; orgId?: string | null } = {}) {
+  const requestContexts: Parameters<
+    AuthorizeDependencies["setRequestContext"]
+  >[0][] = [];
+  const clientContexts: Parameters<
+    AuthorizeDependencies["setClientContext"]
+  >[0][] = [];
+  const projects: Parameters<AuthorizeDependencies["requireProject"]>[0][] = [];
+  return {
+    requestContexts,
+    clientContexts,
+    projects,
+    value: {
+      getAuth: async () => ({
+        userId,
+        orgId,
+        getToken: async () => "session-token",
+      }),
+      setRequestContext: async (value) => {
+        requestContexts.push(value);
+      },
+      setClientContext: async (value) => {
+        clientContexts.push(value);
+      },
+      requireProject: async (value) => {
+        projects.push(value);
+        return { id: value.projectId, name: "project", status: "active" };
+      },
+    } satisfies AuthorizeDependencies,
+  };
+}
+
+describe("GET /authorize", () => {
+  test("redirects to selection and preserves OAuth parameters", async () => {
+    const deps = dependencies();
+    const response = await authorizeRequest(
+      request(
+        "client_id=client_1&state=opaque&resource=https%3A%2F%2Fmcp.example.test%2Fmcp&code_challenge=challenge&code_challenge_method=S256",
+      ),
+      deps.value,
+    );
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.pathname).toBe("/select-org");
+    expect(location.searchParams.get("state")).toBe("opaque");
+    expect(location.searchParams.get("resource")).toBe(
+      "https://mcp.example.test/mcp",
+    );
+  });
+
+  test("stores PKCE-bound organization scope and strips internal parameters", async () => {
+    const deps = dependencies();
+    const response = await authorizeRequest(
+      request(
+        "client_id=client_1&org_id=org_1&access_scope=organization&state=opaque&code_challenge=challenge&code_challenge_method=S256",
+      ),
+      deps.value,
+    );
+
+    expect(response.status).toBe(307);
+    expect(deps.requestContexts).toHaveLength(1);
+    expect(deps.requestContexts[0]).toMatchObject({
+      clientId: "client_1",
+      codeChallenge: "challenge",
+      authorizationContext: {
+        version: 1,
+        clerk_user_id: "user_1",
+        clerk_org_id: "org_1",
+        access_scope: "organization",
+      },
+    });
+    const location = new URL(response.headers.get("location")!);
+    expect(location.host).toBe("clerk.example.test");
+    expect(location.searchParams.get("org_id")).toBeNull();
+    expect(location.searchParams.get("access_scope")).toBeNull();
+    expect(location.searchParams.get("project_id")).toBeNull();
+    expect(location.searchParams.get("state")).toBe("opaque");
+  });
+
+  test("validates and stores project scope", async () => {
+    const deps = dependencies();
+    const response = await authorizeRequest(
+      request(
+        "client_id=client_1&org_id=org_1&access_scope=project&project_id=proj_1&code_challenge=challenge&code_challenge_method=S256",
+      ),
+      deps.value,
+    );
+
+    expect(response.status).toBe(307);
+    expect(deps.projects).toEqual([
+      { clerkSessionToken: "session-token", projectId: "proj_1" },
+    ]);
+    expect(deps.requestContexts[0].authorizationContext).toMatchObject({
+      access_scope: "project",
+      project_id: "proj_1",
+    });
+  });
+
+  test("rejects project scope without S256 PKCE", async () => {
+    const deps = dependencies();
+    const response = await authorizeRequest(
+      request(
+        "client_id=client_1&org_id=org_1&access_scope=project&project_id=proj_1",
+      ),
+      deps.value,
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: "invalid_request" });
+    expect(deps.requestContexts).toHaveLength(0);
+  });
+
+  test("rejects an organization that is not active for the user", async () => {
+    const deps = dependencies({ orgId: "org_2" });
+    const response = await authorizeRequest(
+      request("client_id=client_1&org_id=org_1&access_scope=organization"),
+      deps.value,
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ error: "access_denied" });
+  });
+
+  test("keeps shared-client state compatible and includes scope", async () => {
+    const deps = dependencies();
+    const originalState = Buffer.from(
+      JSON.stringify({ csrf: "csrf_1" }),
+    ).toString("base64");
+    const response = await authorizeRequest(
+      request(
+        `client_id=cli_prod&org_id=org_1&access_scope=project&project_id=proj_1&state=${encodeURIComponent(originalState)}&code_challenge=challenge&code_challenge_method=S256`,
+      ),
+      deps.value,
+    );
+
+    const location = new URL(response.headers.get("location")!);
+    const state = JSON.parse(
+      Buffer.from(location.searchParams.get("state")!, "base64").toString(),
+    );
+    expect(state).toEqual({
+      csrf: "csrf_1",
+      org_id: "org_1",
+      access_scope: "project",
+      project_id: "proj_1",
+    });
+  });
+});

--- a/src/app/authorize/route.test.ts
+++ b/src/app/authorize/route.test.ts
@@ -5,6 +5,7 @@ import type { AuthorizeDependencies } from "./route";
 process.env.KERNEL_CLI_PROD_CLIENT_ID ??= "cli_prod";
 process.env.KERNEL_CLI_STAGING_CLIENT_ID ??= "cli_staging";
 process.env.KERNEL_CLI_DEV_CLIENT_ID ??= "cli_dev";
+process.env.OAUTH_LEGACY_NON_PKCE_CLIENT_IDS = "legacy_client";
 process.env.NEXT_PUBLIC_CLERK_DOMAIN ??= "clerk.example.test";
 
 const { authorizeRequest } = await import("./route");
@@ -144,16 +145,36 @@ describe("GET /authorize", () => {
     expect(deps.requestContexts).toHaveLength(0);
   });
 
-  test("requires PKCE for shared clients", async () => {
+  test("requires PKCE outside the legacy client allowlist", async () => {
     const deps = dependencies();
     const response = await authorizeRequest(
-      request("client_id=cli_prod&org_id=org_1&access_scope=organization"),
+      request("client_id=client_1&org_id=org_1&access_scope=organization"),
       deps.value,
     );
 
     expect(response.status).toBe(400);
     expect(await response.json()).toMatchObject({ error: "invalid_request" });
     expect(deps.clientContexts).toHaveLength(0);
+  });
+
+  test("stores organization scope for an allowlisted legacy client", async () => {
+    const deps = dependencies();
+    const response = await authorizeRequest(
+      request("client_id=legacy_client&org_id=org_1&access_scope=organization"),
+      deps.value,
+    );
+
+    expect(response.status).toBe(307);
+    expect(deps.clientContexts).toEqual([
+      expect.objectContaining({
+        clientId: "legacy_client",
+        authorizationContext: expect.objectContaining({
+          clerk_user_id: "user_1",
+          clerk_org_id: "org_1",
+          access_scope: "organization",
+        }),
+      }),
+    ]);
   });
 
   test("rejects an organization that is not active for the user", async () => {

--- a/src/app/authorize/route.test.ts
+++ b/src/app/authorize/route.test.ts
@@ -129,6 +129,33 @@ describe("GET /authorize", () => {
     expect(deps.requestContexts).toHaveLength(0);
   });
 
+  test("rejects incomplete or unsupported PKCE parameters", async () => {
+    const deps = dependencies();
+    const response = await authorizeRequest(
+      request(
+        "client_id=client_1&org_id=org_1&access_scope=organization&code_challenge=challenge&code_challenge_method=plain",
+      ),
+      deps.value,
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: "invalid_request" });
+    expect(deps.clientContexts).toHaveLength(0);
+    expect(deps.requestContexts).toHaveLength(0);
+  });
+
+  test("requires PKCE for shared clients", async () => {
+    const deps = dependencies();
+    const response = await authorizeRequest(
+      request("client_id=cli_prod&org_id=org_1&access_scope=organization"),
+      deps.value,
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: "invalid_request" });
+    expect(deps.clientContexts).toHaveLength(0);
+  });
+
   test("rejects an organization that is not active for the user", async () => {
     const deps = dependencies({ orgId: "org_2" });
     const response = await authorizeRequest(

--- a/src/app/authorize/route.test.ts
+++ b/src/app/authorize/route.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { NextRequest } from "next/server";
 import type { AuthorizeDependencies } from "./route";
+import { OAuthProjectsError } from "@/lib/oauth-projects";
 
 process.env.KERNEL_CLI_PROD_CLIENT_ID ??= "cli_prod";
 process.env.KERNEL_CLI_STAGING_CLIENT_ID ??= "cli_staging";
@@ -17,7 +18,12 @@ function request(query: string) {
 function dependencies({
   userId = "user_1",
   orgId = "org_1",
-}: { userId?: string | null; orgId?: string | null } = {}) {
+  projectError,
+}: {
+  userId?: string | null;
+  orgId?: string | null;
+  projectError?: Error;
+} = {}) {
   const requestContexts: Parameters<
     AuthorizeDependencies["setRequestContext"]
   >[0][] = [];
@@ -43,6 +49,7 @@ function dependencies({
       },
       requireProject: async (value) => {
         projects.push(value);
+        if (projectError) throw projectError;
         return { id: value.projectId, name: "project", status: "active" };
       },
     } satisfies AuthorizeDependencies,
@@ -114,6 +121,21 @@ describe("GET /authorize", () => {
       access_scope: "project",
       project_id: "proj_1",
     });
+  });
+
+  test("reports project API failures as temporarily unavailable", async () => {
+    const deps = dependencies({
+      projectError: new OAuthProjectsError("upstream unavailable", 502),
+    });
+    const response = await authorizeRequest(
+      request(
+        "client_id=client_1&org_id=org_1&access_scope=project&project_id=proj_1&code_challenge=challenge&code_challenge_method=S256",
+      ),
+      deps.value,
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({ error: "server_error" });
   });
 
   test("rejects project scope without S256 PKCE", async () => {

--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -144,6 +144,20 @@ export async function authorizeRequest(
     );
   }
 
+  const hasPKCEParameters = Boolean(codeChallenge || codeChallengeMethod);
+  if (hasPKCEParameters && (!codeChallenge || codeChallengeMethod !== "S256")) {
+    return errorResponse(
+      "invalid_request",
+      "PKCE requires code_challenge and code_challenge_method=S256",
+    );
+  }
+  if (SHARED_CLIENT_IDS.includes(clientId) && !codeChallenge) {
+    return errorResponse(
+      "invalid_request",
+      "Shared OAuth clients require PKCE with S256",
+    );
+  }
+
   let authorizationContext;
   try {
     authorizationContext = authorizationContextFromSelection({
@@ -160,7 +174,7 @@ export async function authorizeRequest(
   }
 
   if (authorizationContext.access_scope === PROJECT_ACCESS_SCOPE) {
-    if (!codeChallenge || codeChallengeMethod !== "S256") {
+    if (!codeChallenge) {
       return errorResponse(
         "invalid_request",
         "Project-scoped authorization requires PKCE with S256",
@@ -193,7 +207,7 @@ export async function authorizeRequest(
   }
 
   try {
-    if (codeChallenge && codeChallengeMethod === "S256") {
+    if (codeChallenge) {
       await dependencies.setRequestContext({
         clientId,
         codeChallenge,

--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -1,196 +1,246 @@
+import { auth } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
-import { setOrgIdForClientId } from "../../lib/redis";
-import { SHARED_CLIENT_IDS } from "../../lib/const";
+import {
+  setAuthorizationContextForClientId,
+  setAuthorizationContextForRequest,
+} from "@/lib/redis";
+import { SHARED_CLIENT_IDS } from "@/lib/const";
+import {
+  authorizationContextFromSelection,
+  type OAuthAuthorizationContext,
+  PROJECT_ACCESS_SCOPE,
+} from "@/lib/oauth-context";
+import {
+  OAuthProjectsError,
+  requireActiveOAuthProject,
+} from "@/lib/oauth-projects";
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+const INTERNAL_AUTHORIZATION_PARAMS = new Set([
+  "org_id",
+  "access_scope",
+  "project_id",
+]);
 
 export async function OPTIONS(): Promise<NextResponse> {
-  return new NextResponse(null, {
-    status: 204,
-    headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type, Authorization",
-    },
-  });
+  return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
 }
 
-export async function GET(request: NextRequest): Promise<NextResponse> {
-  const searchParams = request.nextUrl.searchParams;
+function errorResponse(
+  error: string,
+  errorDescription: string,
+  status = 400,
+): NextResponse {
+  return NextResponse.json(
+    { error, error_description: errorDescription },
+    { status, headers: CORS_HEADERS },
+  );
+}
 
-  // Step 1: Extract and validate required OAuth parameters
+function sharedClientState({
+  originalState,
+  orgId,
+  accessScope,
+  projectId,
+}: {
+  originalState: string | null;
+  orgId: string;
+  accessScope: string;
+  projectId?: string;
+}): string {
+  let csrf = originalState || "";
+  if (originalState) {
+    try {
+      const parsed = JSON.parse(
+        Buffer.from(originalState, "base64").toString(),
+      ) as { csrf?: string };
+      if (parsed.csrf) csrf = parsed.csrf;
+    } catch {
+      // Older clients may send a plain CSRF value.
+    }
+  }
+
+  return Buffer.from(
+    JSON.stringify({
+      csrf,
+      org_id: orgId,
+      access_scope: accessScope,
+      ...(projectId ? { project_id: projectId } : {}),
+    }),
+  ).toString("base64");
+}
+
+export interface AuthorizeDependencies {
+  getAuth: () => Promise<{
+    userId: string | null | undefined;
+    orgId: string | null | undefined;
+    getToken: () => Promise<string | null>;
+  }>;
+  setRequestContext: (input: {
+    clientId: string;
+    codeChallenge: string;
+    authorizationContext: OAuthAuthorizationContext;
+    ttlSeconds: number;
+  }) => Promise<void>;
+  setClientContext: (input: {
+    clientId: string;
+    authorizationContext: OAuthAuthorizationContext;
+    ttlSeconds: number;
+  }) => Promise<void>;
+  requireProject: typeof requireActiveOAuthProject;
+}
+
+const authorizeDependencies: AuthorizeDependencies = {
+  getAuth: async () => auth(),
+  setRequestContext: setAuthorizationContextForRequest,
+  setClientContext: setAuthorizationContextForClientId,
+  requireProject: requireActiveOAuthProject,
+};
+
+export async function authorizeRequest(
+  request: NextRequest,
+  dependencies: AuthorizeDependencies = authorizeDependencies,
+): Promise<NextResponse> {
+  const searchParams = request.nextUrl.searchParams;
   const clientId = searchParams.get("client_id");
   const selectedOrgId = searchParams.get("org_id");
   const originalState = searchParams.get("state");
+  const accessScope = searchParams.get("access_scope");
+  const projectId = searchParams.get("project_id");
+  const codeChallenge = searchParams.get("code_challenge");
+  const codeChallengeMethod = searchParams.get("code_challenge_method");
 
-  console.debug("[authorize] start", {
-    hasClientId: Boolean(clientId),
-    hasSelectedOrgId: Boolean(selectedOrgId),
-    hasState: Boolean(originalState),
-  });
-
-  // Step 2: Validate minimum required parameters
   if (!clientId) {
-    return NextResponse.json(
-      {
-        error: "invalid_request",
-        error_description: "Missing required parameter: client_id",
-      },
-      {
-        status: 400,
-        headers: {
-          "Access-Control-Allow-Origin": "*",
-          "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-          "Access-Control-Allow-Headers": "Content-Type, Authorization",
-        },
-      },
+    return errorResponse(
+      "invalid_request",
+      "Missing required parameter: client_id",
     );
   }
 
-  // Step 3: Redirect to organization selector if no org chosen yet
   if (!selectedOrgId) {
-    console.debug(
-      "[authorize] no org selected yet, redirecting to /select-org",
-    );
     const selectOrgUrl = new URL("/select-org", request.nextUrl.origin);
-
-    // Pass all OAuth parameters to the org selector
     searchParams.forEach((value, key) => {
       selectOrgUrl.searchParams.set(key, value);
     });
-
-    return NextResponse.redirect(selectOrgUrl.toString());
+    return NextResponse.redirect(selectOrgUrl);
   }
 
-  // Step 4: Validate server configuration
   const clerkDomain = process.env.NEXT_PUBLIC_CLERK_DOMAIN;
-
   if (!clerkDomain) {
-    return NextResponse.json(
-      {
-        error: "server_error",
-        error_description: "Server configuration error",
-      },
-      {
-        status: 500,
-        headers: {
-          "Access-Control-Allow-Origin": "*",
-          "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-          "Access-Control-Allow-Headers": "Content-Type, Authorization",
-        },
-      },
+    return errorResponse("server_error", "Server configuration error", 500);
+  }
+
+  const { userId, orgId, getToken } = await dependencies.getAuth();
+  if (!userId || orgId !== selectedOrgId) {
+    return errorResponse(
+      "access_denied",
+      "The selected organization is not active for this user",
+      403,
     );
   }
 
-  // Step 5: Store organization context for ephemeral clients
-  // Skip Redis storage for shared clients to avoid cross-user overwrites
-  if (!SHARED_CLIENT_IDS.includes(clientId)) {
-    try {
-      // TTL only needs to last through the OAuth flow (authorization_code exchange)
-      await setOrgIdForClientId({
-        clientId,
-        orgId: selectedOrgId,
-        ttlSeconds: 60 * 60, // 1 hour
-      });
-      console.debug("[authorize] stored org_id for ephemeral client", {
-        clientIdMasked: clientId?.slice(0, 4) + "...",
-      });
-    } catch (error) {
-      console.error("[authorize] failed to store org_id in Redis", { error });
-      return NextResponse.json(
-        {
-          error: "server_error",
-          error_description: "Failed to store organization context",
-        },
-        {
-          status: 500,
-          headers: {
-            "Access-Control-Allow-Origin": "*",
-            "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-            "Access-Control-Allow-Headers": "Content-Type, Authorization",
-          },
-        },
+  let authorizationContext;
+  try {
+    authorizationContext = authorizationContextFromSelection({
+      clerkUserId: userId,
+      clerkOrgId: selectedOrgId,
+      accessScope,
+      projectId,
+    });
+  } catch (error) {
+    return errorResponse(
+      "invalid_request",
+      error instanceof Error ? error.message : "Invalid access scope",
+    );
+  }
+
+  if (authorizationContext.access_scope === PROJECT_ACCESS_SCOPE) {
+    if (!codeChallenge || codeChallengeMethod !== "S256") {
+      return errorResponse(
+        "invalid_request",
+        "Project-scoped authorization requires PKCE with S256",
       );
     }
-  } else {
-    console.debug("[authorize] shared client, skipping Redis store", {
-      clientIdMasked: clientId?.slice(0, 4) + "...",
+    const clerkSessionToken = await getToken();
+    if (!clerkSessionToken) {
+      return errorResponse("access_denied", "Authentication required", 401);
+    }
+    try {
+      await dependencies.requireProject({
+        clerkSessionToken,
+        projectId: authorizationContext.project_id,
+      });
+    } catch (error) {
+      console.warn("[authorize] project validation failed", { error });
+      if (error instanceof OAuthProjectsError && error.status >= 500) {
+        return errorResponse(
+          "server_error",
+          "Project validation is temporarily unavailable",
+          503,
+        );
+      }
+      return errorResponse(
+        "access_denied",
+        "Project not found or inactive",
+        403,
+      );
+    }
+  }
+
+  try {
+    if (codeChallenge && codeChallengeMethod === "S256") {
+      await dependencies.setRequestContext({
+        clientId,
+        codeChallenge,
+        authorizationContext,
+        ttlSeconds: 60 * 60,
+      });
+    } else {
+      // Compatibility for existing non-PKCE organization-wide clients. New
+      // project-scoped grants always require the PKCE-bound request mapping.
+      await dependencies.setClientContext({
+        clientId,
+        authorizationContext,
+        ttlSeconds: 60 * 60,
+      });
+    }
+  } catch (error) {
+    console.error("[authorize] failed to store authorization context", {
+      error,
+    });
+    return errorResponse(
+      "server_error",
+      "Failed to store authorization context",
+      500,
+    );
+  }
+
+  let state = originalState;
+  if (SHARED_CLIENT_IDS.includes(clientId)) {
+    state = sharedClientState({
+      originalState,
+      orgId: selectedOrgId,
+      accessScope: authorizationContext.access_scope,
+      projectId: authorizationContext.project_id,
     });
   }
 
-  // Step 6: Handle state parameter based on client type
-  let modifiedState = originalState;
-
-  // Only modify state for shared clients (CLI), not ephemeral clients (MCP)
-  if (selectedOrgId && SHARED_CLIENT_IDS.includes(clientId)) {
-    try {
-      // Extract CSRF token from original state if it's base64-encoded JSON
-      let csrfToken = originalState || "";
-
-      if (originalState) {
-        try {
-          // Try to decode originalState as base64-encoded JSON (from CLI)
-          const decodedState = Buffer.from(originalState, "base64").toString();
-          const parsedState = JSON.parse(decodedState);
-          if (parsedState.csrf) {
-            csrfToken = parsedState.csrf;
-            console.debug("[authorize] extracted CSRF from CLI state param");
-          }
-        } catch (decodeError) {
-          // If decoding fails, treat originalState as plain CSRF token
-          csrfToken = originalState;
-          console.debug("[authorize] using original state as plain CSRF token");
-        }
-      }
-
-      const stateData = {
-        csrf: csrfToken,
-        org_id: selectedOrgId,
-      };
-      modifiedState = Buffer.from(JSON.stringify(stateData)).toString("base64");
-      console.debug("[authorize] encoded org_id into state for shared client", {
-        clientIdMasked: clientId?.slice(0, 4) + "...",
-      });
-    } catch (error) {
-      console.error("[authorize] failed to encode org_id into state", {
-        error,
-      });
-      return NextResponse.json(
-        {
-          error: "server_error",
-          error_description: "Failed to encode organization context",
-        },
-        {
-          status: 500,
-          headers: {
-            "Access-Control-Allow-Origin": "*",
-            "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-            "Access-Control-Allow-Headers": "Content-Type, Authorization",
-          },
-        },
-      );
-    }
-  } else if (selectedOrgId) {
-    // For ephemeral clients, don't modify state - rely on Redis storage
-    console.debug("[authorize] ephemeral client: preserving original state");
-  }
-
-  // Step 7: Build Clerk authorization URL with OAuth parameters
   const clerkAuthUrl = new URL(`https://${clerkDomain}/oauth/authorize`);
-
-  // Pass through all original parameters except our custom org_id
   searchParams.forEach((value, key) => {
-    if (key !== "org_id") {
+    if (!INTERNAL_AUTHORIZATION_PARAMS.has(key)) {
       clerkAuthUrl.searchParams.set(key, value);
     }
   });
+  if (state) clerkAuthUrl.searchParams.set("state", state);
 
-  // Use the modified state parameter that includes org_id
-  if (modifiedState) {
-    clerkAuthUrl.searchParams.set("state", modifiedState);
-  }
+  return NextResponse.redirect(clerkAuthUrl);
+}
 
-  // Step 8: Redirect to Clerk for actual OAuth authentication
-  console.debug("[authorize] redirecting to clerk /oauth/authorize", {
-    hasModifiedState: Boolean(modifiedState),
-  });
-  return NextResponse.redirect(clerkAuthUrl.toString());
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  return authorizeRequest(request);
 }

--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -4,7 +4,7 @@ import {
   setAuthorizationContextForClientId,
   setAuthorizationContextForRequest,
 } from "@/lib/redis";
-import { SHARED_CLIENT_IDS } from "@/lib/const";
+import { isLegacyNonPkceClient, SHARED_CLIENT_IDS } from "@/lib/const";
 import {
   authorizationContextFromSelection,
   type OAuthAuthorizationContext,
@@ -151,10 +151,10 @@ export async function authorizeRequest(
       "PKCE requires code_challenge and code_challenge_method=S256",
     );
   }
-  if (SHARED_CLIENT_IDS.includes(clientId) && !codeChallenge) {
+  if (!codeChallenge && !isLegacyNonPkceClient(clientId)) {
     return errorResponse(
       "invalid_request",
-      "Shared OAuth clients require PKCE with S256",
+      "OAuth clients require PKCE with S256",
     );
   }
 
@@ -215,8 +215,7 @@ export async function authorizeRequest(
         ttlSeconds: 60 * 60,
       });
     } else {
-      // Compatibility for existing non-PKCE organization-wide clients. New
-      // project-scoped grants always require the PKCE-bound request mapping.
+      // Compatibility is limited to explicitly allowlisted legacy clients.
       await dependencies.setClientContext({
         clientId,
         authorizationContext,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,125 +1,122 @@
-import { ClerkProvider } from "@clerk/nextjs";
-import type { Metadata } from "next";
-import { Inter, IBM_Plex_Mono } from "next/font/google";
-import { ThemeProvider } from "next-themes";
-import "./globals.css";
+import { ClerkProvider } from '@clerk/nextjs'
+import type { Metadata } from 'next'
+import { Inter, IBM_Plex_Mono } from 'next/font/google'
+import { ThemeProvider } from 'next-themes'
+import './globals.css'
 
 const inter = Inter({
-  variable: "--font-inter",
-  subsets: ["latin"],
-  display: "optional",
-});
+  variable: '--font-inter',
+  subsets: ['latin'],
+  display: 'optional',
+})
 
 const ibmPlexMono = IBM_Plex_Mono({
-  weight: ["400", "500"],
-  variable: "--font-ibm-plex-mono",
-  subsets: ["latin"],
-  display: "swap",
-});
+  weight: ['400', '500'],
+  variable: '--font-ibm-plex-mono',
+  subsets: ['latin'],
+  display: 'swap',
+})
 
 export const metadata: Metadata = {
-  title: "Kernel MCP Server",
-  description:
-    "A Model Context Protocol (MCP) server that provides AI assistants with secure access to Kernel platform tools and browser automation capabilities.",
+  title: 'Kernel MCP Server',
+  description: 'A Model Context Protocol (MCP) server that provides AI assistants with secure access to Kernel platform tools and browser automation capabilities.',
   keywords: [
-    "MCP",
-    "Model Context Protocol",
-    "Kernel",
-    "browser automation",
-    "AI assistants",
-    "cloud deployment",
-    "web automation",
-    "Chromium",
-    "headless browser",
+    'MCP',
+    'Model Context Protocol',
+    'Kernel',
+    'browser automation',
+    'AI assistants',
+    'cloud deployment',
+    'web automation',
+    'Chromium',
+    'headless browser',
   ],
   icons: {
     icon: [
-      { url: "/favicon.svg", type: "image/svg+xml" },
-      { url: "/favicon-96x96.png", sizes: "96x96", type: "image/png" },
-      { url: "/favicon.ico" },
+      { url: '/favicon.svg', type: 'image/svg+xml' },
+      { url: '/favicon-96x96.png', sizes: '96x96', type: 'image/png' },
+      { url: '/favicon.ico' },
     ],
     apple: [
-      { url: "/apple-touch-icon.png", sizes: "180x180", type: "image/png" },
+      { url: '/apple-touch-icon.png', sizes: '180x180', type: 'image/png' },
     ],
-    shortcut: "/favicon.ico",
+    shortcut: '/favicon.ico',
   },
-  manifest: "/site.webmanifest",
-};
+  manifest: '/site.webmanifest',
+}
 
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode;
+  children: React.ReactNode
 }): React.ReactElement {
   return (
     <ClerkProvider
       appearance={{
         variables: {
-          colorPrimary: "#81b300",
-          colorText: "#1c2024",
-          colorTextSecondary: "#60646c",
-          colorBackground: "#f2f0e7",
-          colorInputBackground: "#f2f0e7",
-          colorInputText: "#1c2024",
-          fontFamily: "var(--font-inter), Inter, sans-serif",
-          borderRadius: "0px",
+          colorPrimary: '#81b300',
+          colorText: '#1c2024',
+          colorTextSecondary: '#60646c',
+          colorBackground: '#f2f0e7',
+          colorInputBackground: '#f2f0e7',
+          colorInputText: '#1c2024',
+          fontFamily: 'var(--font-inter), Inter, sans-serif',
+          borderRadius: '0px',
         },
         elements: {
           card: {
-            backgroundColor: "#f2f0e7",
-            border: "0.5px solid #1c2024",
-            borderRadius: "0px",
-            boxShadow: "none",
+            backgroundColor: '#f2f0e7',
+            border: '0.5px solid #1c2024',
+            borderRadius: '0px',
+            boxShadow: 'none',
           },
           formButtonPrimary: {
-            backgroundColor: "#1c2024",
-            color: "#f2f0e7",
-            fontWeight: "250",
-            borderRadius: "0px",
-            letterSpacing: "0.3px",
-            textTransform: "lowercase" as const,
+            backgroundColor: '#1c2024',
+            color: '#f2f0e7',
+            fontWeight: '250',
+            borderRadius: '0px',
+            letterSpacing: '0.3px',
+            textTransform: 'lowercase' as const,
           },
           formFieldInput: {
-            border: "0.5px solid #1c2024",
-            borderRadius: "0px",
-            backgroundColor: "#f2f0e7",
+            border: '0.5px solid #1c2024',
+            borderRadius: '0px',
+            backgroundColor: '#f2f0e7',
           },
           footerActionLink: {
-            color: "#1c2024",
+            color: '#1c2024',
           },
           headerTitle: {
-            textTransform: "lowercase" as const,
-            fontWeight: "250",
-            letterSpacing: "0.5px",
+            textTransform: 'lowercase' as const,
+            fontWeight: '250',
+            letterSpacing: '0.5px',
           },
           headerSubtitle: {
-            textTransform: "lowercase" as const,
-            fontWeight: "250",
-            letterSpacing: "0.3px",
+            textTransform: 'lowercase' as const,
+            fontWeight: '250',
+            letterSpacing: '0.3px',
           },
           socialButtonsBlockButton: {
-            border: "0.5px solid #1c2024",
-            borderRadius: "0px",
-            textTransform: "lowercase" as const,
+            border: '0.5px solid #1c2024',
+            borderRadius: '0px',
+            textTransform: 'lowercase' as const,
           },
           dividerLine: {
-            backgroundColor: "#1c2024",
+            backgroundColor: '#1c2024',
           },
           identityPreview: {
-            border: "0.5px solid #1c2024",
-            borderRadius: "0px",
+            border: '0.5px solid #1c2024',
+            borderRadius: '0px',
           },
           organizationPreview: {
-            border: "0.5px solid #1c2024",
-            borderRadius: "0px",
+            border: '0.5px solid #1c2024',
+            borderRadius: '0px',
           },
         },
       }}
     >
       <html lang="en" suppressHydrationWarning>
-        <body
-          className={`${inter.variable} ${ibmPlexMono.variable} font-sans overscroll-y-none`}
-        >
+        <body className={`${inter.variable} ${ibmPlexMono.variable} font-sans overscroll-y-none`}>
           <ThemeProvider
             attribute="class"
             forcedTheme="light"
@@ -131,5 +128,5 @@ export default function RootLayout({
         </body>
       </html>
     </ClerkProvider>
-  );
+  )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,132 +1,135 @@
-import { ClerkProvider } from '@clerk/nextjs'
-import type { Metadata } from 'next'
-import { Inter, IBM_Plex_Mono } from 'next/font/google'
-import { ThemeProvider } from 'next-themes'
-import './globals.css'
+import { ClerkProvider } from "@clerk/nextjs";
+import type { Metadata } from "next";
+import { Inter, IBM_Plex_Mono } from "next/font/google";
+import { ThemeProvider } from "next-themes";
+import "./globals.css";
 
 const inter = Inter({
-  variable: '--font-inter',
-  subsets: ['latin'],
-  display: 'optional',
-})
+  variable: "--font-inter",
+  subsets: ["latin"],
+  display: "optional",
+});
 
 const ibmPlexMono = IBM_Plex_Mono({
-  weight: ['400', '500'],
-  variable: '--font-ibm-plex-mono',
-  subsets: ['latin'],
-  display: 'swap',
-})
+  weight: ["400", "500"],
+  variable: "--font-ibm-plex-mono",
+  subsets: ["latin"],
+  display: "swap",
+});
 
 export const metadata: Metadata = {
-  title: 'Kernel MCP Server',
-  description: 'A Model Context Protocol (MCP) server that provides AI assistants with secure access to Kernel platform tools and browser automation capabilities.',
+  title: "Kernel MCP Server",
+  description:
+    "A Model Context Protocol (MCP) server that provides AI assistants with secure access to Kernel platform tools and browser automation capabilities.",
   keywords: [
-    'MCP',
-    'Model Context Protocol',
-    'Kernel',
-    'browser automation',
-    'AI assistants',
-    'cloud deployment',
-    'web automation',
-    'Chromium',
-    'headless browser',
+    "MCP",
+    "Model Context Protocol",
+    "Kernel",
+    "browser automation",
+    "AI assistants",
+    "cloud deployment",
+    "web automation",
+    "Chromium",
+    "headless browser",
   ],
   icons: {
     icon: [
-      { url: '/favicon.svg', type: 'image/svg+xml' },
-      { url: '/favicon-96x96.png', sizes: '96x96', type: 'image/png' },
-      { url: '/favicon.ico' },
+      { url: "/favicon.svg", type: "image/svg+xml" },
+      { url: "/favicon-96x96.png", sizes: "96x96", type: "image/png" },
+      { url: "/favicon.ico" },
     ],
     apple: [
-      { url: '/apple-touch-icon.png', sizes: '180x180', type: 'image/png' },
+      { url: "/apple-touch-icon.png", sizes: "180x180", type: "image/png" },
     ],
-    shortcut: '/favicon.ico',
+    shortcut: "/favicon.ico",
   },
-  manifest: '/site.webmanifest',
-}
+  manifest: "/site.webmanifest",
+};
 
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }): React.ReactElement {
   return (
     <ClerkProvider
       appearance={{
         variables: {
-          colorPrimary: '#81b300',
-          colorText: '#1c2024',
-          colorTextSecondary: '#60646c',
-          colorBackground: '#f2f0e7',
-          colorInputBackground: '#f2f0e7',
-          colorInputText: '#1c2024',
-          fontFamily: 'var(--font-inter), Inter, sans-serif',
-          borderRadius: '0px',
+          colorPrimary: "#81b300",
+          colorText: "#1c2024",
+          colorTextSecondary: "#60646c",
+          colorBackground: "#f2f0e7",
+          colorInputBackground: "#f2f0e7",
+          colorInputText: "#1c2024",
+          fontFamily: "var(--font-inter), Inter, sans-serif",
+          borderRadius: "0px",
         },
         elements: {
           card: {
-            backgroundColor: '#f2f0e7',
-            border: '0.5px solid #1c2024',
-            borderRadius: '0px',
-            boxShadow: 'none',
+            backgroundColor: "#f2f0e7",
+            border: "0.5px solid #1c2024",
+            borderRadius: "0px",
+            boxShadow: "none",
           },
           formButtonPrimary: {
-            backgroundColor: '#1c2024',
-            color: '#f2f0e7',
-            fontWeight: '250',
-            borderRadius: '0px',
-            letterSpacing: '0.3px',
-            textTransform: 'lowercase' as const,
+            backgroundColor: "#1c2024",
+            color: "#f2f0e7",
+            fontWeight: "250",
+            borderRadius: "0px",
+            letterSpacing: "0.3px",
+            textTransform: "lowercase" as const,
           },
           formFieldInput: {
-            border: '0.5px solid #1c2024',
-            borderRadius: '0px',
-            backgroundColor: '#f2f0e7',
+            border: "0.5px solid #1c2024",
+            borderRadius: "0px",
+            backgroundColor: "#f2f0e7",
           },
           footerActionLink: {
-            color: '#1c2024',
+            color: "#1c2024",
           },
           headerTitle: {
-            textTransform: 'lowercase' as const,
-            fontWeight: '250',
-            letterSpacing: '0.5px',
+            textTransform: "lowercase" as const,
+            fontWeight: "250",
+            letterSpacing: "0.5px",
           },
           headerSubtitle: {
-            textTransform: 'lowercase' as const,
-            fontWeight: '250',
-            letterSpacing: '0.3px',
+            textTransform: "lowercase" as const,
+            fontWeight: "250",
+            letterSpacing: "0.3px",
           },
           socialButtonsBlockButton: {
-            border: '0.5px solid #1c2024',
-            borderRadius: '0px',
-            textTransform: 'lowercase' as const,
+            border: "0.5px solid #1c2024",
+            borderRadius: "0px",
+            textTransform: "lowercase" as const,
           },
           dividerLine: {
-            backgroundColor: '#1c2024',
+            backgroundColor: "#1c2024",
           },
           identityPreview: {
-            border: '0.5px solid #1c2024',
-            borderRadius: '0px',
+            border: "0.5px solid #1c2024",
+            borderRadius: "0px",
           },
           organizationPreview: {
-            border: '0.5px solid #1c2024',
-            borderRadius: '0px',
+            border: "0.5px solid #1c2024",
+            borderRadius: "0px",
           },
         },
       }}
     >
       <html lang="en" suppressHydrationWarning>
-        <body className={`${inter.variable} ${ibmPlexMono.variable} font-sans overscroll-y-none`}>
+        <body
+          className={`${inter.variable} ${ibmPlexMono.variable} font-sans overscroll-y-none`}
+        >
           <ThemeProvider
             attribute="class"
-            defaultTheme="light"
+            forcedTheme="light"
             disableTransitionOnChange
-            enableSystem
+            enableSystem={false}
           >
             <main>{children}</main>
           </ThemeProvider>
         </body>
       </html>
     </ClerkProvider>
-  )
+  );
 }

--- a/src/app/oauth/projects/route.test.ts
+++ b/src/app/oauth/projects/route.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+import {
+  oauthProjectsRequest,
+  type OAuthProjectsRouteDependencies,
+} from "./route";
+
+function request(query: string) {
+  return new NextRequest(`https://mcp.example.test/oauth/projects?${query}`);
+}
+
+function dependencies() {
+  const listCalls: Parameters<
+    OAuthProjectsRouteDependencies["listProjects"]
+  >[0][] = [];
+  return {
+    listCalls,
+    value: {
+      getAuth: async () => ({
+        userId: "user_1",
+        orgId: "org_1",
+        getToken: async () => "session-token",
+      }),
+      listProjects: async (input) => {
+        listCalls.push(input);
+        return {
+          projects: [{ id: "proj_1", name: "production", status: "active" }],
+          hasMore: true,
+          nextOffset: 40,
+        };
+      },
+    } satisfies OAuthProjectsRouteDependencies,
+  };
+}
+
+describe("GET /oauth/projects", () => {
+  test("forwards server-side search and pagination", async () => {
+    const deps = dependencies();
+    const response = await oauthProjectsRequest(
+      request("org_id=org_1&query=prod&limit=20&offset=20"),
+      deps.value,
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.listCalls).toEqual([
+      {
+        clerkSessionToken: "session-token",
+        query: "prod",
+        limit: 20,
+        offset: 20,
+      },
+    ]);
+    expect(await response.json()).toEqual({
+      projects: [{ id: "proj_1", name: "production", status: "active" }],
+      has_more: true,
+      next_offset: 40,
+    });
+  });
+
+  test("rejects organization and pagination mismatches", async () => {
+    const deps = dependencies();
+    const wrongOrg = await oauthProjectsRequest(
+      request("org_id=org_2"),
+      deps.value,
+    );
+    expect(wrongOrg.status).toBe(403);
+
+    for (const query of [
+      "org_id=org_1&limit=21",
+      "org_id=org_1&limit=0",
+      "org_id=org_1&offset=-1",
+    ]) {
+      const response = await oauthProjectsRequest(request(query), deps.value);
+      expect(response.status).toBe(400);
+    }
+    expect(deps.listCalls).toHaveLength(0);
+  });
+});

--- a/src/app/oauth/projects/route.ts
+++ b/src/app/oauth/projects/route.ts
@@ -1,0 +1,31 @@
+import { auth } from "@clerk/nextjs/server";
+import { NextRequest, NextResponse } from "next/server";
+import { listOAuthProjects, OAuthProjectsError } from "@/lib/oauth-projects";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const { userId, orgId, getToken } = await auth();
+  if (!userId || !orgId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const requestedOrgId = request.nextUrl.searchParams.get("org_id");
+  if (!requestedOrgId || requestedOrgId !== orgId) {
+    return NextResponse.json(
+      { error: "organization_mismatch" },
+      { status: 403 },
+    );
+  }
+
+  const token = await getToken();
+  if (!token) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  try {
+    return NextResponse.json({ projects: await listOAuthProjects(token) });
+  } catch (error) {
+    const status = error instanceof OAuthProjectsError ? error.status : 500;
+    console.error("[oauth/projects] failed to list projects", { error });
+    return NextResponse.json({ error: "projects_unavailable" }, { status });
+  }
+}

--- a/src/app/oauth/projects/route.ts
+++ b/src/app/oauth/projects/route.ts
@@ -1,9 +1,38 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
-import { listOAuthProjects, OAuthProjectsError } from "@/lib/oauth-projects";
+import {
+  listOAuthProjectsPage,
+  OAuthProjectsError,
+} from "@/lib/oauth-projects";
 
-export async function GET(request: NextRequest): Promise<NextResponse> {
-  const { userId, orgId, getToken } = await auth();
+export interface OAuthProjectsRouteDependencies {
+  getAuth: () => Promise<{
+    userId: string | null | undefined;
+    orgId: string | null | undefined;
+    getToken: () => Promise<string | null>;
+  }>;
+  listProjects: typeof listOAuthProjectsPage;
+}
+
+const routeDependencies: OAuthProjectsRouteDependencies = {
+  getAuth: async () => auth(),
+  listProjects: listOAuthProjectsPage,
+};
+
+function integerParameter(
+  value: string | null,
+  fallback: number,
+): number | null {
+  if (value === null) return fallback;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+export async function oauthProjectsRequest(
+  request: NextRequest,
+  dependencies: OAuthProjectsRouteDependencies = routeDependencies,
+): Promise<NextResponse> {
+  const { userId, orgId, getToken } = await dependencies.getAuth();
   if (!userId || !orgId) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
@@ -16,16 +45,43 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     );
   }
 
+  const limit = integerParameter(request.nextUrl.searchParams.get("limit"), 20);
+  const offset = integerParameter(
+    request.nextUrl.searchParams.get("offset"),
+    0,
+  );
+  if (limit === null || limit < 1 || limit > 20 || offset === null) {
+    return NextResponse.json({ error: "invalid_pagination" }, { status: 400 });
+  }
+  const query = request.nextUrl.searchParams.get("query")?.trim() || undefined;
+  if (query && query.length > 255) {
+    return NextResponse.json({ error: "invalid_query" }, { status: 400 });
+  }
+
   const token = await getToken();
   if (!token) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
   try {
-    return NextResponse.json({ projects: await listOAuthProjects(token) });
+    const page = await dependencies.listProjects({
+      clerkSessionToken: token,
+      query,
+      limit,
+      offset,
+    });
+    return NextResponse.json({
+      projects: page.projects,
+      has_more: page.hasMore,
+      next_offset: page.nextOffset,
+    });
   } catch (error) {
     const status = error instanceof OAuthProjectsError ? error.status : 500;
     console.error("[oauth/projects] failed to list projects", { error });
     return NextResponse.json({ error: "projects_unavailable" }, { status });
   }
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  return oauthProjectsRequest(request);
 }

--- a/src/app/register/route.test.ts
+++ b/src/app/register/route.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+import { registerRequest, type RegisterDependencies } from "./route";
+
+function request(body: unknown, contentType = "application/json") {
+  return new NextRequest("https://auth.example.test/register", {
+    method: "POST",
+    headers: { "Content-Type": contentType },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("POST /register", () => {
+  test("registers a public client and expands localhost redirects", async () => {
+    const createCalls: Parameters<
+      RegisterDependencies["createOAuthApplication"]
+    >[0][] = [];
+    const response = await registerRequest(
+      request({
+        client_name: "Test Client",
+        redirect_uris: ["http://localhost:58432/callback"],
+        token_endpoint_auth_method: "none",
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        scope: "openid",
+      }),
+      {
+        createOAuthApplication: async (value) => {
+          createCalls.push(value);
+          return {
+            id: "oauth_app_1",
+            clientId: "client_1",
+            clientSecret: null,
+          };
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(createCalls).toEqual([
+      {
+        name: "Test Client",
+        redirectUris: [
+          "http://localhost:58432/callback",
+          "http://127.0.0.1:58432/callback",
+        ],
+        scopes: "openid",
+        public: true,
+      },
+    ]);
+    expect(await response.json()).toMatchObject({
+      client_id: "client_1",
+      redirect_uris: ["http://localhost:58432/callback"],
+      token_endpoint_auth_method: "none",
+      grant_types: ["authorization_code", "refresh_token"],
+    });
+  });
+
+  test("rejects malformed and unsafe registrations before Clerk", async () => {
+    let called = false;
+    const deps: RegisterDependencies = {
+      createOAuthApplication: async () => {
+        called = true;
+        return { id: "unexpected", clientId: "unexpected" };
+      },
+    };
+
+    const contentType = await registerRequest(request({}, "text/plain"), deps);
+    expect(contentType.status).toBe(400);
+
+    const missingRedirect = await registerRequest(request({}), deps);
+    expect(missingRedirect.status).toBe(400);
+
+    const insecureRedirect = await registerRequest(
+      request({ redirect_uris: ["http://example.com/callback"] }),
+      deps,
+    );
+    expect(insecureRedirect.status).toBe(400);
+    expect(called).toBe(false);
+  });
+});

--- a/src/app/register/route.ts
+++ b/src/app/register/route.ts
@@ -15,7 +15,32 @@ export async function OPTIONS(): Promise<NextResponse> {
   });
 }
 
-export async function POST(request: NextRequest): Promise<NextResponse> {
+interface OAuthApplicationInput {
+  name: string;
+  redirectUris: string[];
+  scopes: string;
+  public: boolean;
+}
+
+export interface RegisterDependencies {
+  createOAuthApplication: (input: OAuthApplicationInput) => Promise<{
+    id: string;
+    clientId: string;
+    clientSecret?: string | null;
+  }>;
+}
+
+const registerDependencies: RegisterDependencies = {
+  createOAuthApplication: async (input) => {
+    const clerk = await clerkClient();
+    return clerk.oauthApplications.create(input);
+  },
+};
+
+export async function registerRequest(
+  request: NextRequest,
+  dependencies: RegisterDependencies = registerDependencies,
+): Promise<NextResponse> {
   const contentType = request.headers.get("content-type");
   if (!contentType?.includes("application/json")) {
     return NextResponse.json(
@@ -112,8 +137,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const expandedRedirectUris = expandLocalhostUris(redirect_uris);
 
     // Register the OAuth application with Clerk
-    const clerk = await clerkClient();
-    const oauthApp = await clerk.oauthApplications.create({
+    const oauthApp = await dependencies.createOAuthApplication({
       name: client_name || "MCP Client",
       redirectUris: expandedRedirectUris,
       scopes: scope ? scope : "openid",
@@ -160,4 +184,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       { status: 500 },
     );
   }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  return registerRequest(request);
 }

--- a/src/app/select-org/page.tsx
+++ b/src/app/select-org/page.tsx
@@ -487,7 +487,9 @@ function SelectOrgContent(): React.ReactElement {
             className="flex-1 bg-foreground text-background py-3 px-4 font-[250] text-sm hover:underline disabled:opacity-50 cursor-pointer"
           >
             {isSelecting
-              ? "loading..."
+              ? stage === "organization"
+                ? "loading projects..."
+                : "authorizing..."
               : stage === "organization"
                 ? "continue"
                 : "authorize"}

--- a/src/app/select-org/page.tsx
+++ b/src/app/select-org/page.tsx
@@ -294,14 +294,14 @@ function SelectOrgContent(): React.ReactElement {
           </p>
         </Col>
 
-        <div className="relative">
-          <div
-            ref={scrollContainerRef}
-            onScroll={updateScrollState}
-            className="flex flex-col gap-0 max-h-72 overflow-y-auto overscroll-y-none bg-[#faf9f2] border-[0.5px] border-[#e1dccf]"
-          >
-            {stage === "organization" ? (
-              [...memberships]
+        {stage === "organization" ? (
+          <div className="relative">
+            <div
+              ref={scrollContainerRef}
+              onScroll={updateScrollState}
+              className="flex flex-col gap-0 max-h-72 overflow-y-auto overscroll-y-none bg-[#faf9f2] border-[0.5px] border-[#e1dccf]"
+            >
+              {[...memberships]
                 .sort((a, b) => {
                   if (a.organization.id === orgId) return -1;
                   if (b.organization.id === orgId) return 1;
@@ -347,80 +347,111 @@ function SelectOrgContent(): React.ReactElement {
                       </Row>
                     </button>
                   );
-                })
-            ) : (
-              <>
-                <ScopeButton
-                  label="entire organization"
-                  detail="access every project and select projects per request"
-                  selected={selectedScope === "organization"}
-                  onClick={() => setSelectedScope("organization")}
-                />
-                {supportsProjectScope && (
-                  <div className="p-3 border-b-[0.5px] border-b-[#e1dccf] bg-[#faf9f2]">
-                    <input
-                      type="search"
-                      value={projectQuery}
-                      onChange={(event) => setProjectQuery(event.target.value)}
-                      placeholder="search projects"
-                      aria-label="search projects"
-                      className="w-full bg-transparent border-[0.5px] border-[#e1dccf] px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-foreground"
-                    />
-                  </div>
-                )}
-                {projects.map((project) => (
-                  <ScopeButton
-                    key={project.id}
-                    label={project.name}
-                    detail="access only this project"
-                    selected={selectedScope === `project:${project.id}`}
-                    onClick={() => setSelectedScope(`project:${project.id}`)}
-                  />
-                ))}
-                {supportsProjectScope &&
-                  isLoadingProjects &&
-                  projects.length === 0 && (
-                    <p className="p-4 text-xs text-muted-foreground">
-                      loading projects...
-                    </p>
-                  )}
-                {supportsProjectScope &&
-                  !isLoadingProjects &&
-                  projects.length === 0 &&
-                  !hasMoreProjects &&
-                  !projectsError && (
-                    <p className="p-4 text-xs text-muted-foreground">
-                      no projects found.
-                    </p>
-                  )}
-                {supportsProjectScope && hasMoreProjects && (
-                  <button
-                    onClick={() => {
-                      if (selectedOrgId && nextProjectOffset !== undefined) {
-                        void loadProjectsPage({
-                          organizationId: selectedOrgId,
-                          query: projectQuery,
-                          offset: nextProjectOffset,
-                          append: true,
-                        });
-                      }
-                    }}
-                    disabled={isLoadingProjects}
-                    className="w-full p-4 text-left text-sm text-foreground hover:bg-primary/5 disabled:opacity-50 cursor-pointer"
-                  >
-                    {isLoadingProjects ? "loading..." : "show more projects"}
-                  </button>
-                )}
-              </>
+                })}
+            </div>
+            {canScrollUp && (
+              <div className="absolute top-0 left-0 right-0 h-6 bg-gradient-to-b from-[#faf9f2] to-transparent pointer-events-none" />
+            )}
+            {canScrollDown && (
+              <div className="absolute bottom-0 left-0 right-0 h-6 bg-gradient-to-t from-[#faf9f2] to-transparent pointer-events-none" />
             )}
           </div>
-          {canScrollUp && (
-            <div className="absolute top-0 left-0 right-0 h-6 bg-gradient-to-b from-[#faf9f2] to-transparent pointer-events-none" />
-          )}
-          {canScrollDown && (
-            <div className="absolute bottom-0 left-0 right-0 h-6 bg-gradient-to-t from-[#faf9f2] to-transparent pointer-events-none" />
-          )}
-        </div>
+        ) : (
+          <Col className="gap-3">
+            <div className="bg-[#faf9f2] border-[0.5px] border-[#e1dccf]">
+              <ScopeButton
+                label="entire organization"
+                detail="access every project and select projects per request"
+                selected={selectedScope === "organization"}
+                onClick={() => setSelectedScope("organization")}
+              />
+            </div>
+            {supportsProjectScope && (
+              <>
+                <Row className="gap-3">
+                  <div className="h-px flex-1 bg-[#e1dccf]" />
+                  <span className="text-xs text-muted-foreground">
+                    or restrict access
+                  </span>
+                  <div className="h-px flex-1 bg-[#e1dccf]" />
+                </Row>
+                <div className="relative">
+                  <div
+                    ref={scrollContainerRef}
+                    onScroll={updateScrollState}
+                    className="flex flex-col gap-0 max-h-72 overflow-y-auto overscroll-y-none bg-[#faf9f2] border-[0.5px] border-[#e1dccf]"
+                  >
+                    <div className="p-3 border-b-[0.5px] border-b-[#e1dccf] bg-[#faf9f2]">
+                      <input
+                        type="search"
+                        value={projectQuery}
+                        onChange={(event) =>
+                          setProjectQuery(event.target.value)
+                        }
+                        placeholder="search projects"
+                        aria-label="search projects"
+                        className="w-full bg-transparent border-[0.5px] border-[#e1dccf] px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-foreground"
+                      />
+                    </div>
+                    {projects.map((project) => (
+                      <ScopeButton
+                        key={project.id}
+                        label={project.name}
+                        detail="access only this project"
+                        selected={selectedScope === `project:${project.id}`}
+                        onClick={() =>
+                          setSelectedScope(`project:${project.id}`)
+                        }
+                      />
+                    ))}
+                    {isLoadingProjects && projects.length === 0 && (
+                      <p className="p-4 text-xs text-muted-foreground">
+                        loading projects...
+                      </p>
+                    )}
+                    {!isLoadingProjects &&
+                      projects.length === 0 &&
+                      !hasMoreProjects &&
+                      !projectsError && (
+                        <p className="p-4 text-xs text-muted-foreground">
+                          no projects found.
+                        </p>
+                      )}
+                    {hasMoreProjects && (
+                      <button
+                        onClick={() => {
+                          if (
+                            selectedOrgId &&
+                            nextProjectOffset !== undefined
+                          ) {
+                            void loadProjectsPage({
+                              organizationId: selectedOrgId,
+                              query: projectQuery,
+                              offset: nextProjectOffset,
+                              append: true,
+                            });
+                          }
+                        }}
+                        disabled={isLoadingProjects}
+                        className="w-full p-4 text-left text-sm text-foreground hover:bg-primary/5 disabled:opacity-50 cursor-pointer"
+                      >
+                        {isLoadingProjects
+                          ? "loading..."
+                          : "show more projects"}
+                      </button>
+                    )}
+                  </div>
+                  {canScrollUp && (
+                    <div className="absolute top-0 left-0 right-0 h-6 bg-gradient-to-b from-[#faf9f2] to-transparent pointer-events-none" />
+                  )}
+                  {canScrollDown && (
+                    <div className="absolute bottom-0 left-0 right-0 h-6 bg-gradient-to-t from-[#faf9f2] to-transparent pointer-events-none" />
+                  )}
+                </div>
+              </>
+            )}
+          </Col>
+        )}
 
         {selectionError && (
           <p className="text-xs text-muted-foreground">{selectionError}</p>

--- a/src/app/select-org/page.tsx
+++ b/src/app/select-org/page.tsx
@@ -8,7 +8,7 @@ import {
   useUser,
 } from "@clerk/nextjs";
 import { useSearchParams, useRouter } from "next/navigation";
-import { useState, Suspense, useEffect, useRef } from "react";
+import { useState, Suspense, useCallback, useEffect, useRef } from "react";
 import { Col } from "@/components/col";
 import { Row } from "@/components/row";
 import { LoadingState } from "@/components/spinner/loading-state";
@@ -35,12 +35,18 @@ function SelectOrgContent(): React.ReactElement {
     orgId || null,
   );
   const [projects, setProjects] = useState<OAuthProject[]>([]);
+  const [projectQuery, setProjectQuery] = useState("");
+  const [hasMoreProjects, setHasMoreProjects] = useState(false);
+  const [nextProjectOffset, setNextProjectOffset] = useState<number>();
+  const [isLoadingProjects, setIsLoadingProjects] = useState(false);
   const [selectedScope, setSelectedScope] = useState("organization");
   const [projectsError, setProjectsError] = useState(false);
   const [selectionError, setSelectionError] = useState<string | null>(null);
   const [canScrollUp, setCanScrollUp] = useState(false);
   const [canScrollDown, setCanScrollDown] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const projectRequestRef = useRef(0);
+  const lastLoadedProjectQueryRef = useRef("");
   const supportsProjectScope =
     searchParams.get("code_challenge_method") === "S256" &&
     Boolean(searchParams.get("code_challenge"));
@@ -71,6 +77,88 @@ function SelectOrgContent(): React.ReactElement {
     updateScrollState();
   }, [userMemberships?.data, projects, stage]);
 
+  const loadProjectsPage = useCallback(
+    async ({
+      organizationId,
+      query,
+      offset,
+      append,
+    }: {
+      organizationId: string;
+      query: string;
+      offset: number;
+      append: boolean;
+    }): Promise<void> => {
+      const requestId = ++projectRequestRef.current;
+      setIsLoadingProjects(true);
+      setProjectsError(false);
+
+      try {
+        const params = new URLSearchParams({
+          org_id: organizationId,
+          limit: "20",
+          offset: String(offset),
+        });
+        if (query) params.set("query", query);
+        const response = await fetch(`/oauth/projects?${params.toString()}`, {
+          cache: "no-store",
+        });
+        if (!response.ok) throw new Error("failed to load projects");
+        const body = (await response.json()) as {
+          projects: OAuthProject[];
+          has_more: boolean;
+          next_offset?: number;
+        };
+        if (requestId !== projectRequestRef.current) return;
+
+        setProjects((current) =>
+          append ? [...current, ...body.projects] : body.projects,
+        );
+        setHasMoreProjects(body.has_more);
+        setNextProjectOffset(body.next_offset);
+        lastLoadedProjectQueryRef.current = query;
+      } catch (error) {
+        if (requestId !== projectRequestRef.current) return;
+        console.error("Failed to load projects:", error);
+        if (!append) setProjects([]);
+        setProjectsError(true);
+      } finally {
+        if (requestId === projectRequestRef.current) {
+          setIsLoadingProjects(false);
+        }
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (
+      stage !== "scope" ||
+      !supportsProjectScope ||
+      !selectedOrgId ||
+      projectQuery === lastLoadedProjectQueryRef.current
+    ) {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      setSelectedScope("organization");
+      void loadProjectsPage({
+        organizationId: selectedOrgId,
+        query: projectQuery,
+        offset: 0,
+        append: false,
+      });
+    }, 250);
+    return () => clearTimeout(timeout);
+  }, [
+    loadProjectsPage,
+    projectQuery,
+    selectedOrgId,
+    stage,
+    supportsProjectScope,
+  ]);
+
   const handleOrgConfirm = async (): Promise<void> => {
     if (!setActive || isSelecting || !selectedOrgId) return;
     setIsSelecting(true);
@@ -86,22 +174,19 @@ function SelectOrgContent(): React.ReactElement {
       return;
     }
 
-    try {
-      if (supportsProjectScope) {
-        const response = await fetch(
-          `/oauth/projects?org_id=${encodeURIComponent(selectedOrgId)}`,
-          { cache: "no-store" },
-        );
-        if (!response.ok) throw new Error("failed to load projects");
-        const body = (await response.json()) as { projects: OAuthProject[] };
-        setProjects(body.projects);
-      } else {
-        setProjects([]);
-      }
-    } catch (error) {
-      console.error("Failed to load projects:", error);
+    setProjectQuery("");
+    lastLoadedProjectQueryRef.current = "";
+    if (supportsProjectScope) {
+      await loadProjectsPage({
+        organizationId: selectedOrgId,
+        query: "",
+        offset: 0,
+        append: false,
+      });
+    } else {
       setProjects([]);
-      setProjectsError(true);
+      setHasMoreProjects(false);
+      setNextProjectOffset(undefined);
     }
 
     setSelectedScope("organization");
@@ -266,6 +351,18 @@ function SelectOrgContent(): React.ReactElement {
                   selected={selectedScope === "organization"}
                   onClick={() => setSelectedScope("organization")}
                 />
+                {supportsProjectScope && (
+                  <div className="p-3 border-b-[0.5px] border-b-[#e1dccf] bg-[#faf9f2]">
+                    <input
+                      type="search"
+                      value={projectQuery}
+                      onChange={(event) => setProjectQuery(event.target.value)}
+                      placeholder="search projects"
+                      aria-label="search projects"
+                      className="w-full bg-transparent border-[0.5px] border-[#e1dccf] px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-foreground"
+                    />
+                  </div>
+                )}
                 {projects.map((project) => (
                   <ScopeButton
                     key={project.id}
@@ -275,6 +372,39 @@ function SelectOrgContent(): React.ReactElement {
                     onClick={() => setSelectedScope(`project:${project.id}`)}
                   />
                 ))}
+                {supportsProjectScope &&
+                  isLoadingProjects &&
+                  projects.length === 0 && (
+                    <p className="p-4 text-xs text-muted-foreground">
+                      loading projects...
+                    </p>
+                  )}
+                {supportsProjectScope &&
+                  !isLoadingProjects &&
+                  projects.length === 0 &&
+                  !projectsError && (
+                    <p className="p-4 text-xs text-muted-foreground">
+                      no projects found.
+                    </p>
+                  )}
+                {supportsProjectScope && hasMoreProjects && (
+                  <button
+                    onClick={() => {
+                      if (selectedOrgId && nextProjectOffset !== undefined) {
+                        void loadProjectsPage({
+                          organizationId: selectedOrgId,
+                          query: projectQuery,
+                          offset: nextProjectOffset,
+                          append: true,
+                        });
+                      }
+                    }}
+                    disabled={isLoadingProjects}
+                    className="w-full p-4 text-left text-sm text-foreground hover:bg-primary/5 disabled:opacity-50 cursor-pointer"
+                  >
+                    {isLoadingProjects ? "loading..." : "show more projects"}
+                  </button>
+                )}
               </>
             )}
           </div>

--- a/src/app/select-org/page.tsx
+++ b/src/app/select-org/page.tsx
@@ -1,126 +1,170 @@
-'use client';
+"use client";
 
-import { useAuth, useOrganizationList, useUser, CreateOrganization, UserButton } from '@clerk/nextjs';
-import { useSearchParams, useRouter } from 'next/navigation';
-import { useState, Suspense, useEffect, useRef } from 'react';
-import { Col } from '@/components/col'
-import { Row } from '@/components/row'
-import { LoadingState } from '@/components/spinner/loading-state';
-import { KernelWordmark } from '@/components/icons';
+import {
+  CreateOrganization,
+  UserButton,
+  useAuth,
+  useOrganizationList,
+  useUser,
+} from "@clerk/nextjs";
+import { useSearchParams, useRouter } from "next/navigation";
+import { useState, Suspense, useEffect, useRef } from "react";
+import { Col } from "@/components/col";
+import { Row } from "@/components/row";
+import { LoadingState } from "@/components/spinner/loading-state";
+import { KernelWordmark } from "@/components/icons";
+
+interface OAuthProject {
+  id: string;
+  name: string;
+}
+
+type SelectionStage = "organization" | "scope";
 
 function SelectOrgContent(): React.ReactElement {
   const { isLoaded, setActive, userMemberships } = useOrganizationList({
-    userMemberships: {
-      infinite: true,
-      pageSize: 100,
-    },
+    userMemberships: { infinite: true, pageSize: 100 },
   });
+  const { orgId } = useAuth();
+  const { user } = useUser();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const [stage, setStage] = useState<SelectionStage>("organization");
+  const [isSelecting, setIsSelecting] = useState(false);
+  const [selectedOrgId, setSelectedOrgId] = useState<string | null>(
+    orgId || null,
+  );
+  const [projects, setProjects] = useState<OAuthProject[]>([]);
+  const [selectedScope, setSelectedScope] = useState("organization");
+  const [projectsError, setProjectsError] = useState(false);
+  const [selectionError, setSelectionError] = useState<string | null>(null);
+  const [canScrollUp, setCanScrollUp] = useState(false);
+  const [canScrollDown, setCanScrollDown] = useState(false);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const supportsProjectScope =
+    searchParams.get("code_challenge_method") === "S256" &&
+    Boolean(searchParams.get("code_challenge"));
 
   useEffect(() => {
     if (userMemberships?.hasNextPage && !userMemberships.isFetching) {
       userMemberships.fetchNext?.();
     }
   }, [userMemberships?.hasNextPage, userMemberships?.isFetching]);
-  const { orgId } = useAuth();
-  const { user } = useUser();
-  const searchParams = useSearchParams();
-  const router = useRouter();
-  const [isSelecting, setIsSelecting] = useState(false);
-  const [selectedOrgId, setSelectedOrgId] = useState<string | null>(orgId || null);
-  const [canScrollUp, setCanScrollUp] = useState(false);
-  const [canScrollDown, setCanScrollDown] = useState(false);
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
 
-  // Check if we just returned from org creation and reload to get fresh data
   useEffect(() => {
-    if (searchParams.get('org_created') === 'true') {
-      // Remove the flag from URL and reload to get fresh organization data
+    if (searchParams.get("org_created") === "true") {
       const newUrl = new URL(window.location.href);
-      newUrl.searchParams.delete('org_created');
+      newUrl.searchParams.delete("org_created");
       window.location.href = newUrl.toString();
     }
   }, [searchParams]);
 
-  // Check scroll state
   const updateScrollState = (): void => {
     const container = scrollContainerRef.current;
     if (!container) return;
-
     const { scrollTop, scrollHeight, clientHeight } = container;
     setCanScrollUp(scrollTop > 0);
     setCanScrollDown(scrollTop < scrollHeight - clientHeight);
   };
 
-  // Update scroll state when content changes
   useEffect(() => {
     updateScrollState();
-  }, [userMemberships?.data]);
+  }, [userMemberships?.data, projects, stage]);
 
-  // Get the original OAuth parameters from the URL
-  const originalParams = {
-    client_id: searchParams.get('client_id'),
-    redirect_uri: searchParams.get('redirect_uri'),
-    response_type: searchParams.get('response_type'),
-    scope: searchParams.get('scope'),
-    state: searchParams.get('state'),
-    code_challenge: searchParams.get('code_challenge'),
-    code_challenge_method: searchParams.get('code_challenge_method'),
-  };
-
-  const handleOrgSelect = (organizationId: string): void => {
-    setSelectedOrgId(organizationId);
-  };
-
-  const handleConfirm = async (): Promise<void> => {
+  const handleOrgConfirm = async (): Promise<void> => {
     if (!setActive || isSelecting || !selectedOrgId) return;
-
     setIsSelecting(true);
+    setProjectsError(false);
+    setSelectionError(null);
 
     try {
       await setActive({ organization: selectedOrgId });
-
-      // After setting active org, redirect back to authorize
-      const authorizeUrl = new URL('/authorize', window.location.origin);
-
-      // Add all original OAuth parameters
-      Object.entries(originalParams).forEach(([key, value]) => {
-        if (value) authorizeUrl.searchParams.set(key, value);
-      });
-
-      // Add the selected orgId as a parameter
-      authorizeUrl.searchParams.set('org_id', selectedOrgId);
-
-      router.push(authorizeUrl.toString());
     } catch (error) {
-      console.error('Failed to set active organization:', error);
+      console.error("Failed to select organization:", error);
+      setSelectionError("organization selection failed. please try again.");
       setIsSelecting(false);
+      return;
     }
+
+    try {
+      if (supportsProjectScope) {
+        const response = await fetch(
+          `/oauth/projects?org_id=${encodeURIComponent(selectedOrgId)}`,
+          { cache: "no-store" },
+        );
+        if (!response.ok) throw new Error("failed to load projects");
+        const body = (await response.json()) as { projects: OAuthProject[] };
+        setProjects(body.projects);
+      } else {
+        setProjects([]);
+      }
+    } catch (error) {
+      console.error("Failed to load projects:", error);
+      setProjects([]);
+      setProjectsError(true);
+    }
+
+    setSelectedScope("organization");
+    setStage("scope");
+    setIsSelecting(false);
+  };
+
+  const handleAuthorize = (): void => {
+    if (!selectedOrgId || isSelecting) return;
+    setIsSelecting(true);
+
+    const authorizeUrl = new URL("/authorize", window.location.origin);
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("org_created");
+    params.delete("org_id");
+    params.delete("access_scope");
+    params.delete("project_id");
+    params.forEach((value, key) => authorizeUrl.searchParams.set(key, value));
+    authorizeUrl.searchParams.set("org_id", selectedOrgId);
+
+    if (selectedScope.startsWith("project:")) {
+      authorizeUrl.searchParams.set("access_scope", "project");
+      authorizeUrl.searchParams.set(
+        "project_id",
+        selectedScope.slice("project:".length),
+      );
+    } else {
+      authorizeUrl.searchParams.set("access_scope", "organization");
+    }
+
+    router.push(authorizeUrl.toString());
   };
 
   if (!isLoaded || userMemberships?.isLoading) {
     return (
       <Col className="min-h-screen items-center justify-center">
         <LoadingState>
-          <p className="text-muted-foreground text-sm">loading your organizations...</p>
+          <p className="text-muted-foreground text-sm">
+            loading your organizations...
+          </p>
         </LoadingState>
       </Col>
     );
   }
 
-  // Check if user has any organizations (only after loaded)
-  if (isLoaded && !userMemberships?.isLoading && (!userMemberships?.data || userMemberships.data.length === 0)) {
+  const memberships =
+    userMemberships?.data || user?.organizationMemberships || [];
+
+  if (!memberships.length) {
     return (
       <Col className="min-h-screen items-center justify-center">
-        {/* User button in top-right corner */}
         <div className="absolute top-6 right-6">
           <UserButton
             afterSignOutUrl={`/select-org?${searchParams.toString()}`}
           />
         </div>
-
         <Col className="text-center max-w-md mx-auto p-8 gap-8">
           <Col className="items-center gap-4">
-            <KernelWordmark className="text-foreground" width={100} height={22} />
+            <KernelWordmark
+              className="text-foreground"
+              width={100}
+              height={22}
+            />
             <p className="text-muted-foreground text-sm">
               you need to be a member of at least one organization to continue.
             </p>
@@ -128,7 +172,7 @@ function SelectOrgContent(): React.ReactElement {
           <CreateOrganization
             afterCreateOrganizationUrl={(() => {
               const params = new URLSearchParams(searchParams.toString());
-              params.set('org_created', 'true');
+              params.set("org_created", "true");
               return `/select-org?${params.toString()}`;
             })()}
             skipInvitationScreen={true}
@@ -138,9 +182,12 @@ function SelectOrgContent(): React.ReactElement {
     );
   }
 
+  const selectedOrg = memberships.find(
+    (membership) => membership.organization.id === selectedOrgId,
+  )?.organization;
+
   return (
     <Col className="min-h-screen items-center justify-center">
-      {/* User button in top-right corner */}
       <div className="absolute top-6 right-6">
         <UserButton
           afterSignOutUrl={`/select-org?${searchParams.toString()}`}
@@ -151,7 +198,9 @@ function SelectOrgContent(): React.ReactElement {
         <Col className="items-center gap-3">
           <KernelWordmark className="text-foreground" width={100} height={22} />
           <p className="text-muted-foreground text-sm">
-            select an organization to authorize access.
+            {stage === "organization"
+              ? "select an organization to authorize access."
+              : `choose access for ${selectedOrg?.name || "this organization"}.`}
           </p>
         </Col>
 
@@ -159,58 +208,76 @@ function SelectOrgContent(): React.ReactElement {
           <div
             ref={scrollContainerRef}
             onScroll={updateScrollState}
-            className="flex flex-col gap-0 max-h-64 overflow-y-auto overscroll-y-none bg-[#faf9f2] border-[0.5px] border-[#e1dccf]"
+            className="flex flex-col gap-0 max-h-72 overflow-y-auto overscroll-y-none bg-[#faf9f2] border-[0.5px] border-[#e1dccf]"
           >
-            {(userMemberships?.data || user?.organizationMemberships)
-              ?.sort((a, b) => {
-                // Put the currently active org first
-                if (a.organization.id === orgId) return -1;
-                if (b.organization.id === orgId) return 1;
-                return 0;
-              })
-              ?.map((membership, index, arr) => {
-              const isSelected = membership.organization.id === selectedOrgId;
-              const isCurrentlyActive = membership.organization.id === orgId;
-              const isLast = index === arr.length - 1;
-              return (
-                <button
-                  key={membership.organization.id}
-                  onClick={() => handleOrgSelect(membership.organization.id)}
-                  disabled={isSelecting}
-                  className={`w-full p-4 text-left transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${
-                    !isLast ? 'border-b-[0.5px] border-b-[#e1dccf]' : ''
-                  } ${
-                    isSelected
-                      ? 'bg-primary/10'
-                      : 'bg-[#faf9f2] hover:bg-primary/5'
-                  }`}
-                >
-                  <Row className="gap-3">
-                    {membership.organization.imageUrl && (
-                      <img
-                        src={membership.organization.imageUrl}
-                        alt={membership.organization.name}
-                        className="w-10 h-10"
-                      />
-                    )}
-                    <Col className="flex-1 gap-1">
-                      <Row className="justify-between items-center">
-                        <span className="font-light text-sm text-foreground">{membership.organization.name}</span>
-                        {isCurrentlyActive && (
-                          <span className="text-[10px] font-[350] uppercase tracking-normal border-[0.5px] border-foreground px-2 py-0.5">
-                            active
-                          </span>
+            {stage === "organization" ? (
+              [...memberships]
+                .sort((a, b) => {
+                  if (a.organization.id === orgId) return -1;
+                  if (b.organization.id === orgId) return 1;
+                  return 0;
+                })
+                .map((membership, index, arr) => {
+                  const organization = membership.organization;
+                  const isSelected = organization.id === selectedOrgId;
+                  return (
+                    <button
+                      key={organization.id}
+                      onClick={() => setSelectedOrgId(organization.id)}
+                      disabled={isSelecting}
+                      className={`w-full p-4 text-left transition-colors cursor-pointer disabled:opacity-50 ${
+                        index < arr.length - 1
+                          ? "border-b-[0.5px] border-b-[#e1dccf]"
+                          : ""
+                      } ${isSelected ? "bg-primary/10" : "bg-[#faf9f2] hover:bg-primary/5"}`}
+                    >
+                      <Row className="gap-3">
+                        {organization.imageUrl && (
+                          <img
+                            src={organization.imageUrl}
+                            alt={organization.name}
+                            className="w-10 h-10"
+                          />
                         )}
+                        <Col className="flex-1 gap-1">
+                          <Row className="justify-between items-center">
+                            <span className="font-light text-sm text-foreground">
+                              {organization.name}
+                            </span>
+                            {organization.id === orgId && (
+                              <span className="text-[10px] font-[350] uppercase border-[0.5px] border-foreground px-2 py-0.5">
+                                active
+                              </span>
+                            )}
+                          </Row>
+                          <span className="text-xs text-muted-foreground">
+                            {organization.slug}
+                          </span>
+                        </Col>
                       </Row>
-                      <span className="text-xs text-muted-foreground">{membership.organization.slug}</span>
-                    </Col>
-                  </Row>
-                </button>
-              );
-            })}
+                    </button>
+                  );
+                })
+            ) : (
+              <>
+                <ScopeButton
+                  label="entire organization"
+                  detail="access every project and select projects per request"
+                  selected={selectedScope === "organization"}
+                  onClick={() => setSelectedScope("organization")}
+                />
+                {projects.map((project) => (
+                  <ScopeButton
+                    key={project.id}
+                    label={project.name}
+                    detail="access only this project"
+                    selected={selectedScope === `project:${project.id}`}
+                    onClick={() => setSelectedScope(`project:${project.id}`)}
+                  />
+                ))}
+              </>
+            )}
           </div>
-
-          {/* Fade overlays to indicate scrollability */}
           {canScrollUp && (
             <div className="absolute top-0 left-0 right-0 h-6 bg-gradient-to-b from-[#faf9f2] to-transparent pointer-events-none" />
           )}
@@ -219,20 +286,74 @@ function SelectOrgContent(): React.ReactElement {
           )}
         </div>
 
-        <button
-          onClick={handleConfirm}
-          disabled={isSelecting || !selectedOrgId}
-          className="w-full bg-foreground text-background py-3 px-4 font-[250] text-sm hover:underline hover:decoration-[0.5px] hover:underline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer transition-opacity"
-        >
-          {isSelecting ? (
-            <Row className="items-center justify-center gap-2">
-              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-background"></div>
-              authorizing...
-            </Row>
-          ) : 'continue'}
-        </button>
+        {selectionError && (
+          <p className="text-xs text-muted-foreground">{selectionError}</p>
+        )}
+        {stage === "scope" && projectsError && (
+          <p className="text-xs text-muted-foreground">
+            projects could not be loaded. organization-wide access is still
+            available.
+          </p>
+        )}
+        {stage === "scope" && !supportsProjectScope && (
+          <p className="text-xs text-muted-foreground">
+            this client does not support PKCE, so project-scoped access is
+            unavailable.
+          </p>
+        )}
+
+        <Row className="gap-3">
+          {stage === "scope" && (
+            <button
+              onClick={() => setStage("organization")}
+              disabled={isSelecting}
+              className="border-[0.5px] border-foreground py-3 px-4 text-sm disabled:opacity-50 cursor-pointer"
+            >
+              back
+            </button>
+          )}
+          <button
+            onClick={
+              stage === "organization" ? handleOrgConfirm : handleAuthorize
+            }
+            disabled={isSelecting || !selectedOrgId}
+            className="flex-1 bg-foreground text-background py-3 px-4 font-[250] text-sm hover:underline disabled:opacity-50 cursor-pointer"
+          >
+            {isSelecting
+              ? "loading..."
+              : stage === "organization"
+                ? "continue"
+                : "authorize"}
+          </button>
+        </Row>
       </Col>
     </Col>
+  );
+}
+
+function ScopeButton({
+  label,
+  detail,
+  selected,
+  onClick,
+}: {
+  label: string;
+  detail: string;
+  selected: boolean;
+  onClick: () => void;
+}): React.ReactElement {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full p-4 text-left border-b-[0.5px] last:border-b-0 border-b-[#e1dccf] cursor-pointer ${
+        selected ? "bg-primary/10" : "bg-[#faf9f2] hover:bg-primary/5"
+      }`}
+    >
+      <Col className="gap-1">
+        <span className="font-light text-sm text-foreground">{label}</span>
+        <span className="text-xs text-muted-foreground">{detail}</span>
+      </Col>
+    </button>
   );
 }
 

--- a/src/app/select-org/page.tsx
+++ b/src/app/select-org/page.tsx
@@ -147,7 +147,6 @@ function SelectOrgContent(): React.ReactElement {
     }
 
     const timeout = setTimeout(() => {
-      setSelectedScope("organization");
       void loadProjectsPage({
         organizationId: selectedOrgId,
         query: projectQuery,
@@ -200,7 +199,7 @@ function SelectOrgContent(): React.ReactElement {
   };
 
   const handleAuthorize = (): void => {
-    if (!selectedOrgId || isSelecting) return;
+    if (!selectedOrgId || !selectedScope || isSelecting) return;
     setIsSelecting(true);
 
     const authorizeUrl = new URL("/authorize", window.location.origin);
@@ -385,9 +384,10 @@ function SelectOrgContent(): React.ReactElement {
                       <input
                         type="search"
                         value={projectQuery}
-                        onChange={(event) =>
-                          setProjectQuery(event.target.value)
-                        }
+                        onChange={(event) => {
+                          setProjectQuery(event.target.value);
+                          setSelectedScope("");
+                        }}
                         placeholder="search projects"
                         aria-label="search projects"
                         className="w-full bg-transparent border-[0.5px] border-[#e1dccf] px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-foreground"
@@ -483,7 +483,11 @@ function SelectOrgContent(): React.ReactElement {
             onClick={
               stage === "organization" ? handleOrgConfirm : handleAuthorize
             }
-            disabled={isSelecting || !selectedOrgId}
+            disabled={
+              isSelecting ||
+              !selectedOrgId ||
+              (stage === "scope" && !selectedScope)
+            }
             className="flex-1 bg-foreground text-background py-3 px-4 font-[250] text-sm hover:underline disabled:opacity-50 cursor-pointer"
           >
             {isSelecting

--- a/src/app/select-org/page.tsx
+++ b/src/app/select-org/page.tsx
@@ -46,7 +46,7 @@ function SelectOrgContent(): React.ReactElement {
   const [canScrollDown, setCanScrollDown] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const projectRequestRef = useRef(0);
-  const lastLoadedProjectQueryRef = useRef("");
+  const lastLoadedProjectQueryRef = useRef<string | null>(null);
   const supportsProjectScope =
     searchParams.get("code_challenge_method") === "S256" &&
     Boolean(searchParams.get("code_challenge"));
@@ -120,7 +120,12 @@ function SelectOrgContent(): React.ReactElement {
       } catch (error) {
         if (requestId !== projectRequestRef.current) return;
         console.error("Failed to load projects:", error);
-        if (!append) setProjects([]);
+        if (!append) {
+          setProjects([]);
+          setHasMoreProjects(false);
+          setNextProjectOffset(undefined);
+          lastLoadedProjectQueryRef.current = null;
+        }
         setProjectsError(true);
       } finally {
         if (requestId === projectRequestRef.current) {
@@ -175,7 +180,7 @@ function SelectOrgContent(): React.ReactElement {
     }
 
     setProjectQuery("");
-    lastLoadedProjectQueryRef.current = "";
+    lastLoadedProjectQueryRef.current = null;
     if (supportsProjectScope) {
       await loadProjectsPage({
         organizationId: selectedOrgId,
@@ -382,6 +387,7 @@ function SelectOrgContent(): React.ReactElement {
                 {supportsProjectScope &&
                   !isLoadingProjects &&
                   projects.length === 0 &&
+                  !hasMoreProjects &&
                   !projectsError && (
                     <p className="p-4 text-xs text-muted-foreground">
                       no projects found.

--- a/src/app/token/route.test.ts
+++ b/src/app/token/route.test.ts
@@ -30,6 +30,7 @@ function dependencies({
   subject = "user_1",
   member = true,
   clerkStatus = 200,
+  membershipError,
   clerkTokens = {
     access_token: "clerk-access",
     id_token: "header.payload.signature",
@@ -44,15 +45,15 @@ function dependencies({
   subject?: string;
   member?: boolean;
   clerkStatus?: number;
+  membershipError?: Error;
   clerkTokens?: Record<string, unknown>;
 } = {}) {
   const calls = {
     resolve: [] as Parameters<TokenDependencies["resolveContext"]>[0][],
     exchanges: [] as URLSearchParams[],
-    jwt: [] as Parameters<TokenDependencies["setJwtContext"]>[0][],
-    refresh: [] as Parameters<TokenDependencies["setRefreshContext"]>[0][],
-    rotate: [] as Parameters<TokenDependencies["rotateRefreshContext"]>[0][],
-    deleted: [] as Parameters<TokenDependencies["deleteRequestContext"]>[0][],
+    verifications: [] as string[],
+    memberships: [] as Array<{ clerkUserId: string; clerkOrgId: string }>,
+    persisted: [] as Parameters<TokenDependencies["persistContexts"]>[0][],
   };
 
   return {
@@ -73,19 +74,17 @@ function dependencies({
         );
         return Response.json(clerkTokens, { status: clerkStatus });
       },
-      verify: async () => ({ sub: subject }),
-      hasMembership: async () => member,
-      setJwtContext: async (value) => {
-        calls.jwt.push(value);
+      verify: async (token) => {
+        calls.verifications.push(token);
+        return { sub: subject };
       },
-      setRefreshContext: async (value) => {
-        calls.refresh.push(value);
+      hasMembership: async (clerkUserId, clerkOrgId) => {
+        calls.memberships.push({ clerkUserId, clerkOrgId });
+        if (membershipError) throw membershipError;
+        return member;
       },
-      rotateRefreshContext: async (value) => {
-        calls.rotate.push(value);
-      },
-      deleteRequestContext: async (value) => {
-        calls.deleted.push(value);
+      persistContexts: async (value) => {
+        calls.persisted.push(value);
       },
     } satisfies TokenDependencies,
   };
@@ -103,6 +102,7 @@ describe("POST /token", () => {
         org_id: "forged-org",
         access_scope: "project",
         project_id: "forged-project",
+        refresh_token: "unrelated-refresh",
       }),
       deps.value,
     );
@@ -114,14 +114,23 @@ describe("POST /token", () => {
       org_id: "org_1",
       access_scope: "organization",
     });
-    expect(deps.calls.jwt).toHaveLength(1);
-    expect(deps.calls.refresh).toHaveLength(1);
-    expect(deps.calls.deleted).toEqual([
-      { clientId: "client_1", codeChallenge: "derived-challenge" },
+    expect(deps.calls.persisted).toEqual([
+      expect.objectContaining({
+        jwt: "header.payload.signature",
+        newRefreshToken: "refresh-new",
+        authorizationContext: expect.objectContaining({
+          access_scope: "organization",
+        }),
+        consumedRequest: {
+          clientId: "client_1",
+          codeChallenge: "derived-challenge",
+        },
+      }),
     ]);
     expect(deps.calls.exchanges[0].has("org_id")).toBe(false);
     expect(deps.calls.exchanges[0].has("project_id")).toBe(false);
     expect(deps.calls.exchanges[0].has("access_scope")).toBe(false);
+    expect(deps.calls.persisted[0]).not.toHaveProperty("oldRefreshToken");
   });
 
   test("returns the server-bound project scope", async () => {
@@ -175,7 +184,7 @@ describe("POST /token", () => {
       clientId: "cli_prod",
       refreshToken: "refresh-old",
     });
-    expect(deps.calls.rotate).toEqual([
+    expect(deps.calls.persisted).toEqual([
       expect.objectContaining({
         oldRefreshToken: "refresh-old",
         newRefreshToken: "refresh-new",
@@ -185,8 +194,53 @@ describe("POST /token", () => {
         }),
       }),
     ]);
+    expect(deps.calls.memberships).toEqual([
+      { clerkUserId: "user_1", clerkOrgId: "org_1" },
+    ]);
+    expect(deps.calls.verifications).toHaveLength(0);
     expect(deps.calls.exchanges[0].has("org_id")).toBe(false);
     expect(deps.calls.exchanges[0].has("project_id")).toBe(false);
+  });
+
+  test("checks refresh membership before asking Clerk to rotate", async () => {
+    const deps = dependencies({
+      membershipError: new Error("clerk unavailable"),
+    });
+    const response = await tokenRequest(
+      request({
+        grant_type: "refresh_token",
+        client_id: "client_1",
+        refresh_token: "refresh-old",
+      }),
+      deps.value,
+    );
+
+    expect(response.status).toBe(500);
+    expect(deps.calls.exchanges).toHaveLength(0);
+    expect(deps.calls.persisted).toHaveLength(0);
+  });
+
+  test("keeps post-exchange validation for legacy refresh context", async () => {
+    const deps = dependencies({
+      authorizationContext: organizationAuthorizationContext({
+        clerkOrgId: "org_1",
+      }),
+    });
+    const response = await tokenRequest(
+      request({
+        grant_type: "refresh_token",
+        client_id: "client_1",
+        refresh_token: "refresh-old",
+      }),
+      deps.value,
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.calls.exchanges).toHaveLength(1);
+    expect(deps.calls.verifications).toEqual(["header.payload.signature"]);
+    expect(deps.calls.memberships).toEqual([
+      { clerkUserId: "user_1", clerkOrgId: "org_1" },
+    ]);
   });
 
   test("fails closed on subject and membership mismatches", async () => {
@@ -201,7 +255,7 @@ describe("POST /token", () => {
       wrongSubject.value,
     );
     expect(subjectResponse.status).toBe(400);
-    expect(wrongSubject.calls.jwt).toHaveLength(0);
+    expect(wrongSubject.calls.persisted).toHaveLength(0);
 
     const removedMember = dependencies({ member: false });
     const memberResponse = await tokenRequest(
@@ -213,7 +267,8 @@ describe("POST /token", () => {
       removedMember.value,
     );
     expect(memberResponse.status).toBe(400);
-    expect(removedMember.calls.rotate).toHaveLength(0);
+    expect(removedMember.calls.exchanges).toHaveLength(0);
+    expect(removedMember.calls.persisted).toHaveLength(0);
   });
 
   test("does not persist partial context when provider response is invalid", async () => {
@@ -228,7 +283,7 @@ describe("POST /token", () => {
       providerFailure.value,
     );
     expect(failedResponse.status).toBe(400);
-    expect(providerFailure.calls.jwt).toHaveLength(0);
+    expect(providerFailure.calls.persisted).toHaveLength(0);
 
     const missingRefresh = dependencies({
       clerkTokens: {
@@ -248,6 +303,6 @@ describe("POST /token", () => {
       missingRefresh.value,
     );
     expect(missingRefreshResponse.status).toBe(400);
-    expect(missingRefresh.calls.jwt).toHaveLength(0);
+    expect(missingRefresh.calls.persisted).toHaveLength(0);
   });
 });

--- a/src/app/token/route.test.ts
+++ b/src/app/token/route.test.ts
@@ -241,6 +241,11 @@ describe("POST /token", () => {
     expect(deps.calls.memberships).toEqual([
       { clerkUserId: "user_1", clerkOrgId: "org_1" },
     ]);
+    expect(deps.calls.persisted[0].authorizationContext).toMatchObject({
+      clerk_user_id: "user_1",
+      clerk_org_id: "org_1",
+      access_scope: "organization",
+    });
   });
 
   test("fails closed on subject and membership mismatches", async () => {

--- a/src/app/token/route.test.ts
+++ b/src/app/token/route.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+import type { TokenDependencies } from "./route";
+import {
+  organizationAuthorizationContext,
+  projectAuthorizationContext,
+} from "@/lib/oauth-context";
+
+process.env.KERNEL_CLI_PROD_CLIENT_ID ??= "cli_prod";
+process.env.KERNEL_CLI_STAGING_CLIENT_ID ??= "cli_staging";
+process.env.KERNEL_CLI_DEV_CLIENT_ID ??= "cli_dev";
+process.env.NEXT_PUBLIC_CLERK_DOMAIN ??= "clerk.example.test";
+process.env.CLERK_SECRET_KEY ??= "clerk-secret";
+
+const { tokenRequest } = await import("./route");
+
+function request(values: Record<string, string>) {
+  return new NextRequest("https://auth.example.test/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(values),
+  });
+}
+
+function dependencies({
+  authorizationContext = organizationAuthorizationContext({
+    clerkUserId: "user_1",
+    clerkOrgId: "org_1",
+  }),
+  subject = "user_1",
+  member = true,
+  clerkStatus = 200,
+  clerkTokens = {
+    access_token: "clerk-access",
+    id_token: "header.payload.signature",
+    refresh_token: "refresh-new",
+    expires_in: 3600,
+    token_type: "Bearer",
+  },
+}: {
+  authorizationContext?:
+    | ReturnType<typeof organizationAuthorizationContext>
+    | ReturnType<typeof projectAuthorizationContext>;
+  subject?: string;
+  member?: boolean;
+  clerkStatus?: number;
+  clerkTokens?: Record<string, unknown>;
+} = {}) {
+  const calls = {
+    resolve: [] as Parameters<TokenDependencies["resolveContext"]>[0][],
+    exchanges: [] as URLSearchParams[],
+    jwt: [] as Parameters<TokenDependencies["setJwtContext"]>[0][],
+    refresh: [] as Parameters<TokenDependencies["setRefreshContext"]>[0][],
+    rotate: [] as Parameters<TokenDependencies["rotateRefreshContext"]>[0][],
+    deleted: [] as Parameters<TokenDependencies["deleteRequestContext"]>[0][],
+  };
+
+  return {
+    calls,
+    value: {
+      resolveContext: async (value) => {
+        calls.resolve.push(value);
+        return {
+          authorizationContext,
+          ...(value.grantType === "authorization_code"
+            ? { requestCodeChallenge: "derived-challenge" }
+            : {}),
+        };
+      },
+      exchange: async (_input, init) => {
+        calls.exchanges.push(
+          new URLSearchParams(init?.body as URLSearchParams),
+        );
+        return Response.json(clerkTokens, { status: clerkStatus });
+      },
+      verify: async () => ({ sub: subject }),
+      hasMembership: async () => member,
+      setJwtContext: async (value) => {
+        calls.jwt.push(value);
+      },
+      setRefreshContext: async (value) => {
+        calls.refresh.push(value);
+      },
+      rotateRefreshContext: async (value) => {
+        calls.rotate.push(value);
+      },
+      deleteRequestContext: async (value) => {
+        calls.deleted.push(value);
+      },
+    } satisfies TokenDependencies,
+  };
+}
+
+describe("POST /token", () => {
+  test("issues an organization-wide token and persists both contexts", async () => {
+    const deps = dependencies();
+    const response = await tokenRequest(
+      request({
+        grant_type: "authorization_code",
+        client_id: "client_1",
+        code: "code_1",
+        code_verifier: "verifier_1",
+        org_id: "forged-org",
+        access_scope: "project",
+        project_id: "forged-project",
+      }),
+      deps.value,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      access_token: "header.payload.signature",
+      refresh_token: "refresh-new",
+      org_id: "org_1",
+      access_scope: "organization",
+    });
+    expect(deps.calls.jwt).toHaveLength(1);
+    expect(deps.calls.refresh).toHaveLength(1);
+    expect(deps.calls.deleted).toEqual([
+      { clientId: "client_1", codeChallenge: "derived-challenge" },
+    ]);
+    expect(deps.calls.exchanges[0].has("org_id")).toBe(false);
+    expect(deps.calls.exchanges[0].has("project_id")).toBe(false);
+    expect(deps.calls.exchanges[0].has("access_scope")).toBe(false);
+  });
+
+  test("returns the server-bound project scope", async () => {
+    const deps = dependencies({
+      authorizationContext: projectAuthorizationContext({
+        clerkUserId: "user_1",
+        clerkOrgId: "org_1",
+        projectId: "proj_1",
+      }),
+    });
+    const response = await tokenRequest(
+      request({
+        grant_type: "authorization_code",
+        client_id: "client_1",
+        code: "code_1",
+        code_verifier: "verifier_1",
+      }),
+      deps.value,
+    );
+
+    expect(await response.json()).toMatchObject({
+      org_id: "org_1",
+      access_scope: "project",
+      project_id: "proj_1",
+    });
+  });
+
+  test("refresh preserves stored scope and ignores body escalation", async () => {
+    const deps = dependencies({
+      authorizationContext: projectAuthorizationContext({
+        clerkUserId: "user_1",
+        clerkOrgId: "org_1",
+        projectId: "proj_1",
+      }),
+    });
+    const response = await tokenRequest(
+      request({
+        grant_type: "refresh_token",
+        client_id: "cli_prod",
+        refresh_token: "refresh-old",
+        org_id: "org_other",
+        access_scope: "organization",
+        project_id: "proj_other",
+      }),
+      deps.value,
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.calls.resolve[0]).toMatchObject({
+      grantType: "refresh_token",
+      clientId: "cli_prod",
+      refreshToken: "refresh-old",
+    });
+    expect(deps.calls.rotate).toEqual([
+      expect.objectContaining({
+        oldRefreshToken: "refresh-old",
+        newRefreshToken: "refresh-new",
+        authorizationContext: expect.objectContaining({
+          access_scope: "project",
+          project_id: "proj_1",
+        }),
+      }),
+    ]);
+    expect(deps.calls.exchanges[0].has("org_id")).toBe(false);
+    expect(deps.calls.exchanges[0].has("project_id")).toBe(false);
+  });
+
+  test("fails closed on subject and membership mismatches", async () => {
+    const wrongSubject = dependencies({ subject: "user_2" });
+    const subjectResponse = await tokenRequest(
+      request({
+        grant_type: "authorization_code",
+        client_id: "client_1",
+        code: "code_1",
+        code_verifier: "verifier_1",
+      }),
+      wrongSubject.value,
+    );
+    expect(subjectResponse.status).toBe(400);
+    expect(wrongSubject.calls.jwt).toHaveLength(0);
+
+    const removedMember = dependencies({ member: false });
+    const memberResponse = await tokenRequest(
+      request({
+        grant_type: "refresh_token",
+        client_id: "client_1",
+        refresh_token: "refresh-old",
+      }),
+      removedMember.value,
+    );
+    expect(memberResponse.status).toBe(400);
+    expect(removedMember.calls.rotate).toHaveLength(0);
+  });
+
+  test("does not persist partial context when provider response is invalid", async () => {
+    const providerFailure = dependencies({ clerkStatus: 401 });
+    const failedResponse = await tokenRequest(
+      request({
+        grant_type: "authorization_code",
+        client_id: "client_1",
+        code: "bad",
+        code_verifier: "verifier_1",
+      }),
+      providerFailure.value,
+    );
+    expect(failedResponse.status).toBe(400);
+    expect(providerFailure.calls.jwt).toHaveLength(0);
+
+    const missingRefresh = dependencies({
+      clerkTokens: {
+        access_token: "clerk-access",
+        id_token: "header.payload.signature",
+        expires_in: 3600,
+        token_type: "Bearer",
+      },
+    });
+    const missingRefreshResponse = await tokenRequest(
+      request({
+        grant_type: "authorization_code",
+        client_id: "client_1",
+        code: "code_1",
+        code_verifier: "verifier_1",
+      }),
+      missingRefresh.value,
+    );
+    expect(missingRefreshResponse.status).toBe(400);
+    expect(missingRefresh.calls.jwt).toHaveLength(0);
+  });
+});

--- a/src/app/token/route.ts
+++ b/src/app/token/route.ts
@@ -1,185 +1,198 @@
+import { clerkClient, verifyToken } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
 import {
-  setOrgIdForJwt,
-  setOrgIdForRefreshToken,
-  deleteOrgIdForRefreshToken,
+  deleteAuthorizationContextForRequest,
+  rotateAuthorizationContextForRefreshToken,
+  setAuthorizationContextForJwt,
+  setAuthorizationContextForRefreshToken,
 } from "@/lib/redis";
-import { resolveOrgId } from "@/lib/org-utils";
+import { resolveAuthorizationContext } from "@/lib/org-utils";
 import { REFRESH_TOKEN_ORG_TTL_SECONDS } from "@/lib/const";
 import { normalizeLocalhostUri } from "@/lib/auth-utils";
 
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+interface ClerkTokenResponse {
+  access_token: string;
+  expires_in: number;
+  refresh_token?: string;
+  token_type: string;
+  id_token?: string;
+}
+
 export async function OPTIONS(): Promise<NextResponse> {
-  return new NextResponse(null, {
-    status: 204,
-    headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "POST, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type, Authorization",
-    },
-  });
+  return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
 }
 
 function createErrorResponse(
   error: string,
   errorDescription: string,
-  status: number = 400,
+  status = 400,
 ) {
   return NextResponse.json(
-    {
-      error,
-      error_description: errorDescription,
-    },
-    {
-      status,
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Methods": "POST, OPTIONS",
-        "Access-Control-Allow-Headers": "Content-Type, Authorization",
-      },
-    },
+    { error, error_description: errorDescription },
+    { status, headers: CORS_HEADERS },
   );
 }
 
-interface ClerkTokenResponse {
-  access_token: string;
-  expires_in: number;
-  refresh_token: string;
-  token_type: string;
-  id_token?: string; // Optional, only present for authorization_code grants
+function clientCredentials(
+  request: NextRequest,
+  body: FormData,
+  params: URLSearchParams,
+): { clientId: string | null } {
+  let clientId = body.get("client_id")?.toString() || null;
+  let clientSecret = body.get("client_secret")?.toString() || null;
+
+  if (!clientId) {
+    const authHeader = request.headers.get("authorization");
+    if (authHeader?.startsWith("Basic ")) {
+      try {
+        const decoded = atob(authHeader.slice(6));
+        const colonIndex = decoded.indexOf(":");
+        if (colonIndex !== -1) {
+          clientId = decodeURIComponent(decoded.slice(0, colonIndex));
+          clientSecret = decodeURIComponent(decoded.slice(colonIndex + 1));
+          params.set("client_id", clientId);
+          if (clientSecret) params.set("client_secret", clientSecret);
+        }
+      } catch {
+        // Missing client_id is returned below.
+      }
+    }
+  }
+
+  return { clientId };
 }
 
-export async function POST(request: NextRequest): Promise<NextResponse> {
-  // Step 1: Validate request format
+async function hasOrganizationMembership(
+  clerkUserId: string,
+  clerkOrgId: string,
+): Promise<boolean> {
+  const clerk = await clerkClient();
+  let offset = 0;
+  const limit = 100;
+
+  for (;;) {
+    const memberships = await clerk.users.getOrganizationMembershipList({
+      userId: clerkUserId,
+      limit,
+      offset,
+    });
+    if (
+      memberships.data.some(
+        (membership) => membership.organization.id === clerkOrgId,
+      )
+    ) {
+      return true;
+    }
+    offset += memberships.data.length;
+    if (memberships.data.length === 0 || offset >= memberships.totalCount) {
+      return false;
+    }
+  }
+}
+
+export interface TokenDependencies {
+  exchange: typeof fetch;
+  resolveContext: typeof resolveAuthorizationContext;
+  verify: (
+    token: string,
+    options: { secretKey?: string },
+  ) => Promise<{ sub?: string }>;
+  hasMembership: typeof hasOrganizationMembership;
+  setJwtContext: typeof setAuthorizationContextForJwt;
+  setRefreshContext: typeof setAuthorizationContextForRefreshToken;
+  rotateRefreshContext: typeof rotateAuthorizationContextForRefreshToken;
+  deleteRequestContext: typeof deleteAuthorizationContextForRequest;
+}
+
+const tokenDependencies: TokenDependencies = {
+  exchange: fetch,
+  resolveContext: resolveAuthorizationContext,
+  verify: verifyToken,
+  hasMembership: hasOrganizationMembership,
+  setJwtContext: setAuthorizationContextForJwt,
+  setRefreshContext: setAuthorizationContextForRefreshToken,
+  rotateRefreshContext: rotateAuthorizationContextForRefreshToken,
+  deleteRequestContext: deleteAuthorizationContextForRequest,
+};
+
+export async function tokenRequest(
+  request: NextRequest,
+  dependencies: TokenDependencies = tokenDependencies,
+): Promise<NextResponse> {
   const contentType = request.headers.get("content-type");
   if (!contentType?.includes("application/x-www-form-urlencoded")) {
-    console.debug("[token] invalid content-type", { contentType });
     return createErrorResponse(
       "invalid_request",
       "Content-Type must be application/x-www-form-urlencoded",
     );
   }
 
-  const body = await request.formData();
-
-  // Step 2: Validate server configuration
   const clerkDomain = process.env.NEXT_PUBLIC_CLERK_DOMAIN;
-
   if (!clerkDomain) {
-    console.error("NEXT_PUBLIC_CLERK_DOMAIN environment variable is not set");
     return createErrorResponse(
       "server_error",
-      "Server configuration error - clerk domain not found",
+      "Server configuration error",
       500,
     );
   }
 
+  const body = await request.formData();
+  const params = new URLSearchParams();
+  for (const [key, value] of body.entries()) {
+    params.append(
+      key,
+      key === "redirect_uri"
+        ? normalizeLocalhostUri(value.toString())
+        : value.toString(),
+    );
+  }
+
+  const grantType = body.get("grant_type")?.toString() || "";
+  const { clientId } = clientCredentials(request, body, params);
+  if (!clientId) {
+    return createErrorResponse(
+      "invalid_request",
+      "Missing required parameter: client_id",
+    );
+  }
+
+  const refreshToken = body.get("refresh_token")?.toString();
+  const contextResult = await dependencies.resolveContext({
+    grantType,
+    clientId,
+    codeVerifier: body.get("code_verifier")?.toString(),
+    refreshToken,
+  });
+  if (contextResult.error) return contextResult.error;
+  const authorizationContext = contextResult.authorizationContext;
+  if (!authorizationContext) {
+    return createErrorResponse(
+      "invalid_grant",
+      "Authorization context not found. Please re-authorize.",
+    );
+  }
+
+  // Internal context parameters are not part of Clerk's token endpoint.
+  params.delete("org_id");
+  params.delete("project_id");
+  params.delete("access_scope");
+
   try {
-    // Step 3: Prepare parameters for Clerk token exchange
-    // Normalize redirect_uri to match Vercel's query param normalization (127.0.0.1 → localhost)
-    const params = new URLSearchParams();
-    for (const [key, value] of body.entries()) {
-      if (key === "redirect_uri") {
-        params.append(key, normalizeLocalhostUri(value.toString()));
-      } else {
-        params.append(key, value.toString());
-      }
-    }
-
-    const grantType = body.get("grant_type") as string;
-    console.debug("[token] start", { grantType });
-
-    // Extract client_id from body or Authorization: Basic header
-    let clientId = body.get("client_id") as string | null;
-    let clientSecret = body.get("client_secret") as string | null;
-
-    if (!clientId) {
-      const authHeader = request.headers.get("authorization");
-      if (authHeader?.startsWith("Basic ")) {
-        try {
-          const decoded = atob(authHeader.slice(6));
-          const colonIdx = decoded.indexOf(":");
-          if (colonIdx !== -1) {
-            clientId = decodeURIComponent(decoded.slice(0, colonIdx));
-            clientSecret = decodeURIComponent(decoded.slice(colonIdx + 1));
-            params.set("client_id", clientId);
-            if (clientSecret) {
-              params.set("client_secret", clientSecret);
-            }
-            console.debug("[token] extracted client_id from Basic auth header");
-          }
-        } catch {
-          console.debug("[token] failed to decode Basic auth header");
-        }
-      }
-    }
-
-    if (!clientId) {
-      console.debug("[token] missing client_id");
-      return createErrorResponse(
-        "invalid_request",
-        "Missing required parameter: client_id",
-      );
-    }
-
-    // Extract direct org_id if provided (shared clients)
-    let directOrgId: string | undefined;
-    const directOrgIdParam = body.get("org_id");
-    if (directOrgIdParam) {
-      const orgIdParam = directOrgIdParam.toString();
-      directOrgId = orgIdParam;
-      const maskedOrgId = orgIdParam.slice(0, 4) + "..." + orgIdParam.slice(-4);
-      console.debug("[token] using org_id from request body", { maskedOrgId });
-    }
-
-    // For refresh_token flow, resolve org before calling Clerk
-    let resolvedOrgId: string | null = null;
-    let refreshTokenFromBody: string | null = null;
-    if (grantType === "refresh_token") {
-      refreshTokenFromBody = body.get("refresh_token") as string | null;
-      if (!refreshTokenFromBody) {
-        console.debug("[token] missing refresh_token in refresh flow");
-        return createErrorResponse(
-          "invalid_request",
-          "Missing required parameter: refresh_token",
-        );
-      }
-      const orgResultPre = await resolveOrgId({
-        grantType,
-        clientId,
-        directOrgId,
-        refreshToken: refreshTokenFromBody,
-      });
-      if (orgResultPre.error) {
-        console.debug(
-          "[token] resolveOrgId (pre) returned error for refresh flow",
-        );
-        return orgResultPre.error;
-      }
-      resolvedOrgId = orgResultPre.orgId;
-      if (!resolvedOrgId) {
-        console.debug("[token] no org_id resolved for refresh_token flow");
-        return createErrorResponse(
-          "invalid_grant",
-          "Organization context not found for refresh token. Please re-authorize.",
-        );
-      }
-      console.debug("[token] resolved org via refresh_token mapping");
-    }
-
-    // Step 4: Exchange with Clerk
-    const clerkTokenResponse = await fetch(
+    const clerkResponse = await dependencies.exchange(
       `https://${clerkDomain}/oauth/token`,
       {
         method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-        },
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
         body: params,
       },
     );
-
-    if (!clerkTokenResponse.ok) {
-      console.error("[token] clerk token exchange failed");
+    if (!clerkResponse.ok) {
       return createErrorResponse(
         "invalid_grant",
         grantType === "refresh_token"
@@ -188,61 +201,88 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       );
     }
 
-    const clerkTokens: ClerkTokenResponse = await clerkTokenResponse.json();
-
-    // Step 5: Resolve organization context for authorization_code flows (or confirm for refresh flows)
-    let orgId = resolvedOrgId;
-    if (!orgId) {
-      const orgResult = await resolveOrgId({
-        grantType,
-        clientId,
-        directOrgId,
-      });
-      if (orgResult.error) {
-        console.debug("[token] resolveOrgId returned error for auth_code flow");
-        return orgResult.error;
-      }
-      orgId = orgResult.orgId;
-    }
-
-    // Step 6: Validate organization context
-    if (!orgId || orgId === "") {
-      console.warn("[token] no org_id resolved for client", {
-        clientIdMasked: clientId.slice(0, 4) + "...",
-      });
+    const clerkTokens = (await clerkResponse.json()) as ClerkTokenResponse;
+    if (!clerkTokens.id_token) {
       return createErrorResponse(
         "invalid_grant",
-        "Unable to resolve organization context. Please re-authorize.",
+        "Failed to retrieve id_token from OAuth provider",
+      );
+    }
+    if (
+      !Number.isFinite(clerkTokens.expires_in) ||
+      clerkTokens.expires_in <= 0
+    ) {
+      return createErrorResponse(
+        "invalid_grant",
+        "OAuth provider returned an invalid token lifetime",
       );
     }
 
-    // Step 7: Validate grant type and extract JWT
-    let finalJwt: string;
-    let expiresIn: number;
+    const payload = await dependencies.verify(clerkTokens.id_token, {
+      secretKey: process.env.CLERK_SECRET_KEY,
+    });
+    if (!payload.sub) {
+      return createErrorResponse(
+        "invalid_grant",
+        "OAuth provider returned a token without a subject",
+      );
+    }
+    if (
+      authorizationContext.clerk_user_id &&
+      authorizationContext.clerk_user_id !== payload.sub
+    ) {
+      return createErrorResponse(
+        "invalid_grant",
+        "OAuth token subject does not match authorization context",
+      );
+    }
+    if (
+      !(await dependencies.hasMembership(
+        payload.sub,
+        authorizationContext.clerk_org_id,
+      ))
+    ) {
+      return createErrorResponse(
+        "invalid_grant",
+        "Organization membership is no longer active",
+      );
+    }
+
+    const issuedRefreshToken = clerkTokens.refresh_token;
+    if (!issuedRefreshToken) {
+      return createErrorResponse(
+        "invalid_grant",
+        grantType === "refresh_token"
+          ? "OAuth provider did not rotate the refresh token"
+          : "OAuth provider did not return a refresh token",
+      );
+    }
+    const finalJwt = clerkTokens.id_token;
+    await dependencies.setJwtContext({
+      jwt: finalJwt,
+      authorizationContext,
+      ttlSeconds: clerkTokens.expires_in,
+    });
 
     if (grantType === "authorization_code") {
-      // For authorization_code: Use id_token directly (already has proper structure)
-      if (!clerkTokens.id_token) {
-        console.debug("[token] missing id_token in auth_code response");
-        return createErrorResponse(
-          "invalid_grant",
-          "Failed to retrieve id_token from Clerk authorization code",
-        );
-      }
-
-      finalJwt = clerkTokens.id_token;
-      expiresIn = clerkTokens.expires_in;
+      await dependencies.setRefreshContext({
+        refreshToken: issuedRefreshToken,
+        authorizationContext,
+        ttlSeconds: REFRESH_TOKEN_ORG_TTL_SECONDS,
+      });
     } else if (grantType === "refresh_token") {
-      if (!clerkTokens.id_token) {
-        console.debug("[token] missing id_token in refresh response");
+      if (!refreshToken) {
         return createErrorResponse(
           "invalid_grant",
-          "Failed to retrieve id_token from Clerk refresh token",
+          "Missing required parameter: refresh_token",
         );
       }
-
-      finalJwt = clerkTokens.id_token;
-      expiresIn = clerkTokens.expires_in;
+      await dependencies.rotateRefreshContext({
+        oldRefreshToken: refreshToken,
+        newRefreshToken: issuedRefreshToken,
+        authorizationContext,
+        ttlSeconds: REFRESH_TOKEN_ORG_TTL_SECONDS,
+      });
     } else {
       return createErrorResponse(
         "unsupported_grant_type",
@@ -250,113 +290,43 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       );
     }
 
-    // Step 8: Store refresh_token → org_id mapping (where applicable)
-    try {
-      if (grantType === "authorization_code" && clerkTokens.refresh_token) {
-        await setOrgIdForRefreshToken({
-          refreshToken: clerkTokens.refresh_token,
-          orgId,
-          ttlSeconds: REFRESH_TOKEN_ORG_TTL_SECONDS,
+    if (contextResult.requestCodeChallenge) {
+      try {
+        await dependencies.deleteRequestContext({
+          clientId,
+          codeChallenge: contextResult.requestCodeChallenge,
         });
-        console.debug(
-          "[token] stored refresh_token→org_id mapping (auth_code)",
+      } catch (error) {
+        // The provider has already consumed the authorization code and both
+        // token mappings are durable. Let the short pending-context TTL clean up.
+        console.warn(
+          "[token] failed to delete consumed authorization context",
+          {
+            error,
+          },
         );
       }
-      if (grantType === "refresh_token") {
-        // Update mapping for rotated refresh token if provided
-        if (clerkTokens.refresh_token) {
-          // Clean up old mapping before storing the new one
-          if (refreshTokenFromBody) {
-            try {
-              await deleteOrgIdForRefreshToken({
-                refreshToken: refreshTokenFromBody,
-              });
-              console.debug(
-                "[token] deleted old refresh_token→org_id mapping (refresh)",
-              );
-            } catch (e) {
-              console.warn(
-                "[token] failed to delete old refresh_token mapping",
-                { error: e },
-              );
-            }
-          }
-          await setOrgIdForRefreshToken({
-            refreshToken: clerkTokens.refresh_token,
-            orgId,
-            ttlSeconds: REFRESH_TOKEN_ORG_TTL_SECONDS,
-          });
-          console.debug(
-            "[token] updated refresh_token→org_id mapping (refresh)",
-          );
-        }
-      }
-    } catch (error) {
-      console.error("[token] failed to store refresh_token→org_id mapping", {
-        error,
-      });
-      return createErrorResponse(
-        "server_error",
-        "Failed to store refresh token context",
-        500,
-      );
     }
 
-    // Step 9: Store JWT to org_id mapping for verifyjwt.go
-    try {
-      // Store JWT to org_id mapping with JWT expiration time
-      await setOrgIdForJwt({
-        jwt: finalJwt,
-        orgId,
-        ttlSeconds: expiresIn,
-      });
-      console.debug("[token] stored jwt→org_id mapping", {
-        ttlSeconds: expiresIn,
-      });
-    } catch (error) {
-      console.error("[token] failed to store jwt→org_id mapping", { error });
-      return createErrorResponse(
-        "server_error",
-        "Failed to store authentication context",
-        500,
-      );
-    }
-
-    // Step 10: Build final token response
-    const mcpTokenResponse = {
-      ...clerkTokens,
-      access_token: finalJwt,
-      expires_in: expiresIn,
-    };
-
-    console.debug("[token] success", { grantType });
-    return NextResponse.json(mcpTokenResponse, {
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Methods": "POST, OPTIONS",
-        "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    return NextResponse.json(
+      {
+        ...clerkTokens,
+        access_token: finalJwt,
+        expires_in: clerkTokens.expires_in,
+        org_id: authorizationContext.clerk_org_id,
+        access_scope: authorizationContext.access_scope,
+        ...(authorizationContext.project_id
+          ? { project_id: authorizationContext.project_id }
+          : {}),
       },
-    });
+      { headers: CORS_HEADERS },
+    );
   } catch (error) {
-    console.error("[token] unhandled error", { error });
-
-    // If it's a Clerk error, log the detailed error information
-    if (error && typeof error === "object" && "clerkError" in error) {
-      const clerkError = error as any;
-      console.error("Clerk error details:");
-      console.error("  Status:", clerkError.status);
-      console.error("  Clerk Trace ID:", clerkError.clerkTraceId);
-      if (clerkError.errors && Array.isArray(clerkError.errors)) {
-        console.error("  Specific errors:");
-        clerkError.errors.forEach((err: any, index: number) => {
-          console.error(
-            `    Error ${index + 1}:`,
-            JSON.stringify(err, null, 2),
-          );
-        });
-      }
-    }
-
+    console.error("[token] token exchange failed", { error });
     return createErrorResponse("server_error", "Internal server error", 500);
   }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  return tokenRequest(request);
 }

--- a/src/app/token/route.ts
+++ b/src/app/token/route.ts
@@ -1,11 +1,6 @@
 import { clerkClient, verifyToken } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
-import {
-  deleteAuthorizationContextForRequest,
-  rotateAuthorizationContextForRefreshToken,
-  setAuthorizationContextForJwt,
-  setAuthorizationContextForRefreshToken,
-} from "@/lib/redis";
+import { persistOAuthTokenContexts } from "@/lib/redis";
 import { resolveAuthorizationContext } from "@/lib/org-utils";
 import { REFRESH_TOKEN_ORG_TTL_SECONDS } from "@/lib/const";
 import { normalizeLocalhostUri } from "@/lib/auth-utils";
@@ -109,10 +104,7 @@ export interface TokenDependencies {
     options: { secretKey?: string },
   ) => Promise<{ sub?: string }>;
   hasMembership: typeof hasOrganizationMembership;
-  setJwtContext: typeof setAuthorizationContextForJwt;
-  setRefreshContext: typeof setAuthorizationContextForRefreshToken;
-  rotateRefreshContext: typeof rotateAuthorizationContextForRefreshToken;
-  deleteRequestContext: typeof deleteAuthorizationContextForRequest;
+  persistContexts: typeof persistOAuthTokenContexts;
 }
 
 const tokenDependencies: TokenDependencies = {
@@ -120,10 +112,7 @@ const tokenDependencies: TokenDependencies = {
   resolveContext: resolveAuthorizationContext,
   verify: verifyToken,
   hasMembership: hasOrganizationMembership,
-  setJwtContext: setAuthorizationContextForJwt,
-  setRefreshContext: setAuthorizationContextForRefreshToken,
-  rotateRefreshContext: rotateAuthorizationContextForRefreshToken,
-  deleteRequestContext: deleteAuthorizationContextForRequest,
+  persistContexts: persistOAuthTokenContexts,
 };
 
 export async function tokenRequest(
@@ -188,7 +177,28 @@ export async function tokenRequest(
   params.delete("project_id");
   params.delete("access_scope");
 
+  // New refresh contexts carry the user, so validate membership before Clerk
+  // rotates the one-time credential. Legacy org-only contexts still require
+  // post-exchange identity discovery until they expire.
+  const refreshContextUserId =
+    grantType === "refresh_token"
+      ? authorizationContext.clerk_user_id
+      : undefined;
+
   try {
+    if (
+      refreshContextUserId &&
+      !(await dependencies.hasMembership(
+        refreshContextUserId,
+        authorizationContext.clerk_org_id,
+      ))
+    ) {
+      return createErrorResponse(
+        "invalid_grant",
+        "Organization membership is no longer active",
+      );
+    }
+
     const clerkResponse = await dependencies.exchange(
       `https://${clerkDomain}/oauth/token`,
       {
@@ -223,34 +233,36 @@ export async function tokenRequest(
       );
     }
 
-    const payload = await dependencies.verify(clerkTokens.id_token, {
-      secretKey: process.env.CLERK_SECRET_KEY,
-    });
-    if (!payload.sub) {
-      return createErrorResponse(
-        "invalid_grant",
-        "OAuth provider returned a token without a subject",
-      );
-    }
-    if (
-      authorizationContext.clerk_user_id &&
-      authorizationContext.clerk_user_id !== payload.sub
-    ) {
-      return createErrorResponse(
-        "invalid_grant",
-        "OAuth token subject does not match authorization context",
-      );
-    }
-    if (
-      !(await dependencies.hasMembership(
-        payload.sub,
-        authorizationContext.clerk_org_id,
-      ))
-    ) {
-      return createErrorResponse(
-        "invalid_grant",
-        "Organization membership is no longer active",
-      );
+    if (!refreshContextUserId) {
+      const payload = await dependencies.verify(clerkTokens.id_token, {
+        secretKey: process.env.CLERK_SECRET_KEY,
+      });
+      if (!payload.sub) {
+        return createErrorResponse(
+          "invalid_grant",
+          "OAuth provider returned a token without a subject",
+        );
+      }
+      if (
+        authorizationContext.clerk_user_id &&
+        authorizationContext.clerk_user_id !== payload.sub
+      ) {
+        return createErrorResponse(
+          "invalid_grant",
+          "OAuth token subject does not match authorization context",
+        );
+      }
+      if (
+        !(await dependencies.hasMembership(
+          payload.sub,
+          authorizationContext.clerk_org_id,
+        ))
+      ) {
+        return createErrorResponse(
+          "invalid_grant",
+          "Organization membership is no longer active",
+        );
+      }
     }
 
     const issuedRefreshToken = clerkTokens.refresh_token;
@@ -263,55 +275,37 @@ export async function tokenRequest(
       );
     }
     const finalJwt = clerkTokens.id_token;
-    await dependencies.setJwtContext({
-      jwt: finalJwt,
-      authorizationContext,
-      ttlSeconds: clerkTokens.expires_in,
-    });
-
-    if (grantType === "authorization_code") {
-      await dependencies.setRefreshContext({
-        refreshToken: issuedRefreshToken,
-        authorizationContext,
-        ttlSeconds: REFRESH_TOKEN_ORG_TTL_SECONDS,
-      });
-    } else if (grantType === "refresh_token") {
-      if (!refreshToken) {
-        return createErrorResponse(
-          "invalid_grant",
-          "Missing required parameter: refresh_token",
-        );
-      }
-      await dependencies.rotateRefreshContext({
-        oldRefreshToken: refreshToken,
-        newRefreshToken: issuedRefreshToken,
-        authorizationContext,
-        ttlSeconds: REFRESH_TOKEN_ORG_TTL_SECONDS,
-      });
-    } else {
+    if (grantType === "refresh_token" && !refreshToken) {
+      return createErrorResponse(
+        "invalid_grant",
+        "Missing required parameter: refresh_token",
+      );
+    }
+    if (grantType !== "authorization_code" && grantType !== "refresh_token") {
       return createErrorResponse(
         "unsupported_grant_type",
         `Grant type '${grantType}' is not supported`,
       );
     }
 
-    if (contextResult.requestCodeChallenge) {
-      try {
-        await dependencies.deleteRequestContext({
-          clientId,
-          codeChallenge: contextResult.requestCodeChallenge,
-        });
-      } catch (error) {
-        // The provider has already consumed the authorization code and both
-        // token mappings are durable. Let the short pending-context TTL clean up.
-        console.warn(
-          "[token] failed to delete consumed authorization context",
-          {
-            error,
-          },
-        );
-      }
-    }
+    await dependencies.persistContexts({
+      jwt: finalJwt,
+      newRefreshToken: issuedRefreshToken,
+      ...(grantType === "refresh_token" && refreshToken
+        ? { oldRefreshToken: refreshToken }
+        : {}),
+      authorizationContext,
+      jwtTtlSeconds: clerkTokens.expires_in,
+      refreshTtlSeconds: REFRESH_TOKEN_ORG_TTL_SECONDS,
+      ...(contextResult.requestCodeChallenge
+        ? {
+            consumedRequest: {
+              clientId,
+              codeChallenge: contextResult.requestCodeChallenge,
+            },
+          }
+        : {}),
+    });
 
     return NextResponse.json(
       {

--- a/src/app/token/route.ts
+++ b/src/app/token/route.ts
@@ -96,8 +96,13 @@ async function hasOrganizationMembership(
   }
 }
 
+type Fetcher = (
+  input: URL | RequestInfo,
+  init?: RequestInit,
+) => Promise<Response>;
+
 export interface TokenDependencies {
-  exchange: typeof fetch;
+  exchange: Fetcher;
   resolveContext: typeof resolveAuthorizationContext;
   verify: (
     token: string,

--- a/src/app/token/route.ts
+++ b/src/app/token/route.ts
@@ -172,6 +172,8 @@ export async function tokenRequest(
     );
   }
 
+  let persistedAuthorizationContext = authorizationContext;
+
   // Internal context parameters are not part of Clerk's token endpoint.
   params.delete("org_id");
   params.delete("project_id");
@@ -263,6 +265,12 @@ export async function tokenRequest(
           "Organization membership is no longer active",
         );
       }
+      if (!authorizationContext.clerk_user_id) {
+        persistedAuthorizationContext = {
+          ...authorizationContext,
+          clerk_user_id: payload.sub,
+        };
+      }
     }
 
     const issuedRefreshToken = clerkTokens.refresh_token;
@@ -294,7 +302,7 @@ export async function tokenRequest(
       ...(grantType === "refresh_token" && refreshToken
         ? { oldRefreshToken: refreshToken }
         : {}),
-      authorizationContext,
+      authorizationContext: persistedAuthorizationContext,
       jwtTtlSeconds: clerkTokens.expires_in,
       refreshTtlSeconds: REFRESH_TOKEN_ORG_TTL_SECONDS,
       ...(contextResult.requestCodeChallenge

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -16,5 +16,11 @@ export const SHARED_CLIENT_IDS = [
   process.env.KERNEL_CLI_DEV_CLIENT_ID,
 ].filter(Boolean) as string[];
 
+export function isLegacyNonPkceClient(clientId: string): boolean {
+  return (process.env.OAUTH_LEGACY_NON_PKCE_CLIENT_IDS ?? "")
+    .split(",")
+    .some((allowedClientId) => allowedClientId.trim() === clientId);
+}
+
 // Sliding TTL for refresh_token→org_id mapping (defaults to 30 days)
 export const REFRESH_TOKEN_ORG_TTL_SECONDS = 60 * 60 * 24 * 30;

--- a/src/lib/oauth-context.test.ts
+++ b/src/lib/oauth-context.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import {
+  authorizationContextFromSelection,
+  deriveS256CodeChallenge,
+  organizationAuthorizationContext,
+  parseAuthorizationContext,
+  projectAuthorizationContext,
+  serializeAuthorizationContext,
+} from "./oauth-context";
+
+describe("OAuth authorization context", () => {
+  test("decodes legacy org mappings as organization-wide", () => {
+    expect(parseAuthorizationContext("org_legacy")).toEqual(
+      organizationAuthorizationContext({ clerkOrgId: "org_legacy" }),
+    );
+  });
+
+  test("round-trips organization and project contexts", () => {
+    const contexts = [
+      organizationAuthorizationContext({
+        clerkUserId: "user_1",
+        clerkOrgId: "org_1",
+      }),
+      projectAuthorizationContext({
+        clerkUserId: "user_1",
+        clerkOrgId: "org_1",
+        projectId: "proj_1",
+      }),
+    ];
+
+    for (const context of contexts) {
+      expect(
+        parseAuthorizationContext(serializeAuthorizationContext(context)),
+      ).toEqual(context);
+    }
+  });
+
+  test("rejects malformed authorization boundaries", () => {
+    for (const value of [
+      "",
+      "{",
+      "not-an-org",
+      "null",
+      "[]",
+      '{"version":2,"clerk_org_id":"org_1","access_scope":"organization"}',
+      '{"version":1,"access_scope":"organization"}',
+      '{"version":1,"clerk_org_id":"org_1","access_scope":"project"}',
+      '{"version":1,"clerk_org_id":"org_1","access_scope":"organization","project_id":"proj_1"}',
+      '{"version":1,"clerk_org_id":"org_1","access_scope":"account"}',
+    ]) {
+      expect(() => parseAuthorizationContext(value)).toThrow();
+    }
+  });
+
+  test("validates authorization selections", () => {
+    expect(
+      authorizationContextFromSelection({
+        clerkUserId: "user_1",
+        clerkOrgId: "org_1",
+        accessScope: null,
+        projectId: null,
+      }),
+    ).toEqual(
+      organizationAuthorizationContext({
+        clerkUserId: "user_1",
+        clerkOrgId: "org_1",
+      }),
+    );
+
+    expect(
+      authorizationContextFromSelection({
+        clerkUserId: "user_1",
+        clerkOrgId: "org_1",
+        accessScope: "project",
+        projectId: "proj_1",
+      }),
+    ).toEqual(
+      projectAuthorizationContext({
+        clerkUserId: "user_1",
+        clerkOrgId: "org_1",
+        projectId: "proj_1",
+      }),
+    );
+
+    expect(() =>
+      authorizationContextFromSelection({
+        clerkUserId: "user_1",
+        clerkOrgId: "org_1",
+        accessScope: "project",
+        projectId: null,
+      }),
+    ).toThrow("Project access requires a project");
+  });
+});
+
+test("derives RFC 7636 S256 challenge", () => {
+  expect(
+    deriveS256CodeChallenge("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"),
+  ).toBe("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+});

--- a/src/lib/oauth-context.ts
+++ b/src/lib/oauth-context.ts
@@ -1,0 +1,159 @@
+import { createHash } from "crypto";
+
+export const OAUTH_CONTEXT_VERSION = 1;
+export const ORGANIZATION_ACCESS_SCOPE = "organization";
+export const PROJECT_ACCESS_SCOPE = "project";
+
+export type OAuthAccessScope =
+  | typeof ORGANIZATION_ACCESS_SCOPE
+  | typeof PROJECT_ACCESS_SCOPE;
+
+interface OAuthAuthorizationContextBase {
+  version: typeof OAUTH_CONTEXT_VERSION;
+  clerk_user_id?: string;
+  clerk_org_id: string;
+}
+
+export type OAuthAuthorizationContext = OAuthAuthorizationContextBase &
+  (
+    | {
+        access_scope: typeof ORGANIZATION_ACCESS_SCOPE;
+        project_id?: never;
+      }
+    | {
+        access_scope: typeof PROJECT_ACCESS_SCOPE;
+        project_id: string;
+      }
+  );
+
+export function organizationAuthorizationContext({
+  clerkUserId,
+  clerkOrgId,
+}: {
+  clerkUserId?: string;
+  clerkOrgId: string;
+}): OAuthAuthorizationContext {
+  return {
+    version: OAUTH_CONTEXT_VERSION,
+    ...(clerkUserId ? { clerk_user_id: clerkUserId } : {}),
+    clerk_org_id: clerkOrgId,
+    access_scope: ORGANIZATION_ACCESS_SCOPE,
+  };
+}
+
+export function projectAuthorizationContext({
+  clerkUserId,
+  clerkOrgId,
+  projectId,
+}: {
+  clerkUserId?: string;
+  clerkOrgId: string;
+  projectId: string;
+}): OAuthAuthorizationContext {
+  return {
+    version: OAUTH_CONTEXT_VERSION,
+    ...(clerkUserId ? { clerk_user_id: clerkUserId } : {}),
+    clerk_org_id: clerkOrgId,
+    access_scope: PROJECT_ACCESS_SCOPE,
+    project_id: projectId,
+  };
+}
+
+export function parseAuthorizationContext(
+  value: string,
+): OAuthAuthorizationContext {
+  const trimmed = value.trim();
+  if (!trimmed) throw new Error("OAuth authorization context is empty");
+
+  // Existing access and refresh token mappings contain only a Clerk org ID.
+  if (trimmed.startsWith("org_")) {
+    return organizationAuthorizationContext({ clerkOrgId: trimmed });
+  }
+
+  const decoded: unknown = JSON.parse(trimmed);
+  if (!decoded || typeof decoded !== "object" || Array.isArray(decoded)) {
+    throw new Error("OAuth authorization context must be an object");
+  }
+  const parsed = decoded as Partial<OAuthAuthorizationContext>;
+  if (parsed.version !== OAUTH_CONTEXT_VERSION) {
+    throw new Error(
+      `Unsupported OAuth authorization context version: ${String(parsed.version)}`,
+    );
+  }
+  if (!parsed.clerk_org_id) {
+    throw new Error("OAuth authorization context is missing clerk_org_id");
+  }
+  if (
+    parsed.clerk_user_id !== undefined &&
+    typeof parsed.clerk_user_id !== "string"
+  ) {
+    throw new Error("OAuth authorization context has invalid clerk_user_id");
+  }
+
+  if (parsed.access_scope === ORGANIZATION_ACCESS_SCOPE) {
+    if (parsed.project_id) {
+      throw new Error(
+        "Organization-scoped OAuth context cannot include project_id",
+      );
+    }
+    return organizationAuthorizationContext({
+      clerkUserId: parsed.clerk_user_id,
+      clerkOrgId: parsed.clerk_org_id,
+    });
+  }
+
+  if (parsed.access_scope === PROJECT_ACCESS_SCOPE) {
+    if (!parsed.project_id) {
+      throw new Error("Project-scoped OAuth context is missing project_id");
+    }
+    return projectAuthorizationContext({
+      clerkUserId: parsed.clerk_user_id,
+      clerkOrgId: parsed.clerk_org_id,
+      projectId: parsed.project_id,
+    });
+  }
+
+  throw new Error(
+    `Unsupported OAuth access scope: ${String(parsed.access_scope)}`,
+  );
+}
+
+export function serializeAuthorizationContext(
+  context: OAuthAuthorizationContext,
+): string {
+  // Validate before writing so malformed boundaries never enter Redis.
+  return JSON.stringify(parseAuthorizationContext(JSON.stringify(context)));
+}
+
+export function deriveS256CodeChallenge(codeVerifier: string): string {
+  return createHash("sha256").update(codeVerifier).digest("base64url");
+}
+
+export function authorizationContextFromSelection({
+  clerkUserId,
+  clerkOrgId,
+  accessScope,
+  projectId,
+}: {
+  clerkUserId: string;
+  clerkOrgId: string;
+  accessScope: string | null;
+  projectId: string | null;
+}): OAuthAuthorizationContext {
+  const normalizedScope = accessScope || ORGANIZATION_ACCESS_SCOPE;
+  if (normalizedScope === ORGANIZATION_ACCESS_SCOPE) {
+    if (projectId) {
+      throw new Error("Organization-wide access cannot include a project");
+    }
+    return organizationAuthorizationContext({ clerkUserId, clerkOrgId });
+  }
+  if (normalizedScope === PROJECT_ACCESS_SCOPE) {
+    if (!projectId) throw new Error("Project access requires a project");
+    return projectAuthorizationContext({
+      clerkUserId,
+      clerkOrgId,
+      projectId,
+    });
+  }
+  throw new Error(`Unsupported OAuth access scope: ${normalizedScope}`);
+}

--- a/src/lib/oauth-projects.test.ts
+++ b/src/lib/oauth-projects.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  listOAuthProjects,
+  OAuthProjectsError,
+  requireActiveOAuthProject,
+} from "./oauth-projects";
+
+const originalFetch = globalThis.fetch;
+const originalApiBaseUrl = process.env.API_BASE_URL;
+
+beforeEach(() => {
+  process.env.API_BASE_URL = "https://api.example.test";
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalApiBaseUrl === undefined) delete process.env.API_BASE_URL;
+  else process.env.API_BASE_URL = originalApiBaseUrl;
+});
+
+describe("OAuth project lookup", () => {
+  test("paginates and returns only active projects", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      calls.push(url);
+      if (url.includes("offset=0")) {
+        return Response.json(
+          [
+            { id: "proj_1", name: "one", status: "active" },
+            { id: "proj_old", name: "old", status: "archived" },
+          ],
+          { headers: { "X-Has-More": "true", "X-Next-Offset": "2" } },
+        );
+      }
+      return Response.json([{ id: "proj_2", name: "two", status: "active" }], {
+        headers: { "X-Has-More": "false" },
+      });
+    }) as typeof fetch;
+
+    expect(await listOAuthProjects("session-token")).toEqual([
+      { id: "proj_1", name: "one", status: "active" },
+      { id: "proj_2", name: "two", status: "active" },
+    ]);
+    expect(calls).toHaveLength(2);
+  });
+
+  test("requires the selected project to be active and visible", async () => {
+    globalThis.fetch = mock(async () =>
+      Response.json([{ id: "proj_1", name: "one", status: "active" }], {
+        headers: { "X-Has-More": "false" },
+      }),
+    ) as typeof fetch;
+
+    expect(
+      await requireActiveOAuthProject({
+        clerkSessionToken: "session-token",
+        projectId: "proj_1",
+      }),
+    ).toEqual({ id: "proj_1", name: "one", status: "active" });
+
+    await expect(
+      requireActiveOAuthProject({
+        clerkSessionToken: "session-token",
+        projectId: "proj_2",
+      }),
+    ).rejects.toBeInstanceOf(OAuthProjectsError);
+  });
+
+  test("fails on API and pagination errors", async () => {
+    globalThis.fetch = mock(
+      async () => new Response(null, { status: 503 }),
+    ) as typeof fetch;
+    await expect(listOAuthProjects("session-token")).rejects.toMatchObject({
+      status: 502,
+    });
+
+    globalThis.fetch = mock(async () =>
+      Response.json([], {
+        headers: { "X-Has-More": "true", "X-Next-Offset": "0" },
+      }),
+    ) as typeof fetch;
+    await expect(listOAuthProjects("session-token")).rejects.toThrow(
+      "Invalid project pagination response",
+    );
+  });
+});

--- a/src/lib/oauth-projects.test.ts
+++ b/src/lib/oauth-projects.test.ts
@@ -5,7 +5,6 @@ import {
   requireActiveOAuthProject,
 } from "./oauth-projects";
 
-const originalFetch = globalThis.fetch;
 const originalApiBaseUrl = process.env.API_BASE_URL;
 
 beforeEach(() => {
@@ -13,7 +12,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  globalThis.fetch = originalFetch;
   if (originalApiBaseUrl === undefined) delete process.env.API_BASE_URL;
   else process.env.API_BASE_URL = originalApiBaseUrl;
 });
@@ -21,7 +19,7 @@ afterEach(() => {
 describe("OAuth project lookup", () => {
   test("paginates and returns only active projects", async () => {
     const calls: string[] = [];
-    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+    const fetcher = mock(async (input: RequestInfo | URL) => {
       const url = input.toString();
       calls.push(url);
       if (url.includes("offset=0")) {
@@ -36,9 +34,9 @@ describe("OAuth project lookup", () => {
       return Response.json([{ id: "proj_2", name: "two", status: "active" }], {
         headers: { "X-Has-More": "false" },
       });
-    }) as typeof fetch;
+    });
 
-    expect(await listOAuthProjects("session-token")).toEqual([
+    expect(await listOAuthProjects("session-token", fetcher)).toEqual([
       { id: "proj_1", name: "one", status: "active" },
       { id: "proj_2", name: "two", status: "active" },
     ]);
@@ -46,16 +44,17 @@ describe("OAuth project lookup", () => {
   });
 
   test("requires the selected project to be active and visible", async () => {
-    globalThis.fetch = mock(async () =>
+    const fetcher = mock(async () =>
       Response.json([{ id: "proj_1", name: "one", status: "active" }], {
         headers: { "X-Has-More": "false" },
       }),
-    ) as typeof fetch;
+    );
 
     expect(
       await requireActiveOAuthProject({
         clerkSessionToken: "session-token",
         projectId: "proj_1",
+        fetcher,
       }),
     ).toEqual({ id: "proj_1", name: "one", status: "active" });
 
@@ -63,25 +62,26 @@ describe("OAuth project lookup", () => {
       requireActiveOAuthProject({
         clerkSessionToken: "session-token",
         projectId: "proj_2",
+        fetcher,
       }),
     ).rejects.toBeInstanceOf(OAuthProjectsError);
   });
 
   test("fails on API and pagination errors", async () => {
-    globalThis.fetch = mock(
-      async () => new Response(null, { status: 503 }),
-    ) as typeof fetch;
-    await expect(listOAuthProjects("session-token")).rejects.toMatchObject({
+    const unavailable = mock(async () => new Response(null, { status: 503 }));
+    await expect(
+      listOAuthProjects("session-token", unavailable),
+    ).rejects.toMatchObject({
       status: 502,
     });
 
-    globalThis.fetch = mock(async () =>
+    const invalidPagination = mock(async () =>
       Response.json([], {
         headers: { "X-Has-More": "true", "X-Next-Offset": "0" },
       }),
-    ) as typeof fetch;
-    await expect(listOAuthProjects("session-token")).rejects.toThrow(
-      "Invalid project pagination response",
     );
+    await expect(
+      listOAuthProjects("session-token", invalidPagination),
+    ).rejects.toThrow("Invalid project pagination response");
   });
 });

--- a/src/lib/oauth-projects.test.ts
+++ b/src/lib/oauth-projects.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
-  listOAuthProjects,
+  listOAuthProjectsPage,
   OAuthProjectsError,
   requireActiveOAuthProject,
 } from "./oauth-projects";
@@ -17,38 +17,44 @@ afterEach(() => {
 });
 
 describe("OAuth project lookup", () => {
-  test("paginates and returns only active projects", async () => {
-    const calls: string[] = [];
+  test("forwards search and pagination to the API", async () => {
+    let requestedUrl: URL | undefined;
     const fetcher = mock(async (input: RequestInfo | URL) => {
-      const url = input.toString();
-      calls.push(url);
-      if (url.includes("offset=0")) {
-        return Response.json(
-          [
-            { id: "proj_1", name: "one", status: "active" },
-            { id: "proj_old", name: "old", status: "archived" },
-          ],
-          { headers: { "X-Has-More": "true", "X-Next-Offset": "2" } },
-        );
-      }
-      return Response.json([{ id: "proj_2", name: "two", status: "active" }], {
-        headers: { "X-Has-More": "false" },
-      });
+      requestedUrl = new URL(input.toString());
+      return Response.json(
+        [
+          { id: "proj_1", name: "one", status: "active" },
+          { id: "proj_old", name: "old", status: "archived" },
+        ],
+        { headers: { "X-Has-More": "true", "X-Next-Offset": "40" } },
+      );
     });
 
-    expect(await listOAuthProjects("session-token", fetcher)).toEqual([
-      { id: "proj_1", name: "one", status: "active" },
-      { id: "proj_2", name: "two", status: "active" },
-    ]);
-    expect(calls).toHaveLength(2);
+    const page = await listOAuthProjectsPage({
+      clerkSessionToken: "session-token",
+      query: "prod",
+      limit: 20,
+      offset: 20,
+      fetcher,
+    });
+
+    expect(requestedUrl?.pathname).toBe("/org/projects");
+    expect(requestedUrl?.searchParams.get("query")).toBe("prod");
+    expect(requestedUrl?.searchParams.get("limit")).toBe("20");
+    expect(requestedUrl?.searchParams.get("offset")).toBe("20");
+    expect(page).toEqual({
+      projects: [{ id: "proj_1", name: "one", status: "active" }],
+      hasMore: true,
+      nextOffset: 40,
+    });
   });
 
-  test("requires the selected project to be active and visible", async () => {
-    const fetcher = mock(async () =>
-      Response.json([{ id: "proj_1", name: "one", status: "active" }], {
-        headers: { "X-Has-More": "false" },
-      }),
-    );
+  test("validates the selected project directly by ID", async () => {
+    let requestedUrl: URL | undefined;
+    const fetcher = mock(async (input: RequestInfo | URL) => {
+      requestedUrl = new URL(input.toString());
+      return Response.json({ id: "proj_1", name: "one", status: "active" });
+    });
 
     expect(
       await requireActiveOAuthProject({
@@ -57,23 +63,42 @@ describe("OAuth project lookup", () => {
         fetcher,
       }),
     ).toEqual({ id: "proj_1", name: "one", status: "active" });
+    expect(requestedUrl?.pathname).toBe("/org/projects/proj_1");
+  });
 
+  test("rejects missing, inactive, and mismatched projects", async () => {
+    const missing = mock(async () => new Response(null, { status: 404 }));
     await expect(
       requireActiveOAuthProject({
         clerkSessionToken: "session-token",
-        projectId: "proj_2",
-        fetcher,
+        projectId: "proj_1",
+        fetcher: missing,
       }),
     ).rejects.toBeInstanceOf(OAuthProjectsError);
+
+    for (const project of [
+      { id: "proj_1", name: "one", status: "archived" },
+      { id: "proj_2", name: "two", status: "active" },
+    ]) {
+      const fetcher = mock(async () => Response.json(project));
+      await expect(
+        requireActiveOAuthProject({
+          clerkSessionToken: "session-token",
+          projectId: "proj_1",
+          fetcher,
+        }),
+      ).rejects.toBeInstanceOf(OAuthProjectsError);
+    }
   });
 
   test("fails on API and pagination errors", async () => {
     const unavailable = mock(async () => new Response(null, { status: 503 }));
     await expect(
-      listOAuthProjects("session-token", unavailable),
-    ).rejects.toMatchObject({
-      status: 502,
-    });
+      listOAuthProjectsPage({
+        clerkSessionToken: "session-token",
+        fetcher: unavailable,
+      }),
+    ).rejects.toMatchObject({ status: 502 });
 
     const invalidPagination = mock(async () =>
       Response.json([], {
@@ -81,7 +106,10 @@ describe("OAuth project lookup", () => {
       }),
     );
     await expect(
-      listOAuthProjects("session-token", invalidPagination),
+      listOAuthProjectsPage({
+        clerkSessionToken: "session-token",
+        fetcher: invalidPagination,
+      }),
     ).rejects.toThrow("Invalid project pagination response");
   });
 });

--- a/src/lib/oauth-projects.test.ts
+++ b/src/lib/oauth-projects.test.ts
@@ -74,7 +74,16 @@ describe("OAuth project lookup", () => {
         projectId: "proj_1",
         fetcher: missing,
       }),
-    ).rejects.toBeInstanceOf(OAuthProjectsError);
+    ).rejects.toMatchObject({ status: 404 });
+
+    const forbidden = mock(async () => new Response(null, { status: 403 }));
+    await expect(
+      requireActiveOAuthProject({
+        clerkSessionToken: "session-token",
+        projectId: "proj_1",
+        fetcher: forbidden,
+      }),
+    ).rejects.toMatchObject({ status: 403 });
 
     for (const project of [
       { id: "proj_1", name: "one", status: "archived" },

--- a/src/lib/oauth-projects.test.ts
+++ b/src/lib/oauth-projects.test.ts
@@ -100,6 +100,42 @@ describe("OAuth project lookup", () => {
     }
   });
 
+  test("normalizes transport, JSON, and schema failures", async () => {
+    const transportFailure = mock(async () => {
+      throw new Error("connection reset");
+    });
+    const invalidJson = mock(
+      async () =>
+        new Response("{", {
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const invalidPage = mock(async () =>
+      Response.json([{ id: 1, name: "one", status: "active" }]),
+    );
+    const invalidProject = mock(async () =>
+      Response.json({ id: "proj_1", name: "one", status: "unknown" }),
+    );
+
+    for (const fetcher of [transportFailure, invalidJson, invalidPage]) {
+      await expect(
+        listOAuthProjectsPage({
+          clerkSessionToken: "session-token",
+          fetcher,
+        }),
+      ).rejects.toMatchObject({ status: 502 });
+    }
+    for (const fetcher of [transportFailure, invalidJson, invalidProject]) {
+      await expect(
+        requireActiveOAuthProject({
+          clerkSessionToken: "session-token",
+          projectId: "proj_1",
+          fetcher,
+        }),
+      ).rejects.toMatchObject({ status: 502 });
+    }
+  });
+
   test("fails on API and pagination errors", async () => {
     const unavailable = mock(async () => new Response(null, { status: 503 }));
     await expect(

--- a/src/lib/oauth-projects.ts
+++ b/src/lib/oauth-projects.ts
@@ -1,3 +1,8 @@
+export type OAuthProjectsFetcher = (
+  input: URL | RequestInfo,
+  init?: RequestInit,
+) => Promise<Response>;
+
 export interface OAuthProject {
   id: string;
   name: string;
@@ -15,6 +20,7 @@ export class OAuthProjectsError extends Error {
 
 export async function listOAuthProjects(
   clerkSessionToken: string,
+  fetcher: OAuthProjectsFetcher = fetch,
 ): Promise<OAuthProject[]> {
   const apiBaseUrl = process.env.API_BASE_URL;
   if (!apiBaseUrl) {
@@ -30,7 +36,7 @@ export async function listOAuthProjects(
     url.searchParams.set("limit", String(limit));
     url.searchParams.set("offset", String(offset));
 
-    const response = await fetch(url, {
+    const response = await fetcher(url, {
       headers: {
         Authorization: `Bearer ${clerkSessionToken}`,
         "X-Source": "oauth-server",
@@ -63,11 +69,13 @@ export async function listOAuthProjects(
 export async function requireActiveOAuthProject({
   clerkSessionToken,
   projectId,
+  fetcher,
 }: {
   clerkSessionToken: string;
   projectId: string;
+  fetcher?: OAuthProjectsFetcher;
 }): Promise<OAuthProject> {
-  const projects = await listOAuthProjects(clerkSessionToken);
+  const projects = await listOAuthProjects(clerkSessionToken, fetcher);
   const project = projects.find((candidate) => candidate.id === projectId);
   if (!project) {
     throw new OAuthProjectsError("Project not found or inactive", 404);

--- a/src/lib/oauth-projects.ts
+++ b/src/lib/oauth-projects.ts
@@ -1,0 +1,76 @@
+export interface OAuthProject {
+  id: string;
+  name: string;
+  status: "active" | "archived";
+}
+
+export class OAuthProjectsError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+  }
+}
+
+export async function listOAuthProjects(
+  clerkSessionToken: string,
+): Promise<OAuthProject[]> {
+  const apiBaseUrl = process.env.API_BASE_URL;
+  if (!apiBaseUrl) {
+    throw new OAuthProjectsError("API_BASE_URL is not configured", 500);
+  }
+
+  const projects: OAuthProject[] = [];
+  const limit = 100;
+  let offset = 0;
+
+  for (;;) {
+    const url = new URL("/org/projects", apiBaseUrl);
+    url.searchParams.set("limit", String(limit));
+    url.searchParams.set("offset", String(offset));
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${clerkSessionToken}`,
+        "X-Source": "oauth-server",
+      },
+      cache: "no-store",
+    });
+    if (!response.ok) {
+      throw new OAuthProjectsError(
+        `Failed to load projects (${response.status})`,
+        response.status === 401 || response.status === 403
+          ? response.status
+          : 502,
+      );
+    }
+
+    const page = (await response.json()) as OAuthProject[];
+    projects.push(...page.filter((project) => project.status === "active"));
+
+    if (response.headers.get("X-Has-More") !== "true") break;
+    const nextOffset = Number(response.headers.get("X-Next-Offset"));
+    if (!Number.isInteger(nextOffset) || nextOffset <= offset) {
+      throw new OAuthProjectsError("Invalid project pagination response", 502);
+    }
+    offset = nextOffset;
+  }
+
+  return projects;
+}
+
+export async function requireActiveOAuthProject({
+  clerkSessionToken,
+  projectId,
+}: {
+  clerkSessionToken: string;
+  projectId: string;
+}): Promise<OAuthProject> {
+  const projects = await listOAuthProjects(clerkSessionToken);
+  const project = projects.find((candidate) => candidate.id === projectId);
+  if (!project) {
+    throw new OAuthProjectsError("Project not found or inactive", 404);
+  }
+  return project;
+}

--- a/src/lib/oauth-projects.ts
+++ b/src/lib/oauth-projects.ts
@@ -19,9 +19,53 @@ export class OAuthProjectsError extends Error {
   constructor(
     message: string,
     readonly status: number,
+    options?: ErrorOptions,
   ) {
-    super(message);
+    super(message, options);
   }
+}
+
+async function fetchProjectsApi(
+  fetcher: OAuthProjectsFetcher,
+  input: URL,
+  init: RequestInit,
+): Promise<Response> {
+  try {
+    return await fetcher(input, init);
+  } catch (error) {
+    throw new OAuthProjectsError("Project API request failed", 502, {
+      cause: error,
+    });
+  }
+}
+
+async function parseProjectsJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch (error) {
+    throw new OAuthProjectsError("Invalid project API response", 502, {
+      cause: error,
+    });
+  }
+}
+
+function parseOAuthProject(value: unknown): OAuthProject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new OAuthProjectsError("Invalid project API response", 502);
+  }
+  const project = value as Record<string, unknown>;
+  if (
+    typeof project.id !== "string" ||
+    typeof project.name !== "string" ||
+    (project.status !== "active" && project.status !== "archived")
+  ) {
+    throw new OAuthProjectsError("Invalid project API response", 502);
+  }
+  return {
+    id: project.id,
+    name: project.name,
+    status: project.status,
+  };
 }
 
 function apiBaseUrl(): string {
@@ -57,7 +101,7 @@ export async function listOAuthProjectsPage({
   url.searchParams.set("offset", String(offset));
   if (query) url.searchParams.set("query", query);
 
-  const response = await fetcher(url, {
+  const response = await fetchProjectsApi(fetcher, url, {
     headers: projectHeaders(clerkSessionToken),
     cache: "no-store",
   });
@@ -70,7 +114,11 @@ export async function listOAuthProjectsPage({
     );
   }
 
-  const page = (await response.json()) as OAuthProject[];
+  const value = await parseProjectsJson(response);
+  if (!Array.isArray(value)) {
+    throw new OAuthProjectsError("Invalid project API response", 502);
+  }
+  const page = value.map(parseOAuthProject);
   const hasMore = response.headers.get("X-Has-More") === "true";
   const nextOffsetValue = response.headers.get("X-Next-Offset");
   const nextOffset = nextOffsetValue ? Number(nextOffsetValue) : undefined;
@@ -103,7 +151,7 @@ export async function requireActiveOAuthProject({
     `/org/projects/${encodeURIComponent(projectId)}`,
     apiBaseUrl(),
   );
-  const response = await fetcher(url, {
+  const response = await fetchProjectsApi(fetcher, url, {
     headers: projectHeaders(clerkSessionToken),
     cache: "no-store",
   });
@@ -118,7 +166,7 @@ export async function requireActiveOAuthProject({
     );
   }
 
-  const project = (await response.json()) as OAuthProject;
+  const project = parseOAuthProject(await parseProjectsJson(response));
   if (project.status !== "active" || project.id !== projectId) {
     throw new OAuthProjectsError("Project not found or inactive", 404);
   }

--- a/src/lib/oauth-projects.ts
+++ b/src/lib/oauth-projects.ts
@@ -9,6 +9,12 @@ export interface OAuthProject {
   status: "active" | "archived";
 }
 
+export interface OAuthProjectsPage {
+  projects: OAuthProject[];
+  hasMore: boolean;
+  nextOffset?: number;
+}
+
 export class OAuthProjectsError extends Error {
   constructor(
     message: string,
@@ -18,66 +24,98 @@ export class OAuthProjectsError extends Error {
   }
 }
 
-export async function listOAuthProjects(
-  clerkSessionToken: string,
-  fetcher: OAuthProjectsFetcher = fetch,
-): Promise<OAuthProject[]> {
-  const apiBaseUrl = process.env.API_BASE_URL;
-  if (!apiBaseUrl) {
+function apiBaseUrl(): string {
+  const value = process.env.API_BASE_URL;
+  if (!value) {
     throw new OAuthProjectsError("API_BASE_URL is not configured", 500);
   }
+  return value;
+}
 
-  const projects: OAuthProject[] = [];
-  const limit = 100;
-  let offset = 0;
+function projectHeaders(clerkSessionToken: string): HeadersInit {
+  return {
+    Authorization: `Bearer ${clerkSessionToken}`,
+    "X-Source": "oauth-server",
+  };
+}
 
-  for (;;) {
-    const url = new URL("/org/projects", apiBaseUrl);
-    url.searchParams.set("limit", String(limit));
-    url.searchParams.set("offset", String(offset));
+export async function listOAuthProjectsPage({
+  clerkSessionToken,
+  query,
+  limit = 20,
+  offset = 0,
+  fetcher = fetch,
+}: {
+  clerkSessionToken: string;
+  query?: string;
+  limit?: number;
+  offset?: number;
+  fetcher?: OAuthProjectsFetcher;
+}): Promise<OAuthProjectsPage> {
+  const url = new URL("/org/projects", apiBaseUrl());
+  url.searchParams.set("limit", String(limit));
+  url.searchParams.set("offset", String(offset));
+  if (query) url.searchParams.set("query", query);
 
-    const response = await fetcher(url, {
-      headers: {
-        Authorization: `Bearer ${clerkSessionToken}`,
-        "X-Source": "oauth-server",
-      },
-      cache: "no-store",
-    });
-    if (!response.ok) {
-      throw new OAuthProjectsError(
-        `Failed to load projects (${response.status})`,
-        response.status === 401 || response.status === 403
-          ? response.status
-          : 502,
-      );
-    }
-
-    const page = (await response.json()) as OAuthProject[];
-    projects.push(...page.filter((project) => project.status === "active"));
-
-    if (response.headers.get("X-Has-More") !== "true") break;
-    const nextOffset = Number(response.headers.get("X-Next-Offset"));
-    if (!Number.isInteger(nextOffset) || nextOffset <= offset) {
-      throw new OAuthProjectsError("Invalid project pagination response", 502);
-    }
-    offset = nextOffset;
+  const response = await fetcher(url, {
+    headers: projectHeaders(clerkSessionToken),
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    throw new OAuthProjectsError(
+      `Failed to load projects (${response.status})`,
+      response.status === 401 || response.status === 403
+        ? response.status
+        : 502,
+    );
   }
 
-  return projects;
+  const page = (await response.json()) as OAuthProject[];
+  const hasMore = response.headers.get("X-Has-More") === "true";
+  const nextOffsetValue = response.headers.get("X-Next-Offset");
+  const nextOffset = nextOffsetValue ? Number(nextOffsetValue) : undefined;
+  if (
+    hasMore &&
+    (nextOffset === undefined ||
+      !Number.isInteger(nextOffset) ||
+      nextOffset <= offset)
+  ) {
+    throw new OAuthProjectsError("Invalid project pagination response", 502);
+  }
+
+  return {
+    projects: page.filter((project) => project.status === "active"),
+    hasMore,
+    ...(hasMore ? { nextOffset } : {}),
+  };
 }
 
 export async function requireActiveOAuthProject({
   clerkSessionToken,
   projectId,
-  fetcher,
+  fetcher = fetch,
 }: {
   clerkSessionToken: string;
   projectId: string;
   fetcher?: OAuthProjectsFetcher;
 }): Promise<OAuthProject> {
-  const projects = await listOAuthProjects(clerkSessionToken, fetcher);
-  const project = projects.find((candidate) => candidate.id === projectId);
-  if (!project) {
+  const url = new URL(
+    `/org/projects/${encodeURIComponent(projectId)}`,
+    apiBaseUrl(),
+  );
+  const response = await fetcher(url, {
+    headers: projectHeaders(clerkSessionToken),
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    throw new OAuthProjectsError(
+      "Project not found or inactive",
+      response.status === 404 ? 404 : 502,
+    );
+  }
+
+  const project = (await response.json()) as OAuthProject;
+  if (project.status !== "active" || project.id !== projectId) {
     throw new OAuthProjectsError("Project not found or inactive", 404);
   }
   return project;

--- a/src/lib/oauth-projects.ts
+++ b/src/lib/oauth-projects.ts
@@ -110,7 +110,11 @@ export async function requireActiveOAuthProject({
   if (!response.ok) {
     throw new OAuthProjectsError(
       "Project not found or inactive",
-      response.status === 404 ? 404 : 502,
+      response.status === 401 ||
+      response.status === 403 ||
+      response.status === 404
+        ? response.status
+        : 502,
     );
   }
 

--- a/src/lib/org-utils.test.ts
+++ b/src/lib/org-utils.test.ts
@@ -1,31 +1,35 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import {
   type OAuthAuthorizationContext,
   projectAuthorizationContext,
 } from "./oauth-context";
+import type { AuthorizationContextDependencies } from "./org-utils";
 
 process.env.KERNEL_CLI_PROD_CLIENT_ID ??= "cli_prod";
 process.env.KERNEL_CLI_STAGING_CLIENT_ID ??= "cli_staging";
 process.env.KERNEL_CLI_DEV_CLIENT_ID ??= "cli_dev";
+
+const { resolveAuthorizationContext } = await import("./org-utils");
 
 let requestContext: OAuthAuthorizationContext | null = null;
 let clientContext: OAuthAuthorizationContext | null = null;
 let refreshContext: OAuthAuthorizationContext | null = null;
 let requestLookup: { clientId: string; codeChallenge: string } | null = null;
 
-mock.module("./redis", () => ({
-  getAuthorizationContextForRequest: async (value: {
-    clientId: string;
-    codeChallenge: string;
-  }) => {
+const dependencies: AuthorizationContextDependencies = {
+  getRequestContext: async (value) => {
     requestLookup = value;
     return requestContext;
   },
-  getAuthorizationContextForClientId: async () => clientContext,
-  getAuthorizationContextForRefreshTokenSliding: async () => refreshContext,
-}));
+  getClientContext: async () => clientContext,
+  getRefreshContext: async () => refreshContext,
+};
 
-const { resolveAuthorizationContext } = await import("./org-utils");
+function resolveContext(
+  input: Parameters<typeof resolveAuthorizationContext>[0],
+) {
+  return resolveAuthorizationContext(input, dependencies);
+}
 
 beforeEach(() => {
   requestContext = null;
@@ -42,7 +46,7 @@ describe("resolveAuthorizationContext", () => {
       projectId: "proj_1",
     });
 
-    const result = await resolveAuthorizationContext({
+    const result = await resolveContext({
       grantType: "authorization_code",
       clientId: "client_1",
       codeVerifier: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
@@ -65,7 +69,7 @@ describe("resolveAuthorizationContext", () => {
       projectId: "proj_1",
     });
 
-    const result = await resolveAuthorizationContext({
+    const result = await resolveContext({
       grantType: "refresh_token",
       clientId: "cli_prod",
       refreshToken: "refresh-token",
@@ -75,7 +79,7 @@ describe("resolveAuthorizationContext", () => {
   });
 
   test("shared clients cannot supply authorization context directly", async () => {
-    const result = await resolveAuthorizationContext({
+    const result = await resolveContext({
       grantType: "authorization_code",
       clientId: "cli_prod",
     });
@@ -91,7 +95,7 @@ describe("resolveAuthorizationContext", () => {
       projectId: "proj_wrong",
     });
 
-    const result = await resolveAuthorizationContext({
+    const result = await resolveContext({
       grantType: "authorization_code",
       clientId: "client_1",
       codeVerifier: "verifier",
@@ -102,14 +106,14 @@ describe("resolveAuthorizationContext", () => {
   });
 
   test("fails when request and refresh context have expired", async () => {
-    const authCode = await resolveAuthorizationContext({
+    const authCode = await resolveContext({
       grantType: "authorization_code",
       clientId: "client_1",
       codeVerifier: "verifier",
     });
     expect(authCode.error?.status).toBe(400);
 
-    const refresh = await resolveAuthorizationContext({
+    const refresh = await resolveContext({
       grantType: "refresh_token",
       clientId: "client_1",
       refreshToken: "refresh-token",

--- a/src/lib/org-utils.test.ts
+++ b/src/lib/org-utils.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  type OAuthAuthorizationContext,
+  projectAuthorizationContext,
+} from "./oauth-context";
+
+process.env.KERNEL_CLI_PROD_CLIENT_ID ??= "cli_prod";
+process.env.KERNEL_CLI_STAGING_CLIENT_ID ??= "cli_staging";
+process.env.KERNEL_CLI_DEV_CLIENT_ID ??= "cli_dev";
+
+let requestContext: OAuthAuthorizationContext | null = null;
+let clientContext: OAuthAuthorizationContext | null = null;
+let refreshContext: OAuthAuthorizationContext | null = null;
+let requestLookup: { clientId: string; codeChallenge: string } | null = null;
+
+mock.module("./redis", () => ({
+  getAuthorizationContextForRequest: async (value: {
+    clientId: string;
+    codeChallenge: string;
+  }) => {
+    requestLookup = value;
+    return requestContext;
+  },
+  getAuthorizationContextForClientId: async () => clientContext,
+  getAuthorizationContextForRefreshTokenSliding: async () => refreshContext,
+}));
+
+const { resolveAuthorizationContext } = await import("./org-utils");
+
+beforeEach(() => {
+  requestContext = null;
+  clientContext = null;
+  refreshContext = null;
+  requestLookup = null;
+});
+
+describe("resolveAuthorizationContext", () => {
+  test("uses the PKCE-bound request context", async () => {
+    requestContext = projectAuthorizationContext({
+      clerkUserId: "user_1",
+      clerkOrgId: "org_1",
+      projectId: "proj_1",
+    });
+
+    const result = await resolveAuthorizationContext({
+      grantType: "authorization_code",
+      clientId: "client_1",
+      codeVerifier: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+    });
+
+    expect(requestLookup).toEqual({
+      clientId: "client_1",
+      codeChallenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+    });
+    expect(result.authorizationContext).toEqual(requestContext);
+    expect(result.requestCodeChallenge).toBe(requestLookup.codeChallenge);
+  });
+
+  test("refresh uses only the refresh-token mapping", async () => {
+    refreshContext = projectAuthorizationContext({
+      clerkUserId: "user_1",
+      clerkOrgId: "org_1",
+      projectId: "proj_1",
+    });
+
+    const result = await resolveAuthorizationContext({
+      grantType: "refresh_token",
+      clientId: "cli_prod",
+      refreshToken: "refresh-token",
+    });
+
+    expect(result.authorizationContext).toEqual(refreshContext);
+  });
+
+  test("shared clients cannot supply authorization context directly", async () => {
+    const result = await resolveAuthorizationContext({
+      grantType: "authorization_code",
+      clientId: "cli_prod",
+    });
+
+    expect(result.authorizationContext).toBeNull();
+    expect(result.error?.status).toBe(400);
+  });
+
+  test("does not fall back to client context when PKCE context is missing", async () => {
+    clientContext = projectAuthorizationContext({
+      clerkUserId: "user_1",
+      clerkOrgId: "org_wrong",
+      projectId: "proj_wrong",
+    });
+
+    const result = await resolveAuthorizationContext({
+      grantType: "authorization_code",
+      clientId: "client_1",
+      codeVerifier: "verifier",
+    });
+
+    expect(result.authorizationContext).toBeNull();
+    expect(result.error?.status).toBe(400);
+  });
+
+  test("fails when request and refresh context have expired", async () => {
+    const authCode = await resolveAuthorizationContext({
+      grantType: "authorization_code",
+      clientId: "client_1",
+      codeVerifier: "verifier",
+    });
+    expect(authCode.error?.status).toBe(400);
+
+    const refresh = await resolveAuthorizationContext({
+      grantType: "refresh_token",
+      clientId: "client_1",
+      refreshToken: "refresh-token",
+    });
+    expect(refresh.error?.status).toBe(400);
+  });
+});

--- a/src/lib/org-utils.test.ts
+++ b/src/lib/org-utils.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import {
   type OAuthAuthorizationContext,
+  organizationAuthorizationContext,
   projectAuthorizationContext,
 } from "./oauth-context";
 import type { AuthorizationContextDependencies } from "./org-utils";
@@ -8,6 +9,7 @@ import type { AuthorizationContextDependencies } from "./org-utils";
 process.env.KERNEL_CLI_PROD_CLIENT_ID ??= "cli_prod";
 process.env.KERNEL_CLI_STAGING_CLIENT_ID ??= "cli_staging";
 process.env.KERNEL_CLI_DEV_CLIENT_ID ??= "cli_dev";
+process.env.OAUTH_LEGACY_NON_PKCE_CLIENT_IDS = "legacy_client";
 
 const { resolveAuthorizationContext } = await import("./org-utils");
 
@@ -78,10 +80,46 @@ describe("resolveAuthorizationContext", () => {
     expect(result.authorizationContext).toEqual(refreshContext);
   });
 
-  test("shared clients cannot supply authorization context directly", async () => {
+  test("does not resolve client context outside the legacy allowlist", async () => {
+    clientContext = projectAuthorizationContext({
+      clerkUserId: "user_1",
+      clerkOrgId: "org_1",
+      projectId: "proj_1",
+    });
+
     const result = await resolveContext({
       grantType: "authorization_code",
-      clientId: "cli_prod",
+      clientId: "client_1",
+    });
+
+    expect(result.authorizationContext).toBeNull();
+    expect(result.error?.status).toBe(400);
+  });
+
+  test("resolves organization context for an allowlisted legacy client", async () => {
+    clientContext = organizationAuthorizationContext({
+      clerkUserId: "user_1",
+      clerkOrgId: "org_1",
+    });
+
+    const result = await resolveContext({
+      grantType: "authorization_code",
+      clientId: "legacy_client",
+    });
+
+    expect(result.authorizationContext).toEqual(clientContext);
+  });
+
+  test("rejects project context for an allowlisted legacy client", async () => {
+    clientContext = projectAuthorizationContext({
+      clerkUserId: "user_1",
+      clerkOrgId: "org_1",
+      projectId: "proj_1",
+    });
+
+    const result = await resolveContext({
+      grantType: "authorization_code",
+      clientId: "legacy_client",
     });
 
     expect(result.authorizationContext).toBeNull();

--- a/src/lib/org-utils.test.ts
+++ b/src/lib/org-utils.test.ts
@@ -53,7 +53,9 @@ describe("resolveAuthorizationContext", () => {
       codeChallenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
     });
     expect(result.authorizationContext).toEqual(requestContext);
-    expect(result.requestCodeChallenge).toBe(requestLookup.codeChallenge);
+    expect(result.requestCodeChallenge).toBe(
+      "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+    );
   });
 
   test("refresh uses only the refresh-token mapping", async () => {

--- a/src/lib/org-utils.ts
+++ b/src/lib/org-utils.ts
@@ -1,17 +1,22 @@
 import { NextResponse } from "next/server";
-import { getOrgIdForClientId, getOrgIdForRefreshTokenSliding } from "./redis";
-import { REFRESH_TOKEN_ORG_TTL_SECONDS, SHARED_CLIENT_IDS } from "./const";
+import {
+  getAuthorizationContextForClientId,
+  getAuthorizationContextForRefreshTokenSliding,
+  getAuthorizationContextForRequest,
+} from "./redis";
+import { REFRESH_TOKEN_ORG_TTL_SECONDS } from "./const";
+import {
+  deriveS256CodeChallenge,
+  type OAuthAuthorizationContext,
+} from "./oauth-context";
 
 function createErrorResponse(
   error: string,
   errorDescription: string,
-  status: number = 400,
+  status = 400,
 ) {
   return NextResponse.json(
-    {
-      error,
-      error_description: errorDescription,
-    },
+    { error, error_description: errorDescription },
     {
       status,
       headers: {
@@ -23,142 +28,91 @@ function createErrorResponse(
   );
 }
 
-/**
- * Resolves organization ID based on client type and grant type
- * @param grantType - OAuth grant type ("authorization_code" or "refresh_token")
- * @param clientId - The OAuth client ID
- * @param directOrgId - The org_id from OAuth state parameter (shared clients only)
- * @param refreshToken - The refresh token from OAuth state parameter (shared clients only)
- * @returns { orgId: string | null, error?: NextResponse } - org_id or error response
- */
-export async function resolveOrgId({
+export interface ResolvedAuthorizationContext {
+  authorizationContext: OAuthAuthorizationContext | null;
+  requestCodeChallenge?: string;
+  error?: NextResponse;
+}
+
+export async function resolveAuthorizationContext({
   grantType,
   clientId,
-  directOrgId,
+  codeVerifier,
   refreshToken,
 }: {
   grantType: string;
   clientId: string;
-  directOrgId?: string;
+  codeVerifier?: string;
   refreshToken?: string;
-}): Promise<{ orgId: string | null; error?: NextResponse }> {
-  const isSharedClient = SHARED_CLIENT_IDS.includes(clientId);
-  const clientIdMasked = clientId ? clientId.slice(0, 4) + "..." : "";
-  console.debug("[org-utils] resolveOrgId", {
-    grantType,
-    isSharedClient,
-    hasDirectOrgId: Boolean(directOrgId),
-    hasRefreshToken: Boolean(refreshToken),
-  });
-
-  if (isSharedClient) {
-    // Shared clients (CLI): Use org_id from OAuth state parameter
-    if (directOrgId) {
-      console.debug("[org-utils] shared client: using direct org_id from body");
-      return { orgId: directOrgId };
-    } else if (grantType === "refresh_token") {
-      if (!refreshToken) {
-        console.warn(
-          "[org-utils] shared client: missing refresh_token in request body",
-        );
-        return {
-          orgId: null,
-          error: createErrorResponse(
-            "invalid_request",
-            "Missing required parameter: refresh_token",
-          ),
-        };
-      }
-      try {
-        const orgIdFromRefresh = await getOrgIdForRefreshTokenSliding({
-          refreshToken,
-          ttlSeconds: REFRESH_TOKEN_ORG_TTL_SECONDS,
-        });
-        if (orgIdFromRefresh) {
-          console.debug(
-            "[org-utils] shared client: resolved org via refresh_token mapping",
-          );
-          return { orgId: orgIdFromRefresh };
-        }
-      } catch (e) {
-        console.error(
-          "[org-utils] shared client: error reading refresh_token mapping",
-          { error: e },
-        );
-        return {
-          orgId: null,
-          error: createErrorResponse(
-            "server_error",
-            "Failed to retrieve organization context for refresh token.",
-          ),
-        };
-      }
-      console.warn(
-        "[org-utils] shared client: missing org_id and no refresh mapping",
-      );
-      return {
-        orgId: null,
-        error: createErrorResponse(
-          "invalid_grant",
-          "Missing organization context in refresh request. Please re-authorize.",
-        ),
-      };
-    } else {
-      console.warn("[org-utils] shared client: missing org_id in request body");
-      return {
-        orgId: null,
-        error: createErrorResponse(
-          "invalid_grant",
-          "Missing organization context in OAuth request body. Please re-authorize.",
-        ),
-      };
-    }
-  }
-
-  // Ephemeral clients (MCP)
+}): Promise<ResolvedAuthorizationContext> {
   if (grantType === "authorization_code") {
-    // Use client_id mapping just to bridge the initial hop
-    try {
-      const orgId = await getOrgIdForClientId({ clientId });
-      if (orgId) {
-        console.debug(
-          "[org-utils] ephemeral client: resolved org via client_id mapping",
-        );
-        return { orgId };
-      } else {
-        console.warn(
-          "[org-utils] ephemeral client: missing org context for authorization_code",
-          { clientIdMasked },
-        );
+    if (codeVerifier) {
+      const codeChallenge = deriveS256CodeChallenge(codeVerifier);
+      try {
+        const authorizationContext = await getAuthorizationContextForRequest({
+          clientId,
+          codeChallenge,
+        });
+        if (authorizationContext) {
+          return {
+            authorizationContext,
+            requestCodeChallenge: codeChallenge,
+          };
+        }
         return {
-          orgId: null,
+          authorizationContext: null,
           error: createErrorResponse(
             "invalid_grant",
-            "Organization context expired for client: " +
-              clientId +
-              ". Please re-authorize to select your organization.",
+            "Authorization context expired. Please re-authorize.",
+          ),
+        };
+      } catch (error) {
+        console.error("[org-utils] failed to read PKCE authorization context", {
+          error,
+        });
+        return {
+          authorizationContext: null,
+          error: createErrorResponse(
+            "server_error",
+            "Failed to retrieve authorization context",
+            500,
           ),
         };
       }
+    }
+
+    try {
+      const authorizationContext = await getAuthorizationContextForClientId({
+        clientId,
+      });
+      if (authorizationContext) return { authorizationContext };
     } catch (error) {
-      console.error(
-        "[org-utils] ephemeral client: error reading client_id mapping",
-        { error, clientIdMasked },
-      );
+      console.error("[org-utils] failed to read client authorization context", {
+        error,
+      });
       return {
-        orgId: null,
+        authorizationContext: null,
         error: createErrorResponse(
           "server_error",
-          "Failed to retrieve organization context for client: " + clientId,
+          "Failed to retrieve authorization context",
+          500,
         ),
       };
     }
-  } else if (grantType === "refresh_token") {
-    // Use refresh_token mapping for ongoing refresh flows
+
+    return {
+      authorizationContext: null,
+      error: createErrorResponse(
+        "invalid_grant",
+        "Authorization context expired. Please re-authorize.",
+      ),
+    };
+  }
+
+  if (grantType === "refresh_token") {
     if (!refreshToken) {
-      console.debug("[org-utils] refresh flow without refresh_token param");
       return {
-        orgId: null,
+        authorizationContext: null,
         error: createErrorResponse(
           "invalid_request",
           "Missing required parameter: refresh_token",
@@ -166,40 +120,40 @@ export async function resolveOrgId({
       };
     }
     try {
-      const orgId = await getOrgIdForRefreshTokenSliding({
-        refreshToken,
-        ttlSeconds: REFRESH_TOKEN_ORG_TTL_SECONDS,
-      });
-      if (orgId) {
-        console.debug("[org-utils] resolved org via refresh_token mapping");
-        return { orgId };
-      }
-      console.warn(
-        "[org-utils] no org mapping for refresh_token (expired or unknown)",
+      const authorizationContext =
+        await getAuthorizationContextForRefreshTokenSliding({
+          refreshToken,
+          ttlSeconds: REFRESH_TOKEN_ORG_TTL_SECONDS,
+        });
+      if (authorizationContext) return { authorizationContext };
+    } catch (error) {
+      console.error(
+        "[org-utils] failed to read refresh authorization context",
+        {
+          error,
+        },
       );
       return {
-        orgId: null,
-        error: createErrorResponse(
-          "invalid_grant",
-          "Organization context expired for this refresh token. Please re-authorize.",
-        ),
-      };
-    } catch (error) {
-      console.error("[org-utils] error reading refresh_token mapping", {
-        error,
-      });
-      return {
-        orgId: null,
+        authorizationContext: null,
         error: createErrorResponse(
           "server_error",
-          "Failed to retrieve organization context for refresh token.",
+          "Failed to retrieve authorization context for refresh token",
+          500,
         ),
       };
     }
+
+    return {
+      authorizationContext: null,
+      error: createErrorResponse(
+        "invalid_grant",
+        "Authorization context expired for this refresh token. Please re-authorize.",
+      ),
+    };
   }
 
   return {
-    orgId: null,
+    authorizationContext: null,
     error: createErrorResponse(
       "unsupported_grant_type",
       `Grant type '${grantType}' is not supported`,

--- a/src/lib/org-utils.ts
+++ b/src/lib/org-utils.ts
@@ -28,28 +28,43 @@ function createErrorResponse(
   );
 }
 
+export interface AuthorizationContextDependencies {
+  getRequestContext: typeof getAuthorizationContextForRequest;
+  getClientContext: typeof getAuthorizationContextForClientId;
+  getRefreshContext: typeof getAuthorizationContextForRefreshTokenSliding;
+}
+
+const authorizationContextDependencies: AuthorizationContextDependencies = {
+  getRequestContext: getAuthorizationContextForRequest,
+  getClientContext: getAuthorizationContextForClientId,
+  getRefreshContext: getAuthorizationContextForRefreshTokenSliding,
+};
+
 export interface ResolvedAuthorizationContext {
   authorizationContext: OAuthAuthorizationContext | null;
   requestCodeChallenge?: string;
   error?: NextResponse;
 }
 
-export async function resolveAuthorizationContext({
-  grantType,
-  clientId,
-  codeVerifier,
-  refreshToken,
-}: {
-  grantType: string;
-  clientId: string;
-  codeVerifier?: string;
-  refreshToken?: string;
-}): Promise<ResolvedAuthorizationContext> {
+export async function resolveAuthorizationContext(
+  {
+    grantType,
+    clientId,
+    codeVerifier,
+    refreshToken,
+  }: {
+    grantType: string;
+    clientId: string;
+    codeVerifier?: string;
+    refreshToken?: string;
+  },
+  dependencies: AuthorizationContextDependencies = authorizationContextDependencies,
+): Promise<ResolvedAuthorizationContext> {
   if (grantType === "authorization_code") {
     if (codeVerifier) {
       const codeChallenge = deriveS256CodeChallenge(codeVerifier);
       try {
-        const authorizationContext = await getAuthorizationContextForRequest({
+        const authorizationContext = await dependencies.getRequestContext({
           clientId,
           codeChallenge,
         });
@@ -82,7 +97,7 @@ export async function resolveAuthorizationContext({
     }
 
     try {
-      const authorizationContext = await getAuthorizationContextForClientId({
+      const authorizationContext = await dependencies.getClientContext({
         clientId,
       });
       if (authorizationContext) return { authorizationContext };
@@ -120,11 +135,10 @@ export async function resolveAuthorizationContext({
       };
     }
     try {
-      const authorizationContext =
-        await getAuthorizationContextForRefreshTokenSliding({
-          refreshToken,
-          ttlSeconds: REFRESH_TOKEN_ORG_TTL_SECONDS,
-        });
+      const authorizationContext = await dependencies.getRefreshContext({
+        refreshToken,
+        ttlSeconds: REFRESH_TOKEN_ORG_TTL_SECONDS,
+      });
       if (authorizationContext) return { authorizationContext };
     } catch (error) {
       console.error(

--- a/src/lib/org-utils.ts
+++ b/src/lib/org-utils.ts
@@ -4,10 +4,11 @@ import {
   getAuthorizationContextForRefreshTokenSliding,
   getAuthorizationContextForRequest,
 } from "./redis";
-import { REFRESH_TOKEN_ORG_TTL_SECONDS } from "./const";
+import { isLegacyNonPkceClient, REFRESH_TOKEN_ORG_TTL_SECONDS } from "./const";
 import {
   deriveS256CodeChallenge,
   type OAuthAuthorizationContext,
+  ORGANIZATION_ACCESS_SCOPE,
 } from "./oauth-context";
 
 function createErrorResponse(
@@ -96,11 +97,32 @@ export async function resolveAuthorizationContext(
       }
     }
 
+    if (!isLegacyNonPkceClient(clientId)) {
+      return {
+        authorizationContext: null,
+        error: createErrorResponse(
+          "invalid_grant",
+          "PKCE authorization context required. Please re-authorize.",
+        ),
+      };
+    }
+
     try {
       const authorizationContext = await dependencies.getClientContext({
         clientId,
       });
-      if (authorizationContext) return { authorizationContext };
+      if (authorizationContext?.access_scope === ORGANIZATION_ACCESS_SCOPE) {
+        return { authorizationContext };
+      }
+      if (authorizationContext) {
+        return {
+          authorizationContext: null,
+          error: createErrorResponse(
+            "invalid_grant",
+            "Legacy non-PKCE authorization must be organization-wide.",
+          ),
+        };
+      }
     } catch (error) {
       console.error("[org-utils] failed to read client authorization context", {
         error,

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,6 +1,11 @@
 import { createClient } from "redis";
 import { createHmac } from "crypto";
 import { mcpAppsMarkerKey } from "@/lib/mcp-apps-marker";
+import {
+  type OAuthAuthorizationContext,
+  parseAuthorizationContext,
+  serializeAuthorizationContext,
+} from "@/lib/oauth-context";
 
 const redisUrl = process.env.REDIS_URL;
 const redisTlsServerName = process.env.REDIS_TLS_SERVER_NAME;
@@ -108,43 +113,110 @@ function hashOpaqueToken(token: string): string {
   return createHmac("sha256", secretKey).update(token).digest("hex");
 }
 
-export async function setOrgIdForClientId({
+function authorizationRequestKey(
+  clientId: string,
+  codeChallenge: string,
+): string {
+  return `oauth-request:${hashOpaqueToken(`${clientId}:${codeChallenge}`)}`;
+}
+
+export async function setAuthorizationContextForRequest({
   clientId,
-  orgId,
+  codeChallenge,
+  authorizationContext,
   ttlSeconds,
 }: {
   clientId: string;
-  orgId: string;
+  codeChallenge: string;
+  authorizationContext: OAuthAuthorizationContext;
+  ttlSeconds: number;
+}): Promise<void> {
+  await ensureConnected();
+  await withReconnect(() =>
+    client.setEx(
+      authorizationRequestKey(clientId, codeChallenge),
+      ttlSeconds,
+      serializeAuthorizationContext(authorizationContext),
+    ),
+  );
+}
+
+export async function getAuthorizationContextForRequest({
+  clientId,
+  codeChallenge,
+}: {
+  clientId: string;
+  codeChallenge: string;
+}): Promise<OAuthAuthorizationContext | null> {
+  await ensureConnected();
+  const value = await withReconnect(() =>
+    client.get(authorizationRequestKey(clientId, codeChallenge)),
+  );
+  return value ? parseAuthorizationContext(value) : null;
+}
+
+export async function deleteAuthorizationContextForRequest({
+  clientId,
+  codeChallenge,
+}: {
+  clientId: string;
+  codeChallenge: string;
+}): Promise<void> {
+  await ensureConnected();
+  await withReconnect(() =>
+    client.del(authorizationRequestKey(clientId, codeChallenge)),
+  );
+}
+
+export async function setAuthorizationContextForClientId({
+  clientId,
+  authorizationContext,
+  ttlSeconds,
+}: {
+  clientId: string;
+  authorizationContext: OAuthAuthorizationContext;
   ttlSeconds: number;
 }): Promise<void> {
   await ensureConnected();
   const key = `client:${clientId}`;
-  await withReconnect(() => client.setEx(key, ttlSeconds, orgId));
+  await withReconnect(() =>
+    client.setEx(
+      key,
+      ttlSeconds,
+      serializeAuthorizationContext(authorizationContext),
+    ),
+  );
 }
 
-export async function getOrgIdForClientId({
+export async function getAuthorizationContextForClientId({
   clientId,
 }: {
   clientId: string;
-}): Promise<string | null> {
+}): Promise<OAuthAuthorizationContext | null> {
   await ensureConnected();
-  const key = `client:${clientId}`;
-  return await withReconnect(() => client.get(key));
+  const value = await withReconnect(() => client.get(`client:${clientId}`));
+  return value ? parseAuthorizationContext(value) : null;
 }
 
-export async function setOrgIdForJwt({
+export async function setAuthorizationContextForJwt({
   jwt,
-  orgId,
+  authorizationContext,
   ttlSeconds,
 }: {
   jwt: string;
-  orgId: string;
+  authorizationContext: OAuthAuthorizationContext;
   ttlSeconds: number;
 }): Promise<void> {
   await ensureConnected();
   const hashedJwt = hashJwt(jwt);
   const key = `jwt:${hashedJwt}`;
-  await withReconnect(() => client.setEx(key, ttlSeconds, orgId));
+  await withReconnect(() =>
+    client.setEx(
+      key,
+      ttlSeconds,
+      serializeAuthorizationContext(authorizationContext),
+    ),
+  );
 }
 
 export { client as redisClient };
@@ -205,48 +277,65 @@ export async function hasMcpAppsClient({
   return value !== null;
 }
 
-export async function setOrgIdForRefreshToken({
+export async function setAuthorizationContextForRefreshToken({
   refreshToken,
-  orgId,
+  authorizationContext,
   ttlSeconds,
 }: {
   refreshToken: string;
-  orgId: string;
+  authorizationContext: OAuthAuthorizationContext;
   ttlSeconds: number;
 }): Promise<void> {
   await ensureConnected();
-  const hashed = hashOpaqueToken(refreshToken);
-  const key = `refresh:${hashed}`;
-  await withReconnect(() => client.setEx(key, ttlSeconds, orgId));
+  const key = `refresh:${hashOpaqueToken(refreshToken)}`;
+  await withReconnect(() =>
+    client.setEx(
+      key,
+      ttlSeconds,
+      serializeAuthorizationContext(authorizationContext),
+    ),
+  );
 }
 
-export async function getOrgIdForRefreshTokenSliding({
+export async function getAuthorizationContextForRefreshTokenSliding({
   refreshToken,
   ttlSeconds,
 }: {
   refreshToken: string;
   ttlSeconds: number;
-}): Promise<string | null> {
+}): Promise<OAuthAuthorizationContext | null> {
   await ensureConnected();
-  const hashed = hashOpaqueToken(refreshToken);
-  const key = `refresh:${hashed}`;
-  const orgId = await withReconnect(() => client.get(key));
-  if (orgId) {
-    // Refresh TTL to implement sliding expiration on active tokens
-    await withReconnect(() => client.expire(key, ttlSeconds));
+  const key = `refresh:${hashOpaqueToken(refreshToken)}`;
+  const value = await withReconnect(() =>
+    client.getEx(key, { type: "EX", value: ttlSeconds }),
+  );
+  return value ? parseAuthorizationContext(value) : null;
+}
+
+export async function rotateAuthorizationContextForRefreshToken({
+  oldRefreshToken,
+  newRefreshToken,
+  authorizationContext,
+  ttlSeconds,
+}: {
+  oldRefreshToken: string;
+  newRefreshToken: string;
+  authorizationContext: OAuthAuthorizationContext;
+  ttlSeconds: number;
+}): Promise<void> {
+  await ensureConnected();
+  const oldKey = `refresh:${hashOpaqueToken(oldRefreshToken)}`;
+  const newKey = `refresh:${hashOpaqueToken(newRefreshToken)}`;
+  const value = serializeAuthorizationContext(authorizationContext);
+
+  if (oldKey === newKey) {
+    await withReconnect(() => client.setEx(newKey, ttlSeconds, value));
+    return;
   }
-  return orgId;
-}
 
-export async function deleteOrgIdForRefreshToken({
-  refreshToken,
-}: {
-  refreshToken: string;
-}): Promise<void> {
-  await ensureConnected();
-  const hashed = hashOpaqueToken(refreshToken);
-  const key = `refresh:${hashed}`;
-  await withReconnect(() => client.del(key));
+  await withReconnect(async () => {
+    await client.multi().setEx(newKey, ttlSeconds, value).del(oldKey).exec();
+  });
 }
 
 function isTransientSocketError(error: unknown): boolean {

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -155,19 +155,6 @@ export async function getAuthorizationContextForRequest({
   return value ? parseAuthorizationContext(value) : null;
 }
 
-export async function deleteAuthorizationContextForRequest({
-  clientId,
-  codeChallenge,
-}: {
-  clientId: string;
-  codeChallenge: string;
-}): Promise<void> {
-  await ensureConnected();
-  await withReconnect(() =>
-    client.del(authorizationRequestKey(clientId, codeChallenge)),
-  );
-}
-
 export async function setAuthorizationContextForClientId({
   clientId,
   authorizationContext,
@@ -196,27 +183,6 @@ export async function getAuthorizationContextForClientId({
   await ensureConnected();
   const value = await withReconnect(() => client.get(`client:${clientId}`));
   return value ? parseAuthorizationContext(value) : null;
-}
-
-export async function setAuthorizationContextForJwt({
-  jwt,
-  authorizationContext,
-  ttlSeconds,
-}: {
-  jwt: string;
-  authorizationContext: OAuthAuthorizationContext;
-  ttlSeconds: number;
-}): Promise<void> {
-  await ensureConnected();
-  const hashedJwt = hashJwt(jwt);
-  const key = `jwt:${hashedJwt}`;
-  await withReconnect(() =>
-    client.setEx(
-      key,
-      ttlSeconds,
-      serializeAuthorizationContext(authorizationContext),
-    ),
-  );
 }
 
 export { client as redisClient };
@@ -277,26 +243,6 @@ export async function hasMcpAppsClient({
   return value !== null;
 }
 
-export async function setAuthorizationContextForRefreshToken({
-  refreshToken,
-  authorizationContext,
-  ttlSeconds,
-}: {
-  refreshToken: string;
-  authorizationContext: OAuthAuthorizationContext;
-  ttlSeconds: number;
-}): Promise<void> {
-  await ensureConnected();
-  const key = `refresh:${hashOpaqueToken(refreshToken)}`;
-  await withReconnect(() =>
-    client.setEx(
-      key,
-      ttlSeconds,
-      serializeAuthorizationContext(authorizationContext),
-    ),
-  );
-}
-
 export async function getAuthorizationContextForRefreshTokenSliding({
   refreshToken,
   ttlSeconds,
@@ -312,29 +258,50 @@ export async function getAuthorizationContextForRefreshTokenSliding({
   return value ? parseAuthorizationContext(value) : null;
 }
 
-export async function rotateAuthorizationContextForRefreshToken({
-  oldRefreshToken,
+export async function persistOAuthTokenContexts({
+  jwt,
   newRefreshToken,
+  oldRefreshToken,
   authorizationContext,
-  ttlSeconds,
+  jwtTtlSeconds,
+  refreshTtlSeconds,
+  consumedRequest,
 }: {
-  oldRefreshToken: string;
+  jwt: string;
   newRefreshToken: string;
+  oldRefreshToken?: string;
   authorizationContext: OAuthAuthorizationContext;
-  ttlSeconds: number;
+  jwtTtlSeconds: number;
+  refreshTtlSeconds: number;
+  consumedRequest?: { clientId: string; codeChallenge: string };
 }): Promise<void> {
   await ensureConnected();
-  const oldKey = `refresh:${hashOpaqueToken(oldRefreshToken)}`;
-  const newKey = `refresh:${hashOpaqueToken(newRefreshToken)}`;
+  const jwtKey = `jwt:${hashJwt(jwt)}`;
+  const newRefreshKey = `refresh:${hashOpaqueToken(newRefreshToken)}`;
+  const oldRefreshKey = oldRefreshToken
+    ? `refresh:${hashOpaqueToken(oldRefreshToken)}`
+    : undefined;
   const value = serializeAuthorizationContext(authorizationContext);
 
-  if (oldKey === newKey) {
-    await withReconnect(() => client.setEx(newKey, ttlSeconds, value));
-    return;
-  }
-
   await withReconnect(async () => {
-    await client.multi().setEx(newKey, ttlSeconds, value).del(oldKey).exec();
+    const transaction = client
+      .multi()
+      .setEx(jwtKey, jwtTtlSeconds, value)
+      .setEx(newRefreshKey, refreshTtlSeconds, value);
+
+    if (oldRefreshKey && oldRefreshKey !== newRefreshKey) {
+      transaction.del(oldRefreshKey);
+    }
+    if (consumedRequest) {
+      transaction.del(
+        authorizationRequestKey(
+          consumedRequest.clientId,
+          consumedRequest.codeChallenge,
+        ),
+      );
+    }
+
+    await transaction.exec();
   });
 }
 


### PR DESCRIPTION
## summary

- add an explicit authorization choice between organization-wide access and one active project
- bind authorization context to PKCE requests, access tokens, and rotated refresh tokens with atomic Redis persistence
- verify Clerk organization membership before refresh rotation, enrich legacy refresh context after validation, and reject client-supplied scope escalation
- keep legacy org-only access and refresh mappings organization-wide while requiring S256 PKCE outside an explicit legacy allowlist
- normalize project API transport and response failures as temporary upstream errors and keep the hosted OAuth UI explicitly light
- add route-level coverage for registration, authorization, token exchange, refresh, project validation, concurrency boundaries, and negative cases

## tests

- `bun test` (175 passing)
- targeted Prettier checks for changed files
- `bun run build` with test build-time configuration

## dependency

Requires kernel/kernel#3165 to be deployed before this change writes structured OAuth contexts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core OAuth authorize/token flows, Redis persistence shape, and scope enforcement; depends on kernel#3165 for structured contexts and misconfiguration could break login or widen/narrow access incorrectly.
> 
> **Overview**
> Adds **organization-wide vs single-project** OAuth authorization, with project choice in `/select-org` (search/paginated via new `GET /oauth/projects`) and scope carried through authorize → token responses.
> 
> **Authorization context** replaces org-only Redis mappings: structured JSON (org + optional `project_id`) is stored on **PKCE-bound requests**, JWT/refresh tokens, and consumed atomically on code exchange. **S256 PKCE** is required for new clients and mandatory for project scope; `OAUTH_LEGACY_NON_PKCE_CLIENT_IDS` keeps org-only flows for allowlisted clients.
> 
> **Token route** resolves scope server-side (ignores client-supplied `org_id` / `access_scope` / `project_id`), checks Clerk org membership before refresh rotation, validates subject on auth-code grants, and returns `org_id`, `access_scope`, and `project_id` on issued tokens.
> 
> Docs/env note the legacy allowlist; layout forces light theme. Broad route and lib test coverage added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 010e8a0490b10549676dd88ac30f991436324236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->