### PR TITLE
Measure MCP connection authentication context

### DIFF
--- a/src/app/[transport]/route.ts
+++ b/src/app/[transport]/route.ts
@@ -6,7 +6,12 @@ import {
 import { verifyToken } from "@clerk/nextjs/server";
 import { after, NextRequest } from "next/server";
 import { isValidJwtFormat } from "@/lib/auth-utils";
-import { flushMcpAnalytics, instrumentMcpAnalytics } from "@/lib/mcp/analytics";
+import {
+  flushMcpAnalytics,
+  instrumentMcpAnalytics,
+  isMcpAnalyticsEnabled,
+} from "@/lib/mcp/analytics";
+import { resolveMcpConnectionAnalyticsContext } from "@/lib/mcp/auth-context";
 import { mcpAppsAuthSubject } from "@/lib/mcp-apps-marker";
 import { requestUsesMcpApps } from "@/lib/mcp-apps-request";
 import {
@@ -66,6 +71,7 @@ const mcpAppsHandler = createMcpHandler((server) => {
 async function handleAuthenticatedRequest(
   req: NextRequest,
   transportSessionId: string | null = null,
+  observeConnection = false,
 ): Promise<Response> {
   const authHeader = req.headers.get("Authorization");
   const token = authHeader?.startsWith("Bearer ")
@@ -77,6 +83,14 @@ async function handleAuthenticatedRequest(
       "Missing or invalid access token",
     );
   }
+
+  const connectionAnalytics = observeConnection
+    ? await resolveMcpConnectionAnalyticsContext({
+        token,
+        enabled: isMcpAnalyticsEnabled(),
+        signal: req.signal,
+      })
+    : null;
 
   if (!isValidJwtFormat(token)) {
     // Opaque API keys are authenticated by the Kernel API rather than Clerk.
@@ -94,7 +108,11 @@ async function handleAuthenticatedRequest(
         token,
         scopes: ["apikey"],
         clientId: "mcp-server",
-        extra: { userId: null, clerkToken: null },
+        extra: {
+          userId: null,
+          clerkToken: null,
+          connectionAnalytics,
+        },
       }),
       {
         required: true,
@@ -139,6 +157,7 @@ async function handleAuthenticatedRequest(
           extra: {
             userId: payload.sub,
             clerkToken: token,
+            connectionAnalytics,
           },
         };
       },
@@ -208,6 +227,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       signal: req.signal,
     }),
     session?.id ?? null,
+    isStreamableInitialize,
   );
 
   if (!session) return response;

--- a/src/lib/mcp/analytics.test.ts
+++ b/src/lib/mcp/analytics.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import {
+  PostHogMCPAnalyticsEvent,
+  PostHogMCPAnalyticsProperty,
+} from "@posthog/mcp";
+import { enrichMcpAnalyticsEvent } from "@/lib/mcp/analytics";
+
+const privateContextProperty = "__mcp_connection_analytics_context";
+
+function initializeEvent(
+  sessionId: string,
+  context: {
+    authMethod: "api_key" | "oauth";
+    credentialScope: "organization" | "project";
+    connectionScope: "organization" | "project";
+    scopeSource: "credential" | "server_pin";
+    organizationId: string;
+    userId: string | null;
+  },
+): {
+  event: string;
+  distinct_id: string;
+  properties: Record<string, unknown>;
+} {
+  return {
+    event: PostHogMCPAnalyticsEvent.Initialize,
+    distinct_id: sessionId,
+    properties: {
+      [PostHogMCPAnalyticsProperty.SessionId]: sessionId,
+      $process_person_profile: false,
+      [privateContextProperty]: context,
+    },
+  };
+}
+
+describe("enrichMcpAnalyticsEvent", () => {
+  test("keeps API-key connections anonymous and omits credential identity", () => {
+    const event = initializeEvent("session_1", {
+      authMethod: "api_key",
+      credentialScope: "organization",
+      connectionScope: "organization",
+      scopeSource: "credential",
+      organizationId: "org_123",
+      userId: null,
+    });
+
+    enrichMcpAnalyticsEvent(event);
+
+    expect(event.distinct_id).toBe("session_1");
+    expect(event.properties.$process_person_profile).toBe(false);
+    expect(event.properties.$groups).toEqual({ organization: "org_123" });
+    expect(event.properties.$mcp_auth_method).toBe("api_key");
+    expect(event.properties[privateContextProperty]).toBeUndefined();
+  });
+
+  test("uses canonical Kernel user identity only for OAuth", () => {
+    const event = initializeEvent("session_1", {
+      authMethod: "oauth",
+      credentialScope: "organization",
+      connectionScope: "project",
+      scopeSource: "server_pin",
+      organizationId: "org_123",
+      userId: "user_kernel_123",
+    });
+
+    enrichMcpAnalyticsEvent(event);
+
+    expect(event.distinct_id).toBe("user_kernel_123");
+    expect(event.properties.$process_person_profile).toBeUndefined();
+    expect(event.properties.$mcp_credential_scope).toBe("organization");
+    expect(event.properties.$mcp_connection_scope).toBe("project");
+    expect(event.properties.$mcp_scope_source).toBe("server_pin");
+  });
+
+  test("deduplicates refreshes within a session and counts reconnects separately", () => {
+    const context = {
+      authMethod: "oauth" as const,
+      credentialScope: "organization" as const,
+      connectionScope: "organization" as const,
+      scopeSource: "credential" as const,
+      organizationId: "org_123",
+      userId: "user_kernel_123",
+    };
+    const beforeRefresh = initializeEvent("session_1", context);
+    const afterRefresh = initializeEvent("session_1", context);
+    const reconnect = initializeEvent("session_2", context);
+
+    enrichMcpAnalyticsEvent(beforeRefresh);
+    enrichMcpAnalyticsEvent(afterRefresh);
+    enrichMcpAnalyticsEvent(reconnect);
+
+    expect(beforeRefresh.properties.$insert_id).toBe(
+      afterRefresh.properties.$insert_id,
+    );
+    expect(reconnect.properties.$insert_id).not.toBe(
+      beforeRefresh.properties.$insert_id,
+    );
+  });
+
+  test("does not add connection properties to other MCP events", () => {
+    const event: {
+      event: string;
+      distinct_id: string;
+      properties: Record<string, unknown>;
+    } = {
+      event: PostHogMCPAnalyticsEvent.ToolCall,
+      distinct_id: "session_1",
+      properties: {
+        [PostHogMCPAnalyticsProperty.SessionId]: "session_1",
+        [privateContextProperty]: {
+          authMethod: "oauth",
+          credentialScope: "organization",
+          connectionScope: "organization",
+          scopeSource: "credential",
+          organizationId: "org_123",
+          userId: "user_kernel_123",
+        },
+      },
+    };
+
+    enrichMcpAnalyticsEvent(event);
+
+    expect(event.distinct_id).toBe("session_1");
+    expect(event.properties.$mcp_auth_method).toBeUndefined();
+    expect(event.properties[privateContextProperty]).toBeUndefined();
+  });
+});

--- a/src/lib/mcp/analytics.ts
+++ b/src/lib/mcp/analytics.ts
@@ -7,6 +7,7 @@ import {
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { PostHog } from "posthog-node";
 import { z } from "zod";
+import type { McpConnectionAnalyticsContext } from "@/lib/mcp/auth-context";
 
 const projectToken = process.env.POSTHOG_PROJECT_TOKEN;
 
@@ -32,7 +33,12 @@ const posthog = projectToken
 // returned).
 const SENT_PROPERTIES = new Set<string>([
   "$groups",
+  "$insert_id",
   "$process_person_profile",
+  "$mcp_auth_method",
+  "$mcp_connection_scope",
+  "$mcp_credential_scope",
+  "$mcp_scope_source",
   PostHogMCPAnalyticsProperty.ClientName,
   PostHogMCPAnalyticsProperty.ClientVersion,
   PostHogMCPAnalyticsProperty.DurationMs,
@@ -141,6 +147,54 @@ function registerMissingCapabilityTool(server: McpServer) {
  * `$mcp_*` PostHog event, and advertises the tool agents use to report a capability the
  * server doesn't have. No-op when POSTHOG_PROJECT_TOKEN is unset.
  */
+const ANALYTICS_CONTEXT_PROPERTY = "__mcp_connection_analytics_context";
+
+function connectionAnalyticsContext(extra: unknown) {
+  const authInfo = (extra as { authInfo?: { extra?: unknown } } | undefined)
+    ?.authInfo;
+  const authExtra = authInfo?.extra as
+    | { connectionAnalytics?: McpConnectionAnalyticsContext }
+    | undefined;
+  return authExtra?.connectionAnalytics;
+}
+
+export function enrichMcpAnalyticsEvent(event: {
+  event: string;
+  distinct_id: string;
+  properties: Record<string, unknown>;
+}) {
+  const context = event.properties[ANALYTICS_CONTEXT_PROPERTY] as
+    | McpConnectionAnalyticsContext
+    | undefined;
+  delete event.properties[ANALYTICS_CONTEXT_PROPERTY];
+
+  if (event.event !== PostHogMCPAnalyticsEvent.Initialize || !context) {
+    return event;
+  }
+
+  event.properties["$mcp_auth_method"] = context.authMethod;
+  event.properties["$mcp_credential_scope"] = context.credentialScope;
+  event.properties["$mcp_connection_scope"] = context.connectionScope;
+  event.properties["$mcp_scope_source"] = context.scopeSource;
+  event.properties.$groups = { organization: context.organizationId };
+
+  const sessionId = event.properties[PostHogMCPAnalyticsProperty.SessionId];
+  if (typeof sessionId === "string" && sessionId) {
+    event.properties.$insert_id = `mcp-connection:${sessionId}`;
+  }
+
+  if (context.userId) {
+    event.distinct_id = context.userId;
+    delete event.properties.$process_person_profile;
+  }
+
+  return event;
+}
+
+export function isMcpAnalyticsEnabled() {
+  return posthog !== null;
+}
+
 export function instrumentMcpAnalytics(server: McpServer) {
   if (!posthog) return;
 
@@ -157,12 +211,17 @@ export function instrumentMcpAnalytics(server: McpServer) {
     // A failed tool call otherwise fans out into a second `$exception` event whose
     // `$exception_list` is built from the text the tool returned.
     enableExceptionAutocapture: false,
-    // Events are attributed to the analytics session, with no person created. The only
-    // id this server holds is the Clerk subject, while every other producer in these
-    // projects identifies people by their Kernel user id — identifying on the subject
-    // would mint a second profile per person. Resolving the Kernel user id needs an
-    // API that doesn't exist yet, so user-level reporting is out of scope until then.
+    // Keep general MCP telemetry session-scoped. The initialize event alone uses the
+    // canonical Kernel user ID when auth context identifies a user; API-key principals
+    // remain anonymous because their principal ID identifies the credential itself.
     identify: null,
+    // Connection context is present only on initialize. beforeSend turns this private,
+    // typed value into allow-listed analytics properties and removes it before capture.
+    eventProperties: (request, extra) => {
+      if (request.method !== "initialize") return null;
+      const context = connectionAnalyticsContext(extra);
+      return context ? { [ANALYTICS_CONTEXT_PROPERTY]: context } : null;
+    },
     // No part of a call is safe to capture: arguments carry free-form input (credential
     // field maps, curl headers and bodies, typed text, shell commands, Playwright
     // source), results are serialized to a JSON string (see jsonResponse) so the SDK's
@@ -171,6 +230,7 @@ export function instrumentMcpAnalytics(server: McpServer) {
     beforeSend: (event) => {
       if (event.event === PostHogMCPAnalyticsEvent.Exception) return null;
 
+      enrichMcpAnalyticsEvent(event);
       const properties = event.properties;
       if (!properties) return event;
 

--- a/src/lib/mcp/auth-context.test.ts
+++ b/src/lib/mcp/auth-context.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import { resolveMcpConnectionAnalyticsContext } from "@/lib/mcp/auth-context";
+
+function response({
+  method = "api_key",
+  source = "api_key",
+  principalType = "api_key",
+  principalId = "key_sensitive",
+  credentialProjectId = null,
+  effectiveProjectId = null,
+}: {
+  method?: "api_key" | "jwt";
+  source?: "api_key" | "oauth" | "dashboard";
+  principalType?: "api_key" | "user";
+  principalId?: string;
+  credentialProjectId?: string | null;
+  effectiveProjectId?: string | null;
+} = {}) {
+  return {
+    authentication: {
+      method,
+      source,
+      credential_id: method === "api_key" ? "key_sensitive" : null,
+    },
+    principal: { type: principalType, id: principalId },
+    organization: { id: "org_123" },
+    authorization: {
+      credential_scope: { project_id: credentialProjectId },
+      effective_scope: { project_id: effectiveProjectId },
+    },
+  };
+}
+
+function fetchResponse(body: unknown, status = 200) {
+  return async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+}
+
+describe("resolveMcpConnectionAnalyticsContext", () => {
+  test("classifies an organization-wide API key without identifying its owner", async () => {
+    const context = await resolveMcpConnectionAnalyticsContext({
+      token: "sk_secret",
+      enabled: true,
+      fetchImpl: fetchResponse(response()),
+    });
+
+    expect(context).toEqual({
+      authMethod: "api_key",
+      credentialScope: "organization",
+      connectionScope: "organization",
+      scopeSource: "credential",
+      organizationId: "org_123",
+      userId: null,
+    });
+    expect(JSON.stringify(context)).not.toContain("key_sensitive");
+  });
+
+  test("classifies a project-scoped API key", async () => {
+    const context = await resolveMcpConnectionAnalyticsContext({
+      token: "sk_secret",
+      enabled: true,
+      fetchImpl: fetchResponse(
+        response({
+          credentialProjectId: "project_123",
+          effectiveProjectId: "project_123",
+        }),
+      ),
+    });
+
+    expect(context?.credentialScope).toBe("project");
+    expect(context?.connectionScope).toBe("project");
+    expect(context?.scopeSource).toBe("credential");
+  });
+
+  test("identifies OAuth with the canonical user principal", async () => {
+    const context = await resolveMcpConnectionAnalyticsContext({
+      token: "jwt.secret.value",
+      enabled: true,
+      fetchImpl: fetchResponse(
+        response({
+          method: "jwt",
+          source: "oauth",
+          principalType: "user",
+          principalId: "user_kernel_123",
+        }),
+      ),
+    });
+
+    expect(context?.authMethod).toBe("oauth");
+    expect(context?.userId).toBe("user_kernel_123");
+  });
+
+  test("classifies KERNEL_PROJECT as a server pin", async () => {
+    let request: Request | undefined;
+    const fetchImpl = async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      request = new Request(input, init);
+      return new Response(
+        JSON.stringify(response({ effectiveProjectId: "project_pinned" })),
+      );
+    };
+
+    const context = await resolveMcpConnectionAnalyticsContext({
+      token: "sk_secret",
+      enabled: true,
+      fetchImpl,
+      serverProjectId: "project_pinned",
+    });
+
+    expect(request?.headers.get("X-Kernel-Project-Id")).toBe("project_pinned");
+    expect(context?.credentialScope).toBe("organization");
+    expect(context?.connectionScope).toBe("project");
+    expect(context?.scopeSource).toBe("server_pin");
+  });
+
+  test("does not fetch when analytics is disabled", async () => {
+    let calls = 0;
+    const context = await resolveMcpConnectionAnalyticsContext({
+      token: "sk_secret",
+      enabled: false,
+      fetchImpl: async () => {
+        calls += 1;
+        return new Response();
+      },
+    });
+
+    expect(context).toBeNull();
+    expect(calls).toBe(0);
+  });
+
+  test("fails closed for unavailable, malformed, or unsupported context", async () => {
+    const unavailable = await resolveMcpConnectionAnalyticsContext({
+      token: "sk_secret",
+      enabled: true,
+      fetchImpl: fetchResponse({}, 503),
+    });
+    const malformed = await resolveMcpConnectionAnalyticsContext({
+      token: "sk_secret",
+      enabled: true,
+      fetchImpl: fetchResponse({ authentication: {} }),
+    });
+    const dashboard = await resolveMcpConnectionAnalyticsContext({
+      token: "jwt.secret.value",
+      enabled: true,
+      fetchImpl: fetchResponse(
+        response({
+          method: "jwt",
+          source: "dashboard",
+          principalType: "user",
+          principalId: "user_kernel_123",
+        }),
+      ),
+    });
+
+    expect(unavailable).toBeNull();
+    expect(malformed).toBeNull();
+    expect(dashboard).toBeNull();
+  });
+});

--- a/src/lib/mcp/auth-context.ts
+++ b/src/lib/mcp/auth-context.ts
@@ -1,0 +1,127 @@
+import { z } from "zod";
+
+const authContextSchema = z.object({
+  authentication: z.object({
+    method: z.enum(["api_key", "jwt"]),
+    source: z.enum(["api_key", "oauth", "dashboard"]),
+    credential_id: z.string().nullable(),
+  }),
+  principal: z.object({
+    type: z.enum(["api_key", "user"]),
+    id: z.string().min(1),
+  }),
+  organization: z.object({
+    id: z.string().min(1),
+  }),
+  authorization: z.object({
+    credential_scope: z.object({ project_id: z.string().nullable() }),
+    effective_scope: z.object({ project_id: z.string().nullable() }),
+  }),
+});
+
+export type McpConnectionAnalyticsContext = {
+  authMethod: "api_key" | "oauth";
+  credentialScope: "organization" | "project";
+  connectionScope: "organization" | "project";
+  scopeSource: "credential" | "server_pin";
+  organizationId: string;
+  userId: string | null;
+};
+
+type Fetch = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+type ResolveOptions = {
+  token: string;
+  enabled: boolean;
+  signal?: AbortSignal;
+  fetchImpl?: Fetch;
+  apiBaseUrl?: string;
+  serverProjectId?: string;
+};
+
+export async function resolveMcpConnectionAnalyticsContext({
+  token,
+  enabled,
+  signal,
+  fetchImpl = fetch,
+  apiBaseUrl = process.env.API_BASE_URL ?? "https://api.onkernel.com",
+  serverProjectId = process.env.KERNEL_PROJECT,
+}: ResolveOptions): Promise<McpConnectionAnalyticsContext | null> {
+  if (!enabled) return null;
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    "X-Source": "mcp-server",
+    "X-Referral-Source": "mcp.onkernel.com",
+  };
+  if (serverProjectId) headers["X-Kernel-Project-Id"] = serverProjectId;
+
+  let response: Response;
+  try {
+    response = await fetchImpl(
+      new URL("auth/context", `${apiBaseUrl.replace(/\/$/, "")}/`),
+      { headers, signal },
+    );
+  } catch {
+    console.warn("Failed to resolve MCP connection analytics context");
+    return null;
+  }
+
+  if (!response.ok) {
+    console.warn("Failed to resolve MCP connection analytics context");
+    return null;
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    console.warn("Received invalid MCP connection analytics context");
+    return null;
+  }
+  const parsed = authContextSchema.safeParse(body);
+  if (!parsed.success) {
+    console.warn("Received invalid MCP connection analytics context");
+    return null;
+  }
+
+  const context = parsed.data;
+  const isApiKey =
+    context.authentication.method === "api_key" &&
+    context.authentication.source === "api_key" &&
+    context.principal.type === "api_key";
+  const isOAuth =
+    context.authentication.method === "jwt" &&
+    context.authentication.source === "oauth" &&
+    context.principal.type === "user";
+  if (!isApiKey && !isOAuth) return null;
+
+  const credentialProjectId = context.authorization.credential_scope.project_id;
+  const effectiveProjectId = context.authorization.effective_scope.project_id;
+  if (
+    credentialProjectId &&
+    effectiveProjectId &&
+    credentialProjectId !== effectiveProjectId
+  ) {
+    return null;
+  }
+  if (!credentialProjectId && effectiveProjectId && !serverProjectId) {
+    return null;
+  }
+  if (serverProjectId && effectiveProjectId !== serverProjectId) {
+    return null;
+  }
+
+  return {
+    authMethod: isApiKey ? "api_key" : "oauth",
+    credentialScope: credentialProjectId ? "project" : "organization",
+    connectionScope: effectiveProjectId ? "project" : "organization",
+    scopeSource:
+      !credentialProjectId && effectiveProjectId ? "server_pin" : "credential",
+    organizationId: context.organization.id,
+    userId: isOAuth ? context.principal.id : null,
+  };
+}


### PR DESCRIPTION
## summary

- enrich the existing MCP initialize event with authoritative authentication and scope classifications from `GET /auth/context`
- identify OAuth connection events with the canonical Kernel user ID while keeping API-key principals anonymous
- deduplicate connection initialization by signed MCP transport session and classify server-pinned project scope without emitting project or credential identifiers
- skip context lookup entirely when PostHog analytics is disabled and degrade to existing anonymous telemetry when context is unavailable

## dependency

Depends on kernel/kernel#3213 being deployed. This PR uses a small local typed HTTP client because the endpoint is not yet available in the released TypeScript SDK. The MCP server continues normally if the endpoint is unavailable.

## validation

- `bun test` (91 passing)
- `bunx tsc --noEmit --incremental false`
- `bun run check:managed-auth-app`
- `bun run build` with test configuration
- targeted Prettier check for all changed files
- repository-wide `bun run format:check` still reports pre-existing formatting in `AGENTS.md` and `src/lib/mcp/tools/playwright.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an outbound auth-context call on initialize and changes PostHog identity for OAuth users; failures are handled gracefully but depend on a not-yet-released API (kernel#3213).
> 
> **Overview**
> MCP **initialize** PostHog events are enriched with auth and scope metadata from Kernel **`GET /auth/context`**, fetched only on streamable initialize when PostHog is enabled.
> 
> A new **`resolveMcpConnectionAnalyticsContext`** client classifies API key vs OAuth, org vs project credential/connection scope, and server-pinned project scope (via **`KERNEL_PROJECT`** / **`X-Kernel-Project-Id`**). That context is passed through MCP auth **`extra.connectionAnalytics`** and turned into allow-listed properties on initialize only (**`$mcp_auth_method`**, scope fields, org **`$groups`**). OAuth connections use the canonical Kernel **user ID** as **`distinct_id`**; API keys stay session-anonymous. **`$insert_id`** dedupes repeated initialize in the same transport session.
> 
> If analytics is off, the endpoint fails, or the response is unsupported, lookup is skipped or returns null and telemetry falls back to the prior anonymous behavior—MCP serving is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a367175b840c278f8d7f350341e8ae050415e103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->