### PR TITLE
Add durable profile and proxy MCP contract parity

### DIFF
--- a/src/lib/mcp/dependencies.ts
+++ b/src/lib/mcp/dependencies.ts
@@ -1,0 +1,9 @@
+import { createKernelClient, type KernelClient } from "@/lib/mcp/kernel-client";
+
+export type McpDependencies = {
+  createKernelClient: (token: string) => KernelClient;
+};
+
+export const defaultMcpDependencies: McpDependencies = {
+  createKernelClient,
+};

--- a/src/lib/mcp/kernel-client.test-fixtures.ts
+++ b/src/lib/mcp/kernel-client.test-fixtures.ts
@@ -10,7 +10,7 @@ export const unusedKernelClient = new Proxy(
 );
 
 export const kernelClientMock: {
-  factory: (token: string) => any;
+  factory: (token: string) => unknown;
 } = {
   factory: () => unusedKernelClient,
 };

--- a/src/lib/mcp/kernel-client.test-fixtures.ts
+++ b/src/lib/mcp/kernel-client.test-fixtures.ts
@@ -10,7 +10,7 @@ export const unusedKernelClient = new Proxy(
 );
 
 export const kernelClientMock: {
-  factory: (token: string) => unknown;
+  factory: (token: string) => any;
 } = {
   factory: () => unusedKernelClient,
 };

--- a/src/lib/mcp/register.ts
+++ b/src/lib/mcp/register.ts
@@ -1,4 +1,8 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  defaultMcpDependencies,
+  type McpDependencies,
+} from "@/lib/mcp/dependencies";
 import { registerKernelPrompts } from "@/lib/mcp/prompts";
 import { registerAPIKeyCapabilities } from "@/lib/mcp/tools/api-keys";
 import { registerAppCapabilities } from "@/lib/mcp/tools/apps";
@@ -19,7 +23,10 @@ import { registerProxyTools } from "@/lib/mcp/tools/proxies";
 import { registerReplayTools } from "@/lib/mcp/tools/replays";
 import { registerShellTool } from "@/lib/mcp/tools/shell";
 
-type RegisterMcpToolset = (server: McpServer) => void;
+type RegisterMcpToolset = (
+  server: McpServer,
+  dependencies?: McpDependencies,
+) => void;
 
 function registerManagedAuthCapabilities(server: McpServer) {
   registerAuthConnectionTools(server);
@@ -125,7 +132,10 @@ function toolsetEnabled(
 
 export function registerMcpCapabilities(
   server: McpServer,
-  { mcpApps = false }: { mcpApps?: boolean } = {},
+  {
+    mcpApps = false,
+    dependencies = defaultMcpDependencies,
+  }: { mcpApps?: boolean; dependencies?: McpDependencies } = {},
 ) {
   const disabledToolsets = disabledMcpToolsetsFromEnv();
 
@@ -133,7 +143,7 @@ export function registerMcpCapabilities(
 
   for (const [toolset, registerToolset] of mcpToolRegistrations) {
     if (toolsetEnabled(disabledToolsets, toolset)) {
-      registerToolset(server);
+      registerToolset(server, dependencies);
     }
   }
 

--- a/src/lib/mcp/resource-templates.ts
+++ b/src/lib/mcp/resource-templates.ts
@@ -2,7 +2,11 @@ import {
   ResourceTemplate,
   type McpServer,
 } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { createKernelClient, type KernelClient } from "@/lib/mcp/kernel-client";
+import {
+  defaultMcpDependencies,
+  type McpDependencies,
+} from "@/lib/mcp/dependencies";
+import type { KernelClient } from "@/lib/mcp/kernel-client";
 
 type JsonResourceTemplateOptions = {
   name: string;
@@ -26,6 +30,7 @@ function templateVariableValue(
 export function registerJsonResourceTemplate(
   server: McpServer,
   options: JsonResourceTemplateOptions,
+  dependencies: McpDependencies = defaultMcpDependencies,
 ) {
   server.resource(
     options.name,
@@ -40,7 +45,7 @@ export function registerJsonResourceTemplate(
         throw new Error(`Invalid ${options.resourceLabel} URI: ${uri}`);
       }
 
-      const client = createKernelClient(extra.authInfo.token);
+      const client = dependencies.createKernelClient(extra.authInfo.token);
       const resource = await options.read(client, identifier);
 
       if (!resource) {

--- a/src/lib/mcp/responses.test.ts
+++ b/src/lib/mcp/responses.test.ts
@@ -17,6 +17,10 @@ function apiError(status: number, message: string) {
   return APIError.generate(status, undefined, message, new Headers());
 }
 
+function codedApiError(status: number, code: string, message: string) {
+  return APIError.generate(status, { code, message }, undefined, new Headers());
+}
+
 function caught(error: unknown) {
   try {
     throwToolError("manage_browsers", "get", error);
@@ -62,6 +66,38 @@ describe("throwToolError classification", () => {
       "Error in manage_browsers (get): plain string",
     );
   });
+
+  test("keeps stable API codes visible", () => {
+    expect(
+      caught(
+        codedApiError(
+          409,
+          "project_not_empty",
+          "Project still contains resources",
+        ),
+      ).message,
+    ).toBe(
+      "Error in manage_browsers (get): 409 Project still contains resources [code: project_not_empty]",
+    );
+    expect(
+      caught(
+        codedApiError(
+          409,
+          "last_active_project",
+          "Cannot delete the last active project",
+        ),
+      ).message,
+    ).toContain("[code: last_active_project]");
+  });
+
+  test("ignores absent and non-string API codes", () => {
+    const absent = apiError(409, "conflict");
+    expect(caught(absent).message).not.toContain("[code:");
+
+    const numeric = codedApiError(409, "temporary", "conflict");
+    (numeric as unknown as { error: { code: number } }).error.code = 123;
+    expect(caught(numeric).message).not.toContain("[code:");
+  });
 });
 
 describe("what the client receives", () => {
@@ -73,6 +109,18 @@ describe("what the client receives", () => {
         "manage_browsers",
         "get",
         apiError(404, "browser session not found"),
+      );
+    });
+
+    server.tool("coded_api_failure", {}, async () => {
+      throwToolError(
+        "manage_projects",
+        "delete",
+        codedApiError(
+          409,
+          "project_not_empty",
+          "Project still contains resources",
+        ),
       );
     });
 
@@ -111,6 +159,18 @@ describe("what the client receives", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toEqual([
       { type: "text", text: "Error: session_id is required for get action." },
+    ]);
+  });
+
+  test("returns coded API rejections to the client", async () => {
+    const result = await callTool("coded_api_failure");
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: "Error in manage_projects (delete): 409 Project still contains resources [code: project_not_empty]",
+      },
     ]);
   });
 });

--- a/src/lib/mcp/responses.ts
+++ b/src/lib/mcp/responses.ts
@@ -67,8 +67,23 @@ export function errorResponse(text: string) {
   return { ...textResponse(text), isError: true as const };
 }
 
+function apiErrorCode(error: APIError) {
+  if (
+    error.error &&
+    typeof error.error === "object" &&
+    "code" in error.error &&
+    typeof error.error.code === "string"
+  ) {
+    return error.error.code;
+  }
+}
+
 function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
+  const message = error instanceof Error ? error.message : String(error);
+  if (!(error instanceof APIError)) return message;
+
+  const code = apiErrorCode(error);
+  return code ? `${message} [code: ${code}]` : message;
 }
 
 // Named after what the API said, so a stale session id (404) is distinguishable from an

--- a/src/lib/mcp/tools/durable-contracts.test.ts
+++ b/src/lib/mcp/tools/durable-contracts.test.ts
@@ -1,16 +1,13 @@
 /// <reference types="bun-types" />
 
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { afterEach, describe, expect, test } from "bun:test";
-import {
-  kernelClientMock,
-  resetKernelClientFactory,
-} from "@/lib/mcp/kernel-client.test-fixtures";
-
-const { registerProfileCapabilities } = await import(
-  "@/lib/mcp/tools/profiles"
-);
-const { registerProxyTools } = await import("@/lib/mcp/tools/proxies");
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, expect, test } from "bun:test";
+import type { McpDependencies } from "@/lib/mcp/dependencies";
+import type { KernelClient } from "@/lib/mcp/kernel-client";
+import { registerProfileCapabilities } from "@/lib/mcp/tools/profiles";
+import { registerProxyTools } from "@/lib/mcp/tools/proxies";
 
 type ToolResult = {
   content: Array<{ type: string; text: string }>;
@@ -22,7 +19,15 @@ type ToolHandler = (
   extra: { authInfo?: { token: string } },
 ) => Promise<ToolResult>;
 
-function captureTool(register: (server: McpServer) => void, name: string) {
+type RegisterTool = (server: McpServer, dependencies?: McpDependencies) => void;
+
+function testDependencies(client: unknown): McpDependencies {
+  return {
+    createKernelClient: () => client as KernelClient,
+  };
+}
+
+function captureTool(register: RegisterTool, name: string, client: unknown) {
   let handler: ToolHandler | undefined;
   const server = {
     resource() {},
@@ -33,9 +38,40 @@ function captureTool(register: (server: McpServer) => void, name: string) {
     },
   } as unknown as McpServer;
 
-  register(server);
+  register(server, testDependencies(client));
   if (!handler) throw new Error(`${name} was not registered`);
   return handler;
+}
+
+async function connectTool(register: RegisterTool, kernelClient: unknown) {
+  const server = new McpServer({ name: "test", version: "0.0.0" });
+  const tokens: string[] = [];
+  register(server, {
+    createKernelClient: (token) => {
+      tokens.push(token);
+      return kernelClient as KernelClient;
+    },
+  });
+
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const send = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message, options) =>
+    send(message, {
+      ...options,
+      authInfo: {
+        token: "test-token",
+        clientId: "test-client",
+        scopes: [],
+      },
+    });
+
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return { client, tokens };
 }
 
 function profilePage(profiles: Array<{ id: string; name: string }>) {
@@ -48,14 +84,12 @@ function profilePage(profiles: Array<{ id: string; name: string }>) {
 
 const auth = { authInfo: { token: "test-token" } };
 
-afterEach(resetKernelClientFactory);
-
 describe("durable profile contracts", () => {
   test("creates a profile when no exact match exists", async () => {
     const listCalls: unknown[] = [];
     const createCalls: unknown[] = [];
     const browserCalls: unknown[] = [];
-    kernelClientMock.factory = () => ({
+    const client = {
       profiles: {
         list: (params: unknown) => {
           listCalls.push(params);
@@ -75,8 +109,12 @@ describe("durable profile contracts", () => {
           };
         },
       },
-    });
-    const handler = captureTool(registerProfileCapabilities, "manage_profiles");
+    };
+    const handler = captureTool(
+      registerProfileCapabilities,
+      "manage_profiles",
+      client,
+    );
 
     const result = await handler(
       { action: "setup", profile_name: "Acme" },
@@ -97,7 +135,7 @@ describe("durable profile contracts", () => {
 
   test("rejects ambiguous exact profile matches", async () => {
     let browserCreated = false;
-    kernelClientMock.factory = () => ({
+    const client = {
       profiles: {
         list: () =>
           profilePage([
@@ -110,8 +148,12 @@ describe("durable profile contracts", () => {
           browserCreated = true;
         },
       },
-    });
-    const handler = captureTool(registerProfileCapabilities, "manage_profiles");
+    };
+    const handler = captureTool(
+      registerProfileCapabilities,
+      "manage_profiles",
+      client,
+    );
 
     const result = await handler(
       { action: "setup", profile_name: "Acme" },
@@ -132,7 +174,7 @@ describe("durable profile contracts", () => {
 
   test("rejects a missing existing profile", async () => {
     let profileCreated = false;
-    kernelClientMock.factory = () => ({
+    const client = {
       profiles: {
         list: () => profilePage([]),
         create: async () => {
@@ -144,8 +186,12 @@ describe("durable profile contracts", () => {
           throw new Error("browser setup should not start");
         },
       },
-    });
-    const handler = captureTool(registerProfileCapabilities, "manage_profiles");
+    };
+    const handler = captureTool(
+      registerProfileCapabilities,
+      "manage_profiles",
+      client,
+    );
 
     const result = await handler(
       {
@@ -171,7 +217,7 @@ describe("durable profile contracts", () => {
   test("loads the exact existing profile", async () => {
     let profileCreated = false;
     const browserCalls: unknown[] = [];
-    kernelClientMock.factory = () => ({
+    const client = {
       profiles: {
         list: () => profilePage([{ id: "profile-1", name: "Acme" }]),
         create: async () => {
@@ -187,8 +233,12 @@ describe("durable profile contracts", () => {
           };
         },
       },
-    });
-    const handler = captureTool(registerProfileCapabilities, "manage_profiles");
+    };
+    const handler = captureTool(
+      registerProfileCapabilities,
+      "manage_profiles",
+      client,
+    );
 
     const result = await handler(
       { action: "setup", profile_name: "Acme", update_existing: true },
@@ -209,9 +259,9 @@ describe("durable profile contracts", () => {
     expect(result.content[0].text).toContain("Profile ID: profile-1");
   });
 
-  test("renames a profile through the SDK", async () => {
+  test("discovers and renames a profile through the MCP boundary", async () => {
     const updateCalls: unknown[] = [];
-    kernelClientMock.factory = () => ({
+    const { client, tokens } = await connectTool(registerProfileCapabilities, {
       profiles: {
         update: async (...args: unknown[]) => {
           updateCalls.push(args);
@@ -219,26 +269,53 @@ describe("durable profile contracts", () => {
         },
       },
     });
-    const handler = captureTool(registerProfileCapabilities, "manage_profiles");
+    try {
+      const tools = await client.listTools();
+      const tool = tools.tools.find((item) => item.name === "manage_profiles");
+      const schema = tool?.inputSchema as
+        | { properties?: Record<string, { enum?: string[] }> }
+        | undefined;
+      expect(schema?.properties?.action.enum).toContain("rename");
+      expect(schema?.properties).toHaveProperty("profile_id");
+      expect(schema?.properties).toHaveProperty("profile_name");
+      expect(schema?.properties).toHaveProperty("new_name");
 
-    for (const selector of [
-      { profile_id: "profile-1" },
-      { profile_name: "Acme" },
-    ]) {
-      const result = await handler(
-        { action: "rename", ...selector, new_name: "Renamed" },
-        auth,
-      );
-
-      expect(JSON.parse(result.content[0].text)).toEqual({
-        id: "profile-1",
-        name: "Renamed",
+      const invalid = await client.callTool({
+        name: "manage_profiles",
+        arguments: {
+          action: "rename",
+          profile_id: "profile-1",
+          new_name: 123,
+        },
       });
+      expect(invalid.isError).toBe(true);
+      expect(updateCalls).toEqual([]);
+
+      for (const selector of [
+        { profile_id: "profile-1" },
+        { profile_name: "Acme" },
+      ]) {
+        const result = await client.callTool({
+          name: "manage_profiles",
+          arguments: { action: "rename", ...selector, new_name: "Renamed" },
+        });
+
+        expect(result.content).toEqual([
+          {
+            type: "text",
+            text: JSON.stringify({ id: "profile-1", name: "Renamed" }, null, 2),
+          },
+        ]);
+      }
+    } finally {
+      await client.close();
     }
+
     expect(updateCalls).toEqual([
       ["profile-1", { name: "Renamed" }],
       ["Acme", { name: "Renamed" }],
     ]);
+    expect(tokens).toEqual(["test-token", "test-token"]);
   });
 
   test.each([
@@ -259,14 +336,18 @@ describe("durable profile contracts", () => {
     ],
   ])("rejects rename with %s", async (_name, params, wantError) => {
     let updated = false;
-    kernelClientMock.factory = () => ({
+    const client = {
       profiles: {
         update: async () => {
           updated = true;
         },
       },
-    });
-    const handler = captureTool(registerProfileCapabilities, "manage_profiles");
+    };
+    const handler = captureTool(
+      registerProfileCapabilities,
+      "manage_profiles",
+      client,
+    );
 
     const result = await handler({ action: "rename", ...params }, auth);
 
@@ -276,12 +357,67 @@ describe("durable profile contracts", () => {
     });
     expect(updated).toBe(false);
   });
+
+  test.each([
+    [
+      "get",
+      "both identifiers",
+      { profile_id: "profile-1", profile_name: "Acme" },
+      "Error: Cannot specify both profile_name and profile_id.",
+    ],
+    [
+      "get",
+      "no identifier",
+      {},
+      "Error: profile_name or profile_id is required for get.",
+    ],
+    [
+      "delete",
+      "both identifiers",
+      { profile_id: "profile-1", profile_name: "Acme" },
+      "Error: Cannot specify both profile_name and profile_id.",
+    ],
+    [
+      "delete",
+      "no identifier",
+      {},
+      "Error: profile_name or profile_id is required for delete.",
+    ],
+  ])(
+    "preserves %s validation for %s",
+    async (action, _case, params, wantError) => {
+      let called = false;
+      const client = {
+        profiles: {
+          retrieve: async () => {
+            called = true;
+          },
+          delete: async () => {
+            called = true;
+          },
+        },
+      };
+      const handler = captureTool(
+        registerProfileCapabilities,
+        "manage_profiles",
+        client,
+      );
+
+      const result = await handler({ action, ...params }, auth);
+
+      expect(result).toEqual({
+        content: [{ type: "text", text: wantError }],
+        isError: true,
+      });
+      expect(called).toBe(false);
+    },
+  );
 });
 
 describe("durable proxy contracts", () => {
-  test("renames a proxy through the SDK", async () => {
+  test("discovers and renames a proxy through the MCP boundary", async () => {
     const updateCalls: unknown[] = [];
-    kernelClientMock.factory = () => ({
+    const { client, tokens } = await connectTool(registerProxyTools, {
       proxies: {
         update: async (...args: unknown[]) => {
           updateCalls.push(args);
@@ -289,18 +425,48 @@ describe("durable proxy contracts", () => {
         },
       },
     });
-    const handler = captureTool(registerProxyTools, "manage_proxies");
+    try {
+      const tools = await client.listTools();
+      const tool = tools.tools.find((item) => item.name === "manage_proxies");
+      const schema = tool?.inputSchema as
+        | { properties?: Record<string, { enum?: string[] }> }
+        | undefined;
+      expect(schema?.properties?.action.enum).toContain("rename");
+      expect(schema?.properties).toHaveProperty("proxy_id");
+      expect(schema?.properties).toHaveProperty("name");
 
-    const result = await handler(
-      { action: "rename", proxy_id: "proxy-1", name: "Renamed" },
-      auth,
-    );
+      const invalid = await client.callTool({
+        name: "manage_proxies",
+        arguments: {
+          action: "rename",
+          proxy_id: "proxy-1",
+          name: 123,
+        },
+      });
+      expect(invalid.isError).toBe(true);
+      expect(updateCalls).toEqual([]);
+
+      const result = await client.callTool({
+        name: "manage_proxies",
+        arguments: {
+          action: "rename",
+          proxy_id: "proxy-1",
+          name: "Renamed",
+        },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: JSON.stringify({ id: "proxy-1", name: "Renamed" }, null, 2),
+        },
+      ]);
+    } finally {
+      await client.close();
+    }
 
     expect(updateCalls).toEqual([["proxy-1", { name: "Renamed" }]]);
-    expect(JSON.parse(result.content[0].text)).toEqual({
-      id: "proxy-1",
-      name: "Renamed",
-    });
+    expect(tokens).toEqual(["test-token"]);
   });
 
   test.each([
@@ -312,14 +478,14 @@ describe("durable proxy contracts", () => {
     ["no name", { proxy_id: "proxy-1" }, "Error: name is required for rename."],
   ])("rejects rename with %s", async (_name, params, wantError) => {
     let updated = false;
-    kernelClientMock.factory = () => ({
+    const client = {
       proxies: {
         update: async () => {
           updated = true;
         },
       },
-    });
-    const handler = captureTool(registerProxyTools, "manage_proxies");
+    };
+    const handler = captureTool(registerProxyTools, "manage_proxies", client);
 
     const result = await handler({ action: "rename", ...params }, auth);
 

--- a/src/lib/mcp/tools/durable-contracts.test.ts
+++ b/src/lib/mcp/tools/durable-contracts.test.ts
@@ -1,8 +1,11 @@
 /// <reference types="bun-types" />
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { describe, expect, test } from "bun:test";
-import { kernelClientMock } from "@/lib/mcp/kernel-client.test-fixtures";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  kernelClientMock,
+  resetKernelClientFactory,
+} from "@/lib/mcp/kernel-client.test-fixtures";
 
 const { registerProfileCapabilities } = await import(
   "@/lib/mcp/tools/profiles"
@@ -44,6 +47,8 @@ function profilePage(profiles: Array<{ id: string; name: string }>) {
 }
 
 const auth = { authInfo: { token: "test-token" } };
+
+afterEach(resetKernelClientFactory);
 
 describe("durable profile contracts", () => {
   test("creates a profile when no exact match exists", async () => {

--- a/src/lib/mcp/tools/durable-contracts.test.ts
+++ b/src/lib/mcp/tools/durable-contracts.test.ts
@@ -55,6 +55,7 @@ describe("durable profile contracts", () => {
   test("creates a profile when no exact match exists", async () => {
     const listCalls: unknown[] = [];
     const createCalls: unknown[] = [];
+    const browserCalls: unknown[] = [];
     kernelClient = {
       profiles: {
         list: (params: unknown) => {
@@ -67,10 +68,13 @@ describe("durable profile contracts", () => {
         },
       },
       browsers: {
-        create: async () => ({
-          session_id: "session-1",
-          browser_live_view_url: "https://example.test/live",
-        }),
+        create: async (params: unknown) => {
+          browserCalls.push(params);
+          return {
+            session_id: "session-1",
+            browser_live_view_url: "https://example.test/live",
+          };
+        },
       },
     };
     const handler = captureTool(registerProfileCapabilities, "manage_profiles");
@@ -82,6 +86,13 @@ describe("durable profile contracts", () => {
 
     expect(listCalls).toEqual([{ name: "Acme" }]);
     expect(createCalls).toEqual([{ name: "Acme" }]);
+    expect(browserCalls).toEqual([
+      {
+        stealth: true,
+        timeout_seconds: 300,
+        profile: { id: "profile-new", save_changes: true },
+      },
+    ]);
     expect(result.isError).toBeUndefined();
   });
 
@@ -112,7 +123,7 @@ describe("durable profile contracts", () => {
       content: [
         {
           type: "text",
-          text: 'Error: multiple profiles match the exact name "Acme". Rename or delete duplicate profiles by ID, then retry setup.',
+          text: 'Error: multiple profiles match the exact name "Acme": Acme (ID: profile-1), Acme (ID: profile-2). Rename or delete duplicate profiles by ID, then retry setup.',
         },
       ],
       isError: true,
@@ -211,20 +222,24 @@ describe("durable profile contracts", () => {
     };
     const handler = captureTool(registerProfileCapabilities, "manage_profiles");
 
-    const result = await handler(
-      {
-        action: "rename",
-        profile_id: "profile-1",
-        new_name: "Renamed",
-      },
-      auth,
-    );
+    for (const selector of [
+      { profile_id: "profile-1" },
+      { profile_name: "Acme" },
+    ]) {
+      const result = await handler(
+        { action: "rename", ...selector, new_name: "Renamed" },
+        auth,
+      );
 
-    expect(updateCalls).toEqual([["profile-1", { name: "Renamed" }]]);
-    expect(JSON.parse(result.content[0].text)).toEqual({
-      id: "profile-1",
-      name: "Renamed",
-    });
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        id: "profile-1",
+        name: "Renamed",
+      });
+    }
+    expect(updateCalls).toEqual([
+      ["profile-1", { name: "Renamed" }],
+      ["Acme", { name: "Renamed" }],
+    ]);
   });
 
   test.each([

--- a/src/lib/mcp/tools/durable-contracts.test.ts
+++ b/src/lib/mcp/tools/durable-contracts.test.ts
@@ -1,14 +1,8 @@
 /// <reference types="bun-types" />
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { describe, expect, mock, test } from "bun:test";
-import type { KernelClient } from "@/lib/mcp/kernel-client";
-
-let kernelClient: unknown;
-
-mock.module("@/lib/mcp/kernel-client", () => ({
-  createKernelClient: () => kernelClient as KernelClient,
-}));
+import { describe, expect, test } from "bun:test";
+import { kernelClientMock } from "@/lib/mcp/kernel-client.test-fixtures";
 
 const { registerProfileCapabilities } = await import(
   "@/lib/mcp/tools/profiles"
@@ -56,7 +50,7 @@ describe("durable profile contracts", () => {
     const listCalls: unknown[] = [];
     const createCalls: unknown[] = [];
     const browserCalls: unknown[] = [];
-    kernelClient = {
+    kernelClientMock.factory = () => ({
       profiles: {
         list: (params: unknown) => {
           listCalls.push(params);
@@ -76,7 +70,7 @@ describe("durable profile contracts", () => {
           };
         },
       },
-    };
+    });
     const handler = captureTool(registerProfileCapabilities, "manage_profiles");
 
     const result = await handler(
@@ -98,7 +92,7 @@ describe("durable profile contracts", () => {
 
   test("rejects ambiguous exact profile matches", async () => {
     let browserCreated = false;
-    kernelClient = {
+    kernelClientMock.factory = () => ({
       profiles: {
         list: () =>
           profilePage([
@@ -111,7 +105,7 @@ describe("durable profile contracts", () => {
           browserCreated = true;
         },
       },
-    };
+    });
     const handler = captureTool(registerProfileCapabilities, "manage_profiles");
 
     const result = await handler(
@@ -133,7 +127,7 @@ describe("durable profile contracts", () => {
 
   test("rejects a missing existing profile", async () => {
     let profileCreated = false;
-    kernelClient = {
+    kernelClientMock.factory = () => ({
       profiles: {
         list: () => profilePage([]),
         create: async () => {
@@ -145,7 +139,7 @@ describe("durable profile contracts", () => {
           throw new Error("browser setup should not start");
         },
       },
-    };
+    });
     const handler = captureTool(registerProfileCapabilities, "manage_profiles");
 
     const result = await handler(
@@ -172,7 +166,7 @@ describe("durable profile contracts", () => {
   test("loads the exact existing profile", async () => {
     let profileCreated = false;
     const browserCalls: unknown[] = [];
-    kernelClient = {
+    kernelClientMock.factory = () => ({
       profiles: {
         list: () => profilePage([{ id: "profile-1", name: "Acme" }]),
         create: async () => {
@@ -188,7 +182,7 @@ describe("durable profile contracts", () => {
           };
         },
       },
-    };
+    });
     const handler = captureTool(registerProfileCapabilities, "manage_profiles");
 
     const result = await handler(
@@ -212,14 +206,14 @@ describe("durable profile contracts", () => {
 
   test("renames a profile through the SDK", async () => {
     const updateCalls: unknown[] = [];
-    kernelClient = {
+    kernelClientMock.factory = () => ({
       profiles: {
         update: async (...args: unknown[]) => {
           updateCalls.push(args);
           return { id: "profile-1", name: "Renamed" };
         },
       },
-    };
+    });
     const handler = captureTool(registerProfileCapabilities, "manage_profiles");
 
     for (const selector of [
@@ -260,13 +254,13 @@ describe("durable profile contracts", () => {
     ],
   ])("rejects rename with %s", async (_name, params, wantError) => {
     let updated = false;
-    kernelClient = {
+    kernelClientMock.factory = () => ({
       profiles: {
         update: async () => {
           updated = true;
         },
       },
-    };
+    });
     const handler = captureTool(registerProfileCapabilities, "manage_profiles");
 
     const result = await handler({ action: "rename", ...params }, auth);
@@ -282,14 +276,14 @@ describe("durable profile contracts", () => {
 describe("durable proxy contracts", () => {
   test("renames a proxy through the SDK", async () => {
     const updateCalls: unknown[] = [];
-    kernelClient = {
+    kernelClientMock.factory = () => ({
       proxies: {
         update: async (...args: unknown[]) => {
           updateCalls.push(args);
           return { id: "proxy-1", name: "Renamed" };
         },
       },
-    };
+    });
     const handler = captureTool(registerProxyTools, "manage_proxies");
 
     const result = await handler(
@@ -313,13 +307,13 @@ describe("durable proxy contracts", () => {
     ["no name", { proxy_id: "proxy-1" }, "Error: name is required for rename."],
   ])("rejects rename with %s", async (_name, params, wantError) => {
     let updated = false;
-    kernelClient = {
+    kernelClientMock.factory = () => ({
       proxies: {
         update: async () => {
           updated = true;
         },
       },
-    };
+    });
     const handler = captureTool(registerProxyTools, "manage_proxies");
 
     const result = await handler({ action: "rename", ...params }, auth);

--- a/src/lib/mcp/tools/durable-contracts.test.ts
+++ b/src/lib/mcp/tools/durable-contracts.test.ts
@@ -1,0 +1,318 @@
+/// <reference types="bun-types" />
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, expect, mock, test } from "bun:test";
+import type { KernelClient } from "@/lib/mcp/kernel-client";
+
+let kernelClient: unknown;
+
+mock.module("@/lib/mcp/kernel-client", () => ({
+  createKernelClient: () => kernelClient as KernelClient,
+}));
+
+const { registerProfileCapabilities } = await import(
+  "@/lib/mcp/tools/profiles"
+);
+const { registerProxyTools } = await import("@/lib/mcp/tools/proxies");
+
+type ToolResult = {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+};
+
+type ToolHandler = (
+  params: Record<string, unknown>,
+  extra: { authInfo?: { token: string } },
+) => Promise<ToolResult>;
+
+function captureTool(register: (server: McpServer) => void, name: string) {
+  let handler: ToolHandler | undefined;
+  const server = {
+    resource() {},
+    tool(toolName: string, ...args: unknown[]) {
+      if (toolName === name) {
+        handler = args.at(-1) as ToolHandler;
+      }
+    },
+  } as unknown as McpServer;
+
+  register(server);
+  if (!handler) throw new Error(`${name} was not registered`);
+  return handler;
+}
+
+function profilePage(profiles: Array<{ id: string; name: string }>) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield* profiles;
+    },
+  };
+}
+
+const auth = { authInfo: { token: "test-token" } };
+
+describe("durable profile contracts", () => {
+  test("creates a profile when no exact match exists", async () => {
+    const listCalls: unknown[] = [];
+    const createCalls: unknown[] = [];
+    kernelClient = {
+      profiles: {
+        list: (params: unknown) => {
+          listCalls.push(params);
+          return profilePage([]);
+        },
+        create: async (params: unknown) => {
+          createCalls.push(params);
+          return { id: "profile-new", name: "Acme" };
+        },
+      },
+      browsers: {
+        create: async () => ({
+          session_id: "session-1",
+          browser_live_view_url: "https://example.test/live",
+        }),
+      },
+    };
+    const handler = captureTool(registerProfileCapabilities, "manage_profiles");
+
+    const result = await handler(
+      { action: "setup", profile_name: "Acme" },
+      auth,
+    );
+
+    expect(listCalls).toEqual([{ name: "Acme" }]);
+    expect(createCalls).toEqual([{ name: "Acme" }]);
+    expect(result.isError).toBeUndefined();
+  });
+
+  test("rejects ambiguous exact profile matches", async () => {
+    let browserCreated = false;
+    kernelClient = {
+      profiles: {
+        list: () =>
+          profilePage([
+            { id: "profile-1", name: "Acme" },
+            { id: "profile-2", name: "Acme" },
+          ]),
+      },
+      browsers: {
+        create: async () => {
+          browserCreated = true;
+        },
+      },
+    };
+    const handler = captureTool(registerProfileCapabilities, "manage_profiles");
+
+    const result = await handler(
+      { action: "setup", profile_name: "Acme" },
+      auth,
+    );
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: 'Error: multiple profiles match the exact name "Acme". Rename or delete duplicate profiles by ID, then retry setup.',
+        },
+      ],
+      isError: true,
+    });
+    expect(browserCreated).toBe(false);
+  });
+
+  test("rejects a missing existing profile", async () => {
+    let profileCreated = false;
+    kernelClient = {
+      profiles: {
+        list: () => profilePage([]),
+        create: async () => {
+          profileCreated = true;
+        },
+      },
+      browsers: {
+        create: async () => {
+          throw new Error("browser setup should not start");
+        },
+      },
+    };
+    const handler = captureTool(registerProfileCapabilities, "manage_profiles");
+
+    const result = await handler(
+      {
+        action: "setup",
+        profile_name: "Missing",
+        update_existing: true,
+      },
+      auth,
+    );
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: 'Error: profile "Missing" does not exist. Omit update_existing to create it.',
+        },
+      ],
+      isError: true,
+    });
+    expect(profileCreated).toBe(false);
+  });
+
+  test("loads the exact existing profile", async () => {
+    let profileCreated = false;
+    const browserCalls: unknown[] = [];
+    kernelClient = {
+      profiles: {
+        list: () => profilePage([{ id: "profile-1", name: "Acme" }]),
+        create: async () => {
+          profileCreated = true;
+        },
+      },
+      browsers: {
+        create: async (params: unknown) => {
+          browserCalls.push(params);
+          return {
+            session_id: "session-1",
+            browser_live_view_url: "https://example.test/live",
+          };
+        },
+      },
+    };
+    const handler = captureTool(registerProfileCapabilities, "manage_profiles");
+
+    const result = await handler(
+      { action: "setup", profile_name: "Acme", update_existing: true },
+      auth,
+    );
+
+    expect(profileCreated).toBe(false);
+    expect(browserCalls).toEqual([
+      {
+        stealth: true,
+        timeout_seconds: 300,
+        profile: { id: "profile-1", save_changes: true },
+      },
+    ]);
+    expect(result.content[0].text).toContain(
+      'Profile "Acme" loaded for update.',
+    );
+    expect(result.content[0].text).toContain("Profile ID: profile-1");
+  });
+
+  test("renames a profile through the SDK", async () => {
+    const updateCalls: unknown[] = [];
+    kernelClient = {
+      profiles: {
+        update: async (...args: unknown[]) => {
+          updateCalls.push(args);
+          return { id: "profile-1", name: "Renamed" };
+        },
+      },
+    };
+    const handler = captureTool(registerProfileCapabilities, "manage_profiles");
+
+    const result = await handler(
+      {
+        action: "rename",
+        profile_id: "profile-1",
+        new_name: "Renamed",
+      },
+      auth,
+    );
+
+    expect(updateCalls).toEqual([["profile-1", { name: "Renamed" }]]);
+    expect(JSON.parse(result.content[0].text)).toEqual({
+      id: "profile-1",
+      name: "Renamed",
+    });
+  });
+
+  test.each([
+    [
+      "both profile identifiers",
+      { profile_id: "profile-1", profile_name: "Acme", new_name: "New" },
+      "Error: Cannot specify both profile_name and profile_id.",
+    ],
+    [
+      "no profile identifier",
+      { new_name: "New" },
+      "Error: profile_name or profile_id is required for rename.",
+    ],
+    [
+      "no new name",
+      { profile_id: "profile-1" },
+      "Error: new_name is required for rename.",
+    ],
+  ])("rejects rename with %s", async (_name, params, wantError) => {
+    let updated = false;
+    kernelClient = {
+      profiles: {
+        update: async () => {
+          updated = true;
+        },
+      },
+    };
+    const handler = captureTool(registerProfileCapabilities, "manage_profiles");
+
+    const result = await handler({ action: "rename", ...params }, auth);
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: wantError }],
+      isError: true,
+    });
+    expect(updated).toBe(false);
+  });
+});
+
+describe("durable proxy contracts", () => {
+  test("renames a proxy through the SDK", async () => {
+    const updateCalls: unknown[] = [];
+    kernelClient = {
+      proxies: {
+        update: async (...args: unknown[]) => {
+          updateCalls.push(args);
+          return { id: "proxy-1", name: "Renamed" };
+        },
+      },
+    };
+    const handler = captureTool(registerProxyTools, "manage_proxies");
+
+    const result = await handler(
+      { action: "rename", proxy_id: "proxy-1", name: "Renamed" },
+      auth,
+    );
+
+    expect(updateCalls).toEqual([["proxy-1", { name: "Renamed" }]]);
+    expect(JSON.parse(result.content[0].text)).toEqual({
+      id: "proxy-1",
+      name: "Renamed",
+    });
+  });
+
+  test.each([
+    [
+      "no proxy ID",
+      { name: "Renamed" },
+      "Error: proxy_id is required for rename.",
+    ],
+    ["no name", { proxy_id: "proxy-1" }, "Error: name is required for rename."],
+  ])("rejects rename with %s", async (_name, params, wantError) => {
+    let updated = false;
+    kernelClient = {
+      proxies: {
+        update: async () => {
+          updated = true;
+        },
+      },
+    };
+    const handler = captureTool(registerProxyTools, "manage_proxies");
+
+    const result = await handler({ action: "rename", ...params }, auth);
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: wantError }],
+      isError: true,
+    });
+    expect(updated).toBe(false);
+  });
+});

--- a/src/lib/mcp/tools/profiles.ts
+++ b/src/lib/mcp/tools/profiles.ts
@@ -69,19 +69,24 @@ export function registerProfileCapabilities(server: McpServer) {
 
   server.tool(
     "manage_profiles",
-    'Manage browser profiles when an agent needs persistent cookies, login state, or reusable browser state. Use "setup" for a guided login session, "list" to find a profile, "get" to retrieve one, and "delete" only when a profile should be removed.',
+    'Manage browser profiles when an agent needs persistent cookies, login state, or reusable browser state. Use "setup" for a guided login session, "list" to find a profile, "get" to retrieve one, "rename" to change its name, and "delete" only when a profile should be removed. Do not rename a profile while a browser is using it because that session may no longer save changes back to the profile.',
     {
       action: z
-        .enum(["setup", "list", "get", "delete"])
+        .enum(["setup", "list", "get", "rename", "delete"])
         .describe("Operation to perform."),
       profile_name: z
         .string()
-        .describe("(setup, get, delete) Profile name. For setup: 1-255 chars.")
+        .describe(
+          "(setup, get, rename, delete) Profile name. For setup: 1-255 chars.",
+        )
         .optional(),
       profile_id: z
         .string()
-        .describe("(get, delete) Profile ID. Alternative to profile_name.")
+        .describe(
+          "(get, rename, delete) Profile ID. Alternative to profile_name.",
+        )
         .optional(),
+      new_name: z.string().describe("(rename) New profile name.").optional(),
       update_existing: z
         .boolean()
         .describe("(setup) If true, update existing profile. Default false.")
@@ -110,13 +115,20 @@ export function registerProfileCapabilities(server: McpServer) {
               return errorResponse(
                 "Error: profile_name is required for setup.",
               );
-            // Scan all profiles for an exact name match: the list `query` is a
-            // search and may not reliably return an exact-named profile, which
-            // would let setup create a duplicate.
-            const existingProfiles = await listProfiles(client);
-            const existingProfile = existingProfiles?.find(
-              (p) => p.name === params.profile_name,
-            );
+            const existingProfiles = await listProfiles(client, {
+              name: params.profile_name,
+            });
+            if (existingProfiles.length > 1) {
+              return errorResponse(
+                `Error: multiple profiles match the exact name "${params.profile_name}". Rename or delete duplicate profiles by ID, then retry setup.`,
+              );
+            }
+            const existingProfile = existingProfiles[0];
+            if (!existingProfile && params.update_existing) {
+              return errorResponse(
+                `Error: profile "${params.profile_name}" does not exist. Omit update_existing to create it.`,
+              );
+            }
             let profile;
             let isNewProfile = false;
 
@@ -138,7 +150,7 @@ export function registerProfileCapabilities(server: McpServer) {
             const browser = await client.browsers.create({
               stealth: true,
               timeout_seconds: 300,
-              profile: { name: params.profile_name, save_changes: true },
+              profile: { id: profile.id, save_changes: true },
             });
             if (!browser)
               return errorResponse(
@@ -194,6 +206,26 @@ export function registerProfileCapabilities(server: McpServer) {
               );
             }
             const profile = await client.profiles.retrieve(identifier);
+            return jsonResponse(profile);
+          }
+          case "rename": {
+            if (params.profile_name && params.profile_id) {
+              return errorResponse(
+                "Error: Cannot specify both profile_name and profile_id.",
+              );
+            }
+            const identifier = params.profile_name || params.profile_id;
+            if (!identifier) {
+              return errorResponse(
+                "Error: profile_name or profile_id is required for rename.",
+              );
+            }
+            if (!params.new_name) {
+              return errorResponse("Error: new_name is required for rename.");
+            }
+            const profile = await client.profiles.update(identifier, {
+              name: params.new_name,
+            });
             return jsonResponse(profile);
           }
           case "delete": {

--- a/src/lib/mcp/tools/profiles.ts
+++ b/src/lib/mcp/tools/profiles.ts
@@ -1,6 +1,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { createKernelClient, type KernelClient } from "@/lib/mcp/kernel-client";
+import {
+  defaultMcpDependencies,
+  type McpDependencies,
+} from "@/lib/mcp/dependencies";
+import type { KernelClient } from "@/lib/mcp/kernel-client";
 import { registerJsonResourceTemplate } from "@/lib/mcp/resource-templates";
 import {
   errorResponse,
@@ -37,13 +41,38 @@ function fullProfileListResponse(profiles: Profile[], query?: string) {
   });
 }
 
-export function registerProfileCapabilities(server: McpServer) {
+function requireProfileIdentifier(
+  params: { profile_name?: string; profile_id?: string },
+  action: "get" | "rename" | "delete",
+) {
+  if (params.profile_name && params.profile_id) {
+    return {
+      ok: false as const,
+      error: "Error: Cannot specify both profile_name and profile_id.",
+    };
+  }
+
+  const identifier = params.profile_name || params.profile_id;
+  if (!identifier) {
+    return {
+      ok: false as const,
+      error: `Error: profile_name or profile_id is required for ${action}.`,
+    };
+  }
+
+  return { ok: true as const, value: identifier };
+}
+
+export function registerProfileCapabilities(
+  server: McpServer,
+  dependencies: McpDependencies = defaultMcpDependencies,
+) {
   server.resource("profiles", "profiles://", async (uri, extra) => {
     if (!extra.authInfo) {
       throw new Error("Authentication required");
     }
 
-    const client = createKernelClient(extra.authInfo.token);
+    const client = dependencies.createKernelClient(extra.authInfo.token);
     const profiles = await listProfiles(client);
     return {
       contents: [
@@ -59,13 +88,17 @@ export function registerProfileCapabilities(server: McpServer) {
     };
   });
 
-  registerJsonResourceTemplate(server, {
-    name: "profile",
-    uriTemplate: "profiles://{profileName}",
-    variableName: "profileName",
-    resourceLabel: "Profile",
-    read: (client, profileName) => client.profiles.retrieve(profileName),
-  });
+  registerJsonResourceTemplate(
+    server,
+    {
+      name: "profile",
+      uriTemplate: "profiles://{profileName}",
+      variableName: "profileName",
+      resourceLabel: "Profile",
+      read: (client, profileName) => client.profiles.retrieve(profileName),
+    },
+    dependencies,
+  );
 
   server.tool(
     "manage_profiles",
@@ -106,7 +139,7 @@ export function registerProfileCapabilities(server: McpServer) {
     },
     async (params, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");
-      const client = createKernelClient(extra.authInfo.token);
+      const client = dependencies.createKernelClient(extra.authInfo.token);
 
       try {
         switch (params.action) {
@@ -197,54 +230,28 @@ export function registerProfileCapabilities(server: McpServer) {
             );
           }
           case "get": {
-            if (params.profile_name && params.profile_id) {
-              return errorResponse(
-                "Error: Cannot specify both profile_name and profile_id.",
-              );
-            }
-            const identifier = params.profile_name || params.profile_id;
-            if (!identifier) {
-              return errorResponse(
-                "Error: profile_name or profile_id is required for get.",
-              );
-            }
-            const profile = await client.profiles.retrieve(identifier);
+            const identifier = requireProfileIdentifier(params, "get");
+            if (!identifier.ok) return errorResponse(identifier.error);
+            const profile = await client.profiles.retrieve(identifier.value);
             return jsonResponse(profile);
           }
           case "rename": {
-            if (params.profile_name && params.profile_id) {
-              return errorResponse(
-                "Error: Cannot specify both profile_name and profile_id.",
-              );
-            }
-            const identifier = params.profile_name || params.profile_id;
-            if (!identifier) {
-              return errorResponse(
-                "Error: profile_name or profile_id is required for rename.",
-              );
-            }
+            const identifier = requireProfileIdentifier(params, "rename");
+            if (!identifier.ok) return errorResponse(identifier.error);
             if (!params.new_name) {
               return errorResponse("Error: new_name is required for rename.");
             }
-            const profile = await client.profiles.update(identifier, {
+            const profile = await client.profiles.update(identifier.value, {
               name: params.new_name,
             });
             return jsonResponse(profile);
           }
           case "delete": {
-            if (params.profile_name && params.profile_id) {
-              return errorResponse(
-                "Error: Cannot specify both profile_name and profile_id.",
-              );
-            }
-            const identifier = params.profile_name || params.profile_id;
-            if (!identifier)
-              return errorResponse(
-                "Error: profile_name or profile_id is required for delete.",
-              );
-            await client.profiles.delete(identifier);
+            const identifier = requireProfileIdentifier(params, "delete");
+            if (!identifier.ok) return errorResponse(identifier.error);
+            await client.profiles.delete(identifier.value);
             return textResponse(
-              `Profile "${identifier}" deleted successfully.`,
+              `Profile "${identifier.value}" deleted successfully.`,
             );
           }
         }

--- a/src/lib/mcp/tools/profiles.ts
+++ b/src/lib/mcp/tools/profiles.ts
@@ -119,8 +119,11 @@ export function registerProfileCapabilities(server: McpServer) {
               name: params.profile_name,
             });
             if (existingProfiles.length > 1) {
+              const matches = existingProfiles
+                .map((profile) => `${profile.name} (ID: ${profile.id})`)
+                .join(", ");
               return errorResponse(
-                `Error: multiple profiles match the exact name "${params.profile_name}". Rename or delete duplicate profiles by ID, then retry setup.`,
+                `Error: multiple profiles match the exact name "${params.profile_name}": ${matches}. Rename or delete duplicate profiles by ID, then retry setup.`,
               );
             }
             const existingProfile = existingProfiles[0];

--- a/src/lib/mcp/tools/proxies.ts
+++ b/src/lib/mcp/tools/proxies.ts
@@ -26,17 +26,17 @@ const httpUrlSchema = z
   );
 
 export function registerProxyTools(server: McpServer) {
-  // manage_proxies -- Create, list, get, check, and delete proxy configurations
+  // manage_proxies -- Create, list, get, rename, check, and delete proxy configurations
   server.tool(
     "manage_proxies",
-    'Manage proxy configurations for routing browser traffic. Use "create" to add a proxy, "list" to see all proxies, "get" to retrieve one, "check" to test connectivity (optionally against a target URL), or "delete" to remove one. Proxy quality for bot detection avoidance, best to worst: mobile > residential > ISP > datacenter.',
+    'Manage proxy configurations for routing browser traffic. Use "create" to add a proxy, "list" to see all proxies, "get" to retrieve one, "rename" to change its name, "check" to test connectivity (optionally against a target URL), or "delete" to remove one. Proxy quality for bot detection avoidance, best to worst: mobile > residential > ISP > datacenter.',
     {
       action: z
-        .enum(["create", "list", "get", "check", "delete"])
+        .enum(["create", "list", "get", "rename", "check", "delete"])
         .describe("Operation to perform."),
       proxy_id: z
         .string()
-        .describe("(get, check, delete) Proxy ID.")
+        .describe("(get, rename, check, delete) Proxy ID.")
         .optional(),
       check_url: httpUrlSchema
         .describe(
@@ -49,7 +49,7 @@ export function registerProxyTools(server: McpServer) {
         .optional(),
       name: z
         .string()
-        .describe("(create) Readable name for the proxy.")
+        .describe("(create, rename) Readable name for the proxy.")
         .optional(),
       country: z
         .string()
@@ -149,6 +149,18 @@ export function registerProxyTools(server: McpServer) {
               return errorResponse("Error: proxy_id is required for get.");
             }
             const proxy = await client.proxies.retrieve(params.proxy_id);
+            return jsonResponse(proxy);
+          }
+          case "rename": {
+            if (!params.proxy_id) {
+              return errorResponse("Error: proxy_id is required for rename.");
+            }
+            if (!params.name) {
+              return errorResponse("Error: name is required for rename.");
+            }
+            const proxy = await client.proxies.update(params.proxy_id, {
+              name: params.name,
+            });
             return jsonResponse(proxy);
           }
           case "check": {

--- a/src/lib/mcp/tools/proxies.ts
+++ b/src/lib/mcp/tools/proxies.ts
@@ -1,6 +1,9 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { createKernelClient } from "@/lib/mcp/kernel-client";
+import {
+  defaultMcpDependencies,
+  type McpDependencies,
+} from "@/lib/mcp/dependencies";
 import {
   errorResponse,
   jsonResponse,
@@ -25,7 +28,10 @@ const httpUrlSchema = z
     { message: "URL must use http or https." },
   );
 
-export function registerProxyTools(server: McpServer) {
+export function registerProxyTools(
+  server: McpServer,
+  dependencies: McpDependencies = defaultMcpDependencies,
+) {
   // manage_proxies -- Create, list, get, rename, check, and delete proxy configurations
   server.tool(
     "manage_proxies",
@@ -89,7 +95,7 @@ export function registerProxyTools(server: McpServer) {
     },
     async (params, extra) => {
       if (!extra.authInfo) throw new Error("Authentication required");
-      const client = createKernelClient(extra.authInfo.token);
+      const client = dependencies.createKernelClient(extra.authInfo.token);
 
       try {
         switch (params.action) {


### PR DESCRIPTION
## Summary

- make profile setup use exact-name filtering and reject ambiguity
- add profile and proxy rename actions
- preserve stable API error codes in MCP failures
- bind profile setup browsers to the resolved profile ID

## Why

Durable MCP operations should resolve stable identities and surface actionable API failures. Search-style profile matching and name reuse could otherwise select the wrong durable profile.

## Implementation

Profile setup filters by exact name, rejects duplicate exact matches with an executable recovery path, and uses the resolved ID when opening the setup browser. Rename guidance warns before invocation about active profile sessions. Rename responses retain their direct SDK resource shape.

## Verification

- `bun test` (95 tests)
- `bunx tsc --noEmit`
- Prettier and `git diff --check`
- 20 focused scenario tests covering exact lookup, ambiguity, missing resources, rename guards, stable profile identity, and coded API errors
- targeted Stryker: profile/proxy rename and exact-lookup core paths reached 100%; expanded setup/error run killed 84/106 mutants, with remaining survivors in pre-existing presentation branches and equivalent API-error guards
- crap4ts: changed registration paths 1.1; API error-code helper 5.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how durable profiles are resolved during setup (ID binding and ambiguity handling), which could alter agent behavior if duplicate names existed; production wiring stays on default dependencies.
> 
> **Overview**
> Introduces **`McpDependencies`** so MCP registration and tools can inject `createKernelClient` (defaults unchanged in production), enabling contract tests without hitting the real API.
> 
> **Profile setup** now lists by exact `name`, fails on duplicate exact matches with recovery guidance, rejects `update_existing` when the profile is missing, and opens the setup browser with **`profile.id`** instead of name. **`manage_profiles`** gains a **`rename`** action (by name or ID) with shared identifier validation; tool docs warn against renaming while a browser session is attached.
> 
> **`manage_proxies`** gains **`rename`** via `proxies.update`. MCP **`throwToolError`** messages append **`[code: …]`** when the Kernel SDK returns a string API error code.
> 
> Adds **`durable-contracts.test.ts`** and extends **`responses.test.ts`** for coded errors and rename/schema behavior at the MCP boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7fa9aaa19e346fd276dcf0b6f65e92cd3d4d217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->