### PR TITLE
Align MCP browser pools with durable API contracts

### DIFF
--- a/src/lib/mcp/browser-config.test.ts
+++ b/src/lib/mcp/browser-config.test.ts
@@ -1,0 +1,11 @@
+/// <reference types="bun-types" />
+
+import { expect, test } from "bun:test";
+import { buildBrowserCreateConfig } from "@/lib/mcp/browser-config";
+
+test("browser create config rejects an empty start URL", () => {
+  expect(buildBrowserCreateConfig({ start_url: "" })).toEqual({
+    ok: false,
+    error: "Error: start_url must be a valid URL.",
+  });
+});

--- a/src/lib/mcp/browser-config.ts
+++ b/src/lib/mcp/browser-config.ts
@@ -88,6 +88,7 @@ function buildBrowserStartUrl(
   startUrl: string | undefined,
 ): BrowserConfigResult<string | undefined> {
   if (startUrl === undefined) return configValue(undefined);
+  if (startUrl === "") return configValue("");
 
   try {
     new URL(startUrl);

--- a/src/lib/mcp/browser-config.ts
+++ b/src/lib/mcp/browser-config.ts
@@ -38,6 +38,10 @@ export type BrowserCreateConfigParams = BrowserProfileParams &
     start_url?: string;
   };
 
+export type BrowserSharedConfigParams = BrowserProfileParams &
+  BrowserExtensionParams &
+  BrowserViewportParams;
+
 export type BrowserUpdateConfigParams = BrowserProfileParams &
   BrowserViewportUpdateParams;
 
@@ -67,6 +71,11 @@ export type BrowserCreateConfig = Pick<
   "profile" | "extensions" | "viewport" | "start_url"
 >;
 
+export type BrowserSharedConfig = Pick<
+  BrowserCreateParams,
+  "profile" | "extensions" | "viewport"
+>;
+
 export type BrowserUpdateConfig = Pick<
   BrowserUpdateParams,
   "profile" | "viewport"
@@ -88,8 +97,6 @@ function buildBrowserStartUrl(
   startUrl: string | undefined,
 ): BrowserConfigResult<string | undefined> {
   if (startUrl === undefined) return configValue(undefined);
-  // Pool updates use an empty string to clear; create callers must reject it.
-  if (startUrl === "") return configValue("");
 
   try {
     new URL(startUrl);
@@ -190,9 +197,9 @@ function buildBrowserViewportUpdate(
   });
 }
 
-export function buildBrowserCreateConfig(
-  params: BrowserCreateConfigParams,
-): BrowserConfigResult<BrowserCreateConfig> {
+export function buildBrowserSharedConfig(
+  params: BrowserSharedConfigParams,
+): BrowserConfigResult<BrowserSharedConfig> {
   const profile = buildBrowserProfile(params);
   if (!profile.ok) return profile;
 
@@ -202,13 +209,24 @@ export function buildBrowserCreateConfig(
   const viewport = buildBrowserViewport(params);
   if (!viewport.ok) return viewport;
 
-  const startUrl = buildBrowserStartUrl(params.start_url);
-  if (!startUrl.ok) return startUrl;
-
   return configValue({
     ...(profile.value && { profile: profile.value }),
     ...(extensions.value && { extensions: extensions.value }),
     ...(viewport.value && { viewport: viewport.value }),
+  });
+}
+
+export function buildBrowserCreateConfig(
+  params: BrowserCreateConfigParams,
+): BrowserConfigResult<BrowserCreateConfig> {
+  const sharedConfig = buildBrowserSharedConfig(params);
+  if (!sharedConfig.ok) return sharedConfig;
+
+  const startUrl = buildBrowserStartUrl(params.start_url);
+  if (!startUrl.ok) return startUrl;
+
+  return configValue({
+    ...sharedConfig.value,
     ...(startUrl.value !== undefined && { start_url: startUrl.value }),
   });
 }

--- a/src/lib/mcp/browser-config.ts
+++ b/src/lib/mcp/browser-config.ts
@@ -88,6 +88,7 @@ function buildBrowserStartUrl(
   startUrl: string | undefined,
 ): BrowserConfigResult<string | undefined> {
   if (startUrl === undefined) return configValue(undefined);
+  // Pool updates use an empty string to clear; create callers must reject it.
   if (startUrl === "") return configValue("");
 
   try {

--- a/src/lib/mcp/kernel-client.test-fixtures.ts
+++ b/src/lib/mcp/kernel-client.test-fixtures.ts
@@ -1,0 +1,24 @@
+import { mock } from "bun:test";
+
+export const unusedKernelClient = new Proxy(
+  {},
+  {
+    get: () => {
+      throw new Error("unexpected Kernel client use");
+    },
+  },
+);
+
+export const kernelClientMock: {
+  factory: (token: string) => any;
+} = {
+  factory: () => unusedKernelClient,
+};
+
+export function resetKernelClientFactory() {
+  kernelClientMock.factory = () => unusedKernelClient;
+}
+
+mock.module("@/lib/mcp/kernel-client", () => ({
+  createKernelClient: (token: string) => kernelClientMock.factory(token),
+}));

--- a/src/lib/mcp/tools/auth-connections.test-fixtures.ts
+++ b/src/lib/mcp/tools/auth-connections.test-fixtures.ts
@@ -1,34 +1,16 @@
-import { expect, mock } from "bun:test";
+import { expect } from "bun:test";
 import type { KernelClient } from "@/lib/mcp/kernel-client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type {
   ManagedAuth,
   ManagedAuthTimelineEvent,
 } from "@onkernel/sdk/resources/auth/connections";
+export {
+  kernelClientMock,
+  resetKernelClientFactory,
+  unusedKernelClient,
+} from "@/lib/mcp/kernel-client.test-fixtures";
 import { registerAuthConnectionTools } from "./auth-connections";
-
-export const unusedKernelClient = new Proxy(
-  {},
-  {
-    get: () => {
-      throw new Error("unexpected Kernel client use");
-    },
-  },
-);
-
-export const kernelClientMock: {
-  factory: (token: string) => any;
-} = {
-  factory: () => unusedKernelClient,
-};
-
-mock.module("@/lib/mcp/kernel-client", () => ({
-  createKernelClient: (token: string) => kernelClientMock.factory(token),
-}));
-
-export function resetKernelClientFactory() {
-  kernelClientMock.factory = () => unusedKernelClient;
-}
 
 export function connection(overrides: Partial<ManagedAuth> = {}): ManagedAuth {
   return {

--- a/src/lib/mcp/tools/auth-login-app.test.ts
+++ b/src/lib/mcp/tools/auth-login-app.test.ts
@@ -3,6 +3,10 @@ import { encodeSessionId } from "@posthog/mcp";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { MANAGED_AUTH_APP_HTML } from "@/lib/mcp/apps/generated/managed-auth-app";
+import {
+  kernelClientMock,
+  resetKernelClientFactory,
+} from "@/lib/mcp/kernel-client.test-fixtures";
 import { verifyAuthFlowCheckpoint } from "@/lib/mcp/tools/managed-auth-checkpoint";
 import {
   initializeDeclaresMcpApps,
@@ -14,21 +18,6 @@ import {
 
 process.env.CLERK_SECRET_KEY ??= "test-clerk-secret";
 
-// Tests that exercise API-backed handlers substitute a fake Kernel client.
-// The default stub errors if any API method is actually invoked.
-const unusedKernelClient = new Proxy(
-  {},
-  {
-    get: () => {
-      throw new Error("unexpected Kernel client use");
-    },
-  },
-);
-let kernelClientFactory: (token: string) => any = () => unusedKernelClient;
-function resetKernelClientFactory() {
-  kernelClientFactory = () => unusedKernelClient;
-}
-
 // The capability gate falls back to a Redis marker (recorded by the route
 // layer at initialize) on stateless transports. Tests control it directly.
 let redisMarkerPresent = false;
@@ -36,10 +25,6 @@ mock.module("@/lib/redis", () => ({
   hasMcpAppsClient: async () => redisMarkerPresent,
   markMcpAppsClient: async () => {},
 }));
-mock.module("@/lib/mcp/kernel-client", () => ({
-  createKernelClient: (token: string) => kernelClientFactory(token),
-}));
-
 type ToolRegistration = {
   config: Record<string, any>;
   handler: (params: any, extra: any) => Promise<any>;
@@ -243,7 +228,7 @@ describe("managed-auth MCP App registration", () => {
     // Simulates the streamable-HTTP path: no client capabilities on the
     // per-request server, but the route layer recorded the capability.
     redisMarkerPresent = true;
-    kernelClientFactory = () => ({
+    kernelClientMock.factory = () => ({
       auth: {
         connections: {
           retrieve: async () => ({
@@ -361,7 +346,7 @@ describe("managed-auth MCP App registration", () => {
   });
 
   test("reauth launcher issues a signed server checkpoint, never a guessed flow type", async () => {
-    kernelClientFactory = () => ({
+    kernelClientMock.factory = () => ({
       auth: {
         connections: {
           retrieve: async () => ({
@@ -416,7 +401,7 @@ describe("managed-auth MCP App registration", () => {
   });
 
   test("reauth launcher preserves an explicitly empty timeline baseline", async () => {
-    kernelClientFactory = () => ({
+    kernelClientMock.factory = () => ({
       auth: {
         connections: {
           retrieve: async () => ({
@@ -454,7 +439,7 @@ describe("managed-auth MCP App registration", () => {
   });
 
   test("reauth launcher identifies an already-live flow", async () => {
-    kernelClientFactory = () => ({
+    kernelClientMock.factory = () => ({
       auth: {
         connections: {
           retrieve: async () => ({

--- a/src/lib/mcp/tools/browser-pools.test.ts
+++ b/src/lib/mcp/tools/browser-pools.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { z } from "zod";
 import {
   kernelClientMock,
@@ -60,6 +60,10 @@ function pool() {
 
 describe("browser-pool contract parity", () => {
   beforeEach(() => {
+    resetKernelClientFactory();
+  });
+
+  afterEach(() => {
     resetKernelClientFactory();
   });
 

--- a/src/lib/mcp/tools/browser-pools.test.ts
+++ b/src/lib/mcp/tools/browser-pools.test.ts
@@ -1,0 +1,240 @@
+/// <reference types="bun-types" />
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { z } from "zod";
+
+let kernelClient: unknown;
+
+mock.module("@/lib/mcp/kernel-client", () => ({
+  createKernelClient: () => kernelClient,
+}));
+
+const { registerBrowserPoolCapabilities } = await import(
+  "@/lib/mcp/tools/browser-pools"
+);
+
+type ToolHandler = (
+  params: Record<string, unknown>,
+  extra: { authInfo?: { token: string } },
+) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+function captureBrowserPoolTool() {
+  let handler: ToolHandler | undefined;
+  let schema: z.ZodRawShape | undefined;
+  const server = {
+    resource() {},
+    registerResource() {},
+    tool(name: string, ...args: unknown[]) {
+      if (name !== "manage_browser_pools") return;
+      schema = args[1] as z.ZodRawShape;
+      handler = args.at(-1) as ToolHandler;
+    },
+  } as unknown as McpServer;
+
+  registerBrowserPoolCapabilities(server);
+  if (!handler || !schema)
+    throw new Error("manage_browser_pools was not registered");
+  return { handler, schema };
+}
+
+const auth = { authInfo: { token: "test-token" } };
+
+function pool() {
+  return {
+    id: "pool_1",
+    name: "production",
+    created_at: "2026-08-06T12:00:00Z",
+    available_count: 2,
+    acquired_count: 1,
+    profile_id: "profile_resolved",
+    extension_ids: ["extension_resolved"],
+    browser_pool_config: {
+      size: 3,
+      profile: { name: "configured-profile-name" },
+      extensions: [{ name: "configured-extension-name" }],
+    },
+  };
+}
+
+describe("browser-pool contract parity", () => {
+  beforeEach(() => {
+    kernelClient = undefined;
+  });
+
+  test("validates API boundaries", () => {
+    const { schema } = captureBrowserPoolTool();
+
+    expect(schema.fill_rate_per_minute.safeParse(0).success).toBe(true);
+    expect(schema.fill_rate_per_minute.safeParse(25).success).toBe(true);
+    expect(schema.fill_rate_per_minute.safeParse(0.5).success).toBe(false);
+    expect(schema.fill_rate_per_minute.safeParse(-1).success).toBe(false);
+    expect(schema.timeout_seconds.safeParse(10).success).toBe(true);
+    expect(schema.timeout_seconds.safeParse(259200).success).toBe(true);
+    expect(schema.timeout_seconds.safeParse(9).success).toBe(false);
+    expect(schema.timeout_seconds.safeParse(259201).success).toBe(false);
+    expect(schema.timeout_seconds.safeParse(10.5).success).toBe(false);
+    expect(schema.start_url.safeParse("").success).toBe(true);
+    expect(schema.start_url.safeParse("https://example.com").success).toBe(
+      true,
+    );
+    expect(schema.start_url.safeParse("not-a-url").success).toBe(false);
+  });
+
+  test("keeps ordinary create valid", async () => {
+    const createCalls: unknown[] = [];
+    kernelClient = {
+      browserPools: {
+        create: async (params: unknown) => {
+          createCalls.push(params);
+          return pool();
+        },
+      },
+    };
+    const { handler } = captureBrowserPoolTool();
+
+    const result = await handler({ action: "create", size: 1 }, auth);
+
+    expect(createCalls).toEqual([{ size: 1 }]);
+    expect(result.isError).toBeUndefined();
+  });
+
+  test("rejects an update with no fields", async () => {
+    let updated = false;
+    kernelClient = {
+      browserPools: {
+        update: async () => {
+          updated = true;
+        },
+      },
+    };
+    const { handler } = captureBrowserPoolTool();
+
+    const result = await handler(
+      { action: "update", id_or_name: "pool_1" },
+      auth,
+    );
+
+    expect(result).toEqual({
+      content: [
+        { type: "text", text: "Error: at least one update field is required." },
+      ],
+      isError: true,
+    });
+    expect(updated).toBe(false);
+  });
+
+  test.each(["clear_profile", "clear_extensions"])(
+    "rejects update-only %s during create",
+    async (clearField) => {
+      kernelClient = { browserPools: {} };
+      const { handler } = captureBrowserPoolTool();
+
+      const result = await handler(
+        { action: "create", size: 1, [clearField]: true },
+        auth,
+      );
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Error: clear_profile and clear_extensions are update-only.",
+          },
+        ],
+        isError: true,
+      });
+    },
+  );
+
+  test("rejects an empty start URL during create", async () => {
+    kernelClient = { browserPools: {} };
+    const { handler } = captureBrowserPoolTool();
+
+    const result = await handler(
+      { action: "create", size: 1, start_url: "" },
+      auth,
+    );
+
+    expect(result).toEqual({
+      content: [
+        { type: "text", text: "Error: an empty start_url is update-only." },
+      ],
+      isError: true,
+    });
+  });
+
+  test("sends explicit durable clears on update", async () => {
+    const updateCalls: unknown[] = [];
+    kernelClient = {
+      browserPools: {
+        update: async (...args: unknown[]) => {
+          updateCalls.push(args);
+          return pool();
+        },
+      },
+    };
+    const { handler } = captureBrowserPoolTool();
+
+    const result = await handler(
+      {
+        action: "update",
+        id_or_name: "pool_1",
+        proxy_id: "",
+        start_url: "",
+        clear_profile: true,
+        clear_extensions: true,
+        chrome_policy: {},
+      },
+      auth,
+    );
+
+    expect(updateCalls).toEqual([
+      [
+        "pool_1",
+        {
+          proxy_id: "",
+          start_url: "",
+          profile: { id: "" },
+          extensions: [],
+          chrome_policy: {},
+        },
+      ],
+    ]);
+    expect(result.isError).toBeUndefined();
+    const response = JSON.parse(result.content[0].text);
+    expect(response.browser_pool.config).toMatchObject({
+      profile_id: "profile_resolved",
+      extension_ids: ["extension_resolved"],
+    });
+    expect(response.browser_pool.config).not.toHaveProperty("profile");
+    expect(response.browser_pool.config).not.toHaveProperty("extensions");
+  });
+
+  test.each([
+    [
+      { clear_profile: true, profile_id: "profile_1" },
+      "Error: clear_profile cannot be combined with profile_id or profile_name.",
+    ],
+    [
+      { clear_extensions: true, extension_name: "ublock" },
+      "Error: clear_extensions cannot be combined with extension_id or extension_name.",
+    ],
+  ])("rejects conflicting clear and set values", async (params, wantError) => {
+    kernelClient = { browserPools: {} };
+    const { handler } = captureBrowserPoolTool();
+
+    const result = await handler(
+      { action: "update", id_or_name: "pool_1", ...params },
+      auth,
+    );
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: wantError }],
+      isError: true,
+    });
+  });
+});

--- a/src/lib/mcp/tools/browser-pools.test.ts
+++ b/src/lib/mcp/tools/browser-pools.test.ts
@@ -100,6 +100,13 @@ describe("browser-pool contract parity", () => {
 
     expect(createCalls).toEqual([{ size: 1 }]);
     expect(result.isError).toBeUndefined();
+    const response = JSON.parse(result.content[0].text);
+    expect(response.browser_pool.config).toMatchObject({
+      profile_id: "profile_resolved",
+      extension_ids: ["extension_resolved"],
+    });
+    expect(response.browser_pool.config).not.toHaveProperty("profile");
+    expect(response.browser_pool.config).not.toHaveProperty("extensions");
   });
 
   test("rejects an update with no fields", async () => {
@@ -173,7 +180,11 @@ describe("browser-pool contract parity", () => {
       browserPools: {
         update: async (...args: unknown[]) => {
           updateCalls.push(args);
-          return pool();
+          return {
+            ...pool(),
+            profile_id: undefined,
+            extension_ids: [],
+          };
         },
       },
     };
@@ -206,10 +217,8 @@ describe("browser-pool contract parity", () => {
     ]);
     expect(result.isError).toBeUndefined();
     const response = JSON.parse(result.content[0].text);
-    expect(response.browser_pool.config).toMatchObject({
-      profile_id: "profile_resolved",
-      extension_ids: ["extension_resolved"],
-    });
+    expect(response.browser_pool.config.extension_ids).toEqual([]);
+    expect(response.browser_pool.config).not.toHaveProperty("profile_id");
     expect(response.browser_pool.config).not.toHaveProperty("profile");
     expect(response.browser_pool.config).not.toHaveProperty("extensions");
   });

--- a/src/lib/mcp/tools/browser-pools.test.ts
+++ b/src/lib/mcp/tools/browser-pools.test.ts
@@ -1,14 +1,12 @@
 /// <reference types="bun-types" />
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import type { z } from "zod";
-
-let kernelClient: unknown;
-
-mock.module("@/lib/mcp/kernel-client", () => ({
-  createKernelClient: () => kernelClient,
-}));
+import {
+  kernelClientMock,
+  resetKernelClientFactory,
+} from "@/lib/mcp/kernel-client.test-fixtures";
 
 const { registerBrowserPoolCapabilities } = await import(
   "@/lib/mcp/tools/browser-pools"
@@ -62,7 +60,7 @@ function pool() {
 
 describe("browser-pool contract parity", () => {
   beforeEach(() => {
-    kernelClient = undefined;
+    resetKernelClientFactory();
   });
 
   test("validates API boundaries", () => {
@@ -86,14 +84,14 @@ describe("browser-pool contract parity", () => {
 
   test("keeps ordinary create valid", async () => {
     const createCalls: unknown[] = [];
-    kernelClient = {
+    kernelClientMock.factory = () => ({
       browserPools: {
         create: async (params: unknown) => {
           createCalls.push(params);
           return pool();
         },
       },
-    };
+    });
     const { handler } = captureBrowserPoolTool();
 
     const result = await handler({ action: "create", size: 1 }, auth);
@@ -111,13 +109,13 @@ describe("browser-pool contract parity", () => {
 
   test("rejects an update with no fields", async () => {
     let updated = false;
-    kernelClient = {
+    kernelClientMock.factory = () => ({
       browserPools: {
         update: async () => {
           updated = true;
         },
       },
-    };
+    });
     const { handler } = captureBrowserPoolTool();
 
     const result = await handler(
@@ -137,7 +135,7 @@ describe("browser-pool contract parity", () => {
   test.each(["clear_profile", "clear_extensions"])(
     "rejects update-only %s during create",
     async (clearField) => {
-      kernelClient = { browserPools: {} };
+      kernelClientMock.factory = () => ({ browserPools: {} });
       const { handler } = captureBrowserPoolTool();
 
       const result = await handler(
@@ -158,7 +156,7 @@ describe("browser-pool contract parity", () => {
   );
 
   test("rejects an empty start URL during create", async () => {
-    kernelClient = { browserPools: {} };
+    kernelClientMock.factory = () => ({ browserPools: {} });
     const { handler } = captureBrowserPoolTool();
 
     const result = await handler(
@@ -176,7 +174,7 @@ describe("browser-pool contract parity", () => {
 
   test("sends explicit durable clears on update", async () => {
     const updateCalls: unknown[] = [];
-    kernelClient = {
+    kernelClientMock.factory = () => ({
       browserPools: {
         update: async (...args: unknown[]) => {
           updateCalls.push(args);
@@ -187,7 +185,7 @@ describe("browser-pool contract parity", () => {
           };
         },
       },
-    };
+    });
     const { handler } = captureBrowserPoolTool();
 
     const result = await handler(
@@ -233,7 +231,7 @@ describe("browser-pool contract parity", () => {
       "Error: clear_extensions cannot be combined with extension_id or extension_name.",
     ],
   ])("rejects conflicting clear and set values", async (params, wantError) => {
-    kernelClient = { browserPools: {} };
+    kernelClientMock.factory = () => ({ browserPools: {} });
     const { handler } = captureBrowserPoolTool();
 
     const result = await handler(

--- a/src/lib/mcp/tools/browser-pools.ts
+++ b/src/lib/mcp/tools/browser-pools.ts
@@ -42,7 +42,12 @@ type PoolConfigParams = Omit<
   fill_rate_per_minute?: number;
   chrome_policy?: Record<string, unknown>;
   kiosk_mode?: boolean;
+  clear_profile?: boolean;
+  clear_extensions?: boolean;
 };
+
+const browserPoolTimeoutSchema = z.number().int().min(10).max(259200);
+const browserPoolFillRateSchema = z.number().int().min(0);
 
 function buildPoolConfigParams(
   params: PoolConfigParams,
@@ -81,6 +86,18 @@ function buildPoolCreateParams(
   if (params.size === undefined) {
     return { ok: false, error: "Error: size is required for create." };
   }
+  if (params.clear_profile || params.clear_extensions) {
+    return {
+      ok: false,
+      error: "Error: clear_profile and clear_extensions are update-only.",
+    };
+  }
+  if (params.start_url === "") {
+    return {
+      ok: false,
+      error: "Error: an empty start_url is update-only.",
+    };
+  }
 
   const config = buildPoolConfigParams(params);
   if (!config.ok) return config;
@@ -94,10 +111,34 @@ function buildPoolUpdateParams(
   const config = buildPoolConfigParams(params);
   if (!config.ok) return config;
 
+  if (params.clear_profile && (params.profile_id || params.profile_name)) {
+    return {
+      ok: false,
+      error:
+        "Error: clear_profile cannot be combined with profile_id or profile_name.",
+    };
+  }
+  if (
+    params.clear_extensions &&
+    (params.extension_id || params.extension_name)
+  ) {
+    return {
+      ok: false,
+      error:
+        "Error: clear_extensions cannot be combined with extension_id or extension_name.",
+    };
+  }
+
   return {
     ok: true,
     value: {
       ...config.value,
+      ...(params.proxy_id !== undefined && { proxy_id: params.proxy_id }),
+      ...(params.chrome_policy !== undefined && {
+        chrome_policy: params.chrome_policy,
+      }),
+      ...(params.clear_profile && { profile: { id: "" } }),
+      ...(params.clear_extensions && { extensions: [] }),
       ...(params.discard_all_idle !== undefined && {
         discard_all_idle: params.discard_all_idle,
       }),
@@ -123,10 +164,10 @@ function summarizeBrowserPool(pool: BrowserPool) {
       timeout_seconds: config.timeout_seconds,
       fill_rate_per_minute: config.fill_rate_per_minute,
       start_url: config.start_url,
-      profile: config.profile,
+      profile_id: pool.profile_id,
       proxy_id: config.proxy_id,
       viewport: config.viewport,
-      extensions: config.extensions,
+      extension_ids: pool.extension_ids,
       chrome_policy_keys: config.chrome_policy
         ? Object.keys(config.chrome_policy)
         : undefined,
@@ -233,10 +274,7 @@ export function registerBrowserPoolCapabilities(server: McpServer) {
         .boolean()
         .describe("(create, update) Stealth mode for pool browsers.")
         .optional(),
-      timeout_seconds: z
-        .number()
-        .int()
-        .min(1)
+      timeout_seconds: browserPoolTimeoutSchema
         .describe(
           "(create, update) Idle timeout for acquired browsers. Default 600.",
         )
@@ -253,30 +291,33 @@ export function registerBrowserPoolCapabilities(server: McpServer) {
           "(create, update) Profile ID to load into pool browsers. Cannot use with profile_name.",
         )
         .optional(),
+      clear_profile: z
+        .boolean()
+        .describe(
+          "(update) Remove the profile from the pool. Cannot use with profile_id or profile_name.",
+        )
+        .optional(),
       proxy_id: z
         .string()
-        .describe("(create, update) Proxy for pool browsers.")
-        .optional(),
-      // Percentage rate, not a count — the API accepts fractional values, so
-      // intentionally no .int() (unlike the size/timeout count fields).
-      fill_rate_per_minute: z
-        .number()
-        .min(0)
         .describe(
-          "(create, update) Pool fill rate percentage per minute. Default 10%.",
+          "(create, update) Proxy for pool browsers. On update, an empty string clears the proxy.",
+        )
+        .optional(),
+      fill_rate_per_minute: browserPoolFillRateSchema
+        .describe(
+          "(create, update) Pool fill rate percentage per minute. Default 25%.",
         )
         .optional(),
       start_url: z
-        .string()
-        .url()
+        .union([z.literal(""), z.string().url()])
         .describe(
-          "(create, update) URL to open when a browser is warmed into the pool. Navigation is best-effort.",
+          "(create, update) URL to open when a browser is warmed into the pool. On update, an empty string clears it. Navigation is best-effort.",
         )
         .optional(),
       chrome_policy: z
         .record(z.string(), z.unknown())
         .describe(
-          "(create, update) Chrome enterprise policy overrides for all browsers in the pool. Kernel-managed policies such as extensions, proxy, CDP, and automation are blocked by the API.",
+          "(create, update) Chrome enterprise policy overrides for all browsers in the pool. On update, an empty object clears the policy. Kernel-managed policies such as extensions, proxy, CDP, and automation are blocked by the API.",
         )
         .optional(),
       kiosk_mode: z
@@ -290,6 +331,12 @@ export function registerBrowserPoolCapabilities(server: McpServer) {
       extension_name: z
         .string()
         .describe("(create, update) Extension name to load.")
+        .optional(),
+      clear_extensions: z
+        .boolean()
+        .describe(
+          "(update) Remove all extensions from the pool. Cannot use with extension_id or extension_name.",
+        )
         .optional(),
       viewport_width: z
         .number()

--- a/src/lib/mcp/tools/browser-pools.ts
+++ b/src/lib/mcp/tools/browser-pools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import {
   buildBrowserCreateConfig,
+  buildBrowserSharedConfig,
   type BrowserConfigResult,
   type BrowserCreateConfigParams,
 } from "@/lib/mcp/browser-config";
@@ -49,37 +50,6 @@ type PoolConfigParams = Omit<
 const browserPoolTimeoutSchema = z.number().int().min(10).max(259200);
 const browserPoolFillRateSchema = z.number().int().min(0);
 
-function buildPoolConfigParams(
-  params: PoolConfigParams,
-): BrowserConfigResult<BrowserPoolUpdateParams> {
-  const browserConfig = buildBrowserCreateConfig(params);
-  if (!browserConfig.ok) return browserConfig;
-  const chromePolicy =
-    params.chrome_policy && Object.keys(params.chrome_policy).length > 0
-      ? params.chrome_policy
-      : undefined;
-
-  return {
-    ok: true,
-    value: {
-      ...(params.size !== undefined && { size: params.size }),
-      ...(params.name && { name: params.name }),
-      ...(params.headless !== undefined && { headless: params.headless }),
-      ...(params.stealth !== undefined && { stealth: params.stealth }),
-      ...(params.timeout_seconds !== undefined && {
-        timeout_seconds: params.timeout_seconds,
-      }),
-      ...(params.proxy_id && { proxy_id: params.proxy_id }),
-      ...(params.fill_rate_per_minute !== undefined && {
-        fill_rate_per_minute: params.fill_rate_per_minute,
-      }),
-      ...(chromePolicy && { chrome_policy: chromePolicy }),
-      ...(params.kiosk_mode !== undefined && { kiosk_mode: params.kiosk_mode }),
-      ...browserConfig.value,
-    },
-  };
-}
-
 function buildPoolCreateParams(
   params: PoolConfigParams,
 ): BrowserConfigResult<BrowserPoolCreateParams> {
@@ -99,18 +69,37 @@ function buildPoolCreateParams(
     };
   }
 
-  const config = buildPoolConfigParams(params);
-  if (!config.ok) return config;
+  const browserConfig = buildBrowserCreateConfig(params);
+  if (!browserConfig.ok) return browserConfig;
+  const chromePolicy =
+    params.chrome_policy && Object.keys(params.chrome_policy).length > 0
+      ? params.chrome_policy
+      : undefined;
 
-  return { ok: true, value: { ...config.value, size: params.size } };
+  return {
+    ok: true,
+    value: {
+      size: params.size,
+      ...(params.name && { name: params.name }),
+      ...(params.headless !== undefined && { headless: params.headless }),
+      ...(params.stealth !== undefined && { stealth: params.stealth }),
+      ...(params.timeout_seconds !== undefined && {
+        timeout_seconds: params.timeout_seconds,
+      }),
+      ...(params.proxy_id && { proxy_id: params.proxy_id }),
+      ...(params.fill_rate_per_minute !== undefined && {
+        fill_rate_per_minute: params.fill_rate_per_minute,
+      }),
+      ...(chromePolicy && { chrome_policy: chromePolicy }),
+      ...(params.kiosk_mode !== undefined && { kiosk_mode: params.kiosk_mode }),
+      ...browserConfig.value,
+    },
+  };
 }
 
 function buildPoolUpdateParams(
   params: PoolConfigParams & { discard_all_idle?: boolean },
 ): BrowserConfigResult<BrowserPoolUpdateParams> {
-  const config = buildPoolConfigParams(params);
-  if (!config.ok) return config;
-
   if (params.clear_profile && (params.profile_id || params.profile_name)) {
     return {
       ok: false,
@@ -129,14 +118,36 @@ function buildPoolUpdateParams(
     };
   }
 
+  const browserConfig = buildBrowserSharedConfig(params);
+  if (!browserConfig.ok) return browserConfig;
+  if (params.start_url) {
+    try {
+      new URL(params.start_url);
+    } catch {
+      return { ok: false, error: "Error: start_url must be a valid URL." };
+    }
+  }
+
   return {
     ok: true,
     value: {
-      ...config.value,
+      ...(params.size !== undefined && { size: params.size }),
+      ...(params.name && { name: params.name }),
+      ...(params.headless !== undefined && { headless: params.headless }),
+      ...(params.stealth !== undefined && { stealth: params.stealth }),
+      ...(params.timeout_seconds !== undefined && {
+        timeout_seconds: params.timeout_seconds,
+      }),
       ...(params.proxy_id !== undefined && { proxy_id: params.proxy_id }),
+      ...(params.fill_rate_per_minute !== undefined && {
+        fill_rate_per_minute: params.fill_rate_per_minute,
+      }),
       ...(params.chrome_policy !== undefined && {
         chrome_policy: params.chrome_policy,
       }),
+      ...(params.kiosk_mode !== undefined && { kiosk_mode: params.kiosk_mode }),
+      ...(params.start_url !== undefined && { start_url: params.start_url }),
+      ...browserConfig.value,
       ...(params.clear_profile && { profile: { id: "" } }),
       ...(params.clear_extensions && { extensions: [] }),
       ...(params.discard_all_idle !== undefined && {


### PR DESCRIPTION
## Summary

- align browser-pool validation with merged API limits and defaults
- add durable update clear semantics for profile, proxy, extensions, Chrome policy, and start URL
- return authoritative resolved profile and extension IDs in compact responses
- keep create and update semantics distinct for empty values

## Why

The MCP tool lagged the durable browser-pool API contract. Agents could not reliably pause filling, clear configuration, or see the IDs the API actually resolved.

## Implementation

The registered MCP surface now enforces integer fill rates, timeout bounds of 10 through 259200 seconds, and update-only empty sentinels. Tests exercise the registered tool rather than exporting implementation helpers.

## Verification

- `bun test` (90 tests)
- `bunx tsc --noEmit`
- Prettier and `git diff --check`
- registered-tool scenario tests for create, update, validation, omission, clears, and resolved IDs
- targeted Stryker runs killed all 46 core PATCH mutants; the expanded boundary run killed 45/51, with survivors limited to schema-blocked duplicate validation and description strings
- crap4ts: create 6.0, update 13.0, shared config 13.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP tool input mapping and API payloads for pool create/update (clears, bounds, responses); incorrect mapping could send wrong clears or reject valid agent requests, but scope is limited to browser-pool tooling with strong test coverage.
> 
> **Overview**
> Aligns the **`manage_browser_pools`** MCP tool with the durable browser-pool API so create/update behavior, validation, and responses match what agents need.
> 
> **Create vs update:** Empty `start_url` and `clear_profile` / `clear_extensions` are **update-only**; create rejects them. Updates can clear profile, extensions, proxy (`proxy_id: ""`), `start_url`, and Chrome policy (`{}`) via explicit sentinels, with guards against mixing clears with set profile/extension fields.
> 
> **Validation:** Integer `fill_rate_per_minute` (min 0) and `timeout_seconds` bounded **10–259200**; `start_url` schema allows `""` on update. Pool summaries expose **`profile_id`** and **`extension_ids`** from the API instead of nested profile/extension objects.
> 
> **Refactor:** **`buildBrowserSharedConfig`** extracts shared profile/extensions/viewport building; create still uses **`buildBrowserCreateConfig`** for `start_url`. Kernel client test mocks move to **`kernel-client.test-fixtures`**; new contract tests cover the registered tool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08f762c287113a975323f948101b04c00713b405. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->