### PR TITLE
Add branded OAuth consent page

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "kernel-mcp-server",
       "dependencies": {
         "@clerk/mcp-tools": "^0.1.1",
-        "@clerk/nextjs": "^6.39.2",
+        "@clerk/nextjs": "^7.7.1",
         "@clerk/themes": "^2.4.19",
         "@mcp-ui/server": "^5.10.0",
         "@modelcontextprotocol/sdk": "1.26.0",
@@ -50,19 +50,19 @@
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
-    "@clerk/backend": ["@clerk/backend@2.33.2", "", { "dependencies": { "@clerk/shared": "^3.47.4", "@clerk/types": "^4.101.22", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-5nNPTdSLCTt7yVvMdd5CoEYZXVQhA9i0C50PxmAOjApYDIEfASedP9KXRb+YARiDrOSHQg0qFJhWUnujaG3hpw=="],
-
-    "@clerk/clerk-react": ["@clerk/clerk-react@5.61.5", "", { "dependencies": { "@clerk/shared": "^3.47.4", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-MKVEsvRR47WlizFki5BPjLIm1TPbJju4m2CNJGzrRqhEMide0Yjm4DGYfh/r2k/uFjOGMWfSJ7EToM1y2AQ5rg=="],
+    "@clerk/backend": ["@clerk/backend@3.16.1", "", { "dependencies": { "@clerk/shared": "^4.27.1", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-tbsrGqw45ar7PDnEV3gwkHE/HM1EwRcYPPLyL3Hw9H0Ms5fG7hZ8+EJegPJ4DpKdfvOw5M+hYMeCVKwv3NxahA=="],
 
     "@clerk/mcp-tools": ["@clerk/mcp-tools@0.1.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.12.3" }, "peerDependencies": { "better-sqlite3": "^8.7.0", "pg": "^8.11.0", "redis": "^4.0.0" }, "optionalPeers": ["better-sqlite3", "pg", "redis"] }, "sha512-SHoLmSAXtG4lXoVI4rbFScPP5GHK8YAvFFFh/NtKO8enaSnytv8gm7JKxymaxP7+OvRasQpmIJ8KmMR84sxhig=="],
 
-    "@clerk/nextjs": ["@clerk/nextjs@6.39.2", "", { "dependencies": { "@clerk/backend": "^2.33.2", "@clerk/clerk-react": "^5.61.5", "@clerk/shared": "^3.47.4", "@clerk/types": "^4.101.22", "server-only": "0.0.1", "tslib": "2.8.1" }, "peerDependencies": { "next": "^13.5.7 || ^14.2.25 || ^15.2.3 || ^16", "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-NTAgvhpntCdQD4KR+4f/KFs8cqd6oyzoE73AoO9w0xKoJbTB8IIIPG+CtdIw+mx7z4JqbQATKWZbMPGeZbZYCw=="],
+    "@clerk/nextjs": ["@clerk/nextjs@7.7.1", "", { "dependencies": { "@clerk/backend": "^3.16.1", "@clerk/react": "^6.13.1", "@clerk/shared": "^4.27.1", "server-only": "0.0.1", "tslib": "2.8.1" }, "peerDependencies": { "next": "^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0", "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-g5OxgJzFJ64G2+J61FRQtGGinWch0yG9BkOVe5LqqgplE7wCPGkbLPBW5kpAQRcDrvGTob24S0FOJ7ihPQs7ew=="],
 
-    "@clerk/shared": ["@clerk/shared@3.47.4", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-0O5/zgB5SO26PKarAIw7uj4j+4JsnT2/uiJ7SPI3LQMb62sM+AjDlVadcXuYc+4sY6w1szrAIVepI5Bkv57hnQ=="],
+    "@clerk/react": ["@clerk/react@6.13.1", "", { "dependencies": { "@clerk/shared": "^4.27.1", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-Wc+uxIAb8R5Qh6FJ01SXxTSfDgaQwmo5ZjRPkamJF7nNxsb7TNRQwR6kbrj113JDVbLwZZubjnY2zfleF/Po3g=="],
+
+    "@clerk/shared": ["@clerk/shared@4.27.1", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-eAin1Iy42P3vkytTebD99BhxDm6Yh72Kf8xnpM401Yz/hPUe/Ut4jFqU64xzlhf/RTCPfoTkOHaNDWdMACwXjQ=="],
 
     "@clerk/themes": ["@clerk/themes@2.4.19", "", { "dependencies": { "@clerk/types": "^4.86.0", "tslib": "2.8.1" } }, "sha512-/NxZ1IGNkcR0bEhYC2gmR6LhHFj7NRUl82+3FoC6gxU8Xu1+yIret4DH65GlN4FGtdKT5I538UH/lsA+g3Ym8w=="],
 
-    "@clerk/types": ["@clerk/types@4.101.22", "", { "dependencies": { "@clerk/shared": "^3.47.4" } }, "sha512-74hV9MMw9MzOOSuJNJMFP95XZ2jDfPS1v3pfALS3rSQa+h/lNREU+fLGArzYckEpqNtuF6xy0odg9YqF5BLNhA=="],
+    "@clerk/types": ["@clerk/types@4.86.0", "", { "dependencies": { "csstype": "3.1.3" } }, "sha512-YFaOYIAZWbpXehAmtgUB0YNf1v5b/hlwePvdqxlD5vdwrNsap28RpupWZat0hp1+PTtb9uAwSa5AFCOxkYLUJQ=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
 
@@ -228,6 +228,8 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.11", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.1.11", "@tailwindcss/oxide": "4.1.11", "postcss": "^8.4.41", "tailwindcss": "4.1.11" } }, "sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA=="],
 
+    "@tanstack/query-core": ["@tanstack/query-core@5.101.4", "", {}, "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw=="],
+
     "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
 
     "@types/jszip": ["@types/jszip@3.4.1", "", { "dependencies": { "jszip": "*" } }, "sha512-TezXjmf3lj+zQ651r6hPqvSScqBLvyPI9FxdXBqpEwBijNGQ2NXpaFW/7joGzveYkKQUil7iiDHLo6LV71Pc0A=="],
@@ -392,7 +394,7 @@
 
     "jose": ["jose@6.0.11", "", {}, "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg=="],
 
-    "js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
+    "js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -568,13 +570,9 @@
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
-    "std-env": ["std-env@3.9.0", "", {}, "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw=="],
-
     "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
-
-    "swr": ["swr@2.3.4", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg=="],
 
     "tailwindcss": ["tailwindcss@4.1.11", "", {}, "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA=="],
 
@@ -596,8 +594,6 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
-    "use-sync-external-store": ["use-sync-external-store@1.5.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A=="],
-
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
@@ -613,8 +609,6 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "@clerk/mcp-tools/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.15.1", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-W/XlN9c528yYn+9MQkVjxiTPgPxoxt+oczfjHBDsJx0+59+O7B75Zhsp0B16Xbwbz8ANISDajh6+V7nIcPMc5w=="],
-
-    "@clerk/themes/@clerk/types": ["@clerk/types@4.86.0", "", { "dependencies": { "csstype": "3.1.3" } }, "sha512-YFaOYIAZWbpXehAmtgUB0YNf1v5b/hlwePvdqxlD5vdwrNsap28RpupWZat0hp1+PTtb9uAwSa5AFCOxkYLUJQ=="],
 
     "@mcp-ui/server/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.15.1", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-W/XlN9c528yYn+9MQkVjxiTPgPxoxt+oczfjHBDsJx0+59+O7B75Zhsp0B16Xbwbz8ANISDajh6+V7nIcPMc5w=="],
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,20 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  headers: async () => {
+    return [
+      {
+        source: "/oauth-consent",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: "frame-ancestors 'none'",
+          },
+          { key: "X-Frame-Options", value: "DENY" },
+        ],
+      },
+    ];
+  },
   redirects: async () => {
     return [
       {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@clerk/mcp-tools": "^0.1.1",
-    "@clerk/nextjs": "^6.39.2",
+    "@clerk/nextjs": "^7.7.1",
     "@clerk/themes": "^2.4.19",
     "@mcp-ui/server": "^5.10.0",
     "@modelcontextprotocol/sdk": "1.26.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -55,11 +55,11 @@ export default function RootLayout({
       appearance={{
         variables: {
           colorPrimary: '#81b300',
-          colorText: '#1c2024',
-          colorTextSecondary: '#60646c',
+          colorForeground: '#1c2024',
+          colorMutedForeground: '#60646c',
           colorBackground: '#f2f0e7',
-          colorInputBackground: '#f2f0e7',
-          colorInputText: '#1c2024',
+          colorInput: '#f2f0e7',
+          colorInputForeground: '#1c2024',
           fontFamily: 'var(--font-inter), Inter, sans-serif',
           borderRadius: '0px',
         },

--- a/src/app/oauth-consent/page.tsx
+++ b/src/app/oauth-consent/page.tsx
@@ -1,0 +1,35 @@
+import { OAuthConsent, RedirectToSignIn, Show } from "@clerk/nextjs";
+import type { Metadata } from "next";
+import { Col } from "@/components/col";
+import { KernelWordmark } from "@/components/icons";
+
+export const metadata: Metadata = {
+  title: "authorize access | Kernel",
+  referrer: "strict-origin-when-cross-origin",
+};
+
+export default function OAuthConsentPage(): React.ReactElement {
+  return (
+    <Show when="signed-in" fallback={<RedirectToSignIn />}>
+      <Col className="min-h-screen items-center justify-center p-8">
+        <Col className="w-full max-w-md items-center gap-8">
+          <KernelWordmark className="text-foreground" width={100} height={22} />
+          <OAuthConsent
+            appearance={{
+              elements: {
+                rootBox: "w-full",
+                cardBox: "w-full",
+                card: "w-full",
+              },
+            }}
+            fallback={
+              <p className="text-sm text-muted-foreground">
+                loading authorization...
+              </p>
+            }
+          />
+        </Col>
+      </Col>
+    </Show>
+  );
+}

--- a/src/app/select-org/oauth-params.test.ts
+++ b/src/app/select-org/oauth-params.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { buildSelectOrgRedirectUrl } from "./oauth-params";
+
+describe("select organization OAuth parameters", () => {
+  test("preserves client, redirect, state, and PKCE parameters when switching accounts", () => {
+    const params = new URLSearchParams({
+      client_id: "client_1",
+      state: "opaque state",
+      redirect_uri: "https://client.example.test/oauth/callback?source=mcp",
+      code_challenge: "challenge_1",
+      code_challenge_method: "S256",
+    });
+
+    const redirect = new URL(
+      buildSelectOrgRedirectUrl(params),
+      "https://auth.example.test",
+    );
+
+    expect(redirect.pathname).toBe("/select-org");
+    expect(redirect.searchParams.get("client_id")).toBe("client_1");
+    expect(redirect.searchParams.get("state")).toBe("opaque state");
+    expect(redirect.searchParams.get("redirect_uri")).toBe(
+      "https://client.example.test/oauth/callback?source=mcp",
+    );
+    expect(redirect.searchParams.get("code_challenge")).toBe("challenge_1");
+    expect(redirect.searchParams.get("code_challenge_method")).toBe("S256");
+  });
+});

--- a/src/app/select-org/oauth-params.ts
+++ b/src/app/select-org/oauth-params.ts
@@ -1,0 +1,6 @@
+export function buildSelectOrgRedirectUrl(
+  searchParams: Pick<URLSearchParams, "toString">,
+): string {
+  const query = searchParams.toString();
+  return query ? `/select-org?${query}` : "/select-org";
+}

--- a/src/app/select-org/page.tsx
+++ b/src/app/select-org/page.tsx
@@ -13,6 +13,7 @@ import { Col } from "@/components/col";
 import { Row } from "@/components/row";
 import { LoadingState } from "@/components/spinner/loading-state";
 import { KernelWordmark } from "@/components/icons";
+import { buildSelectOrgRedirectUrl } from "./oauth-params";
 
 interface OAuthProject {
   id: string;
@@ -243,7 +244,7 @@ function SelectOrgContent(): React.ReactElement {
     return (
       <Col className="min-h-screen items-center justify-center">
         <div className="absolute top-6 right-6">
-          <SignOutButton redirectUrl={`/select-org?${searchParams.toString()}`}>
+          <SignOutButton redirectUrl={buildSelectOrgRedirectUrl(searchParams)}>
             <button className="border-[0.5px] border-foreground px-4 py-2 text-sm cursor-pointer hover:underline">
               switch account
             </button>
@@ -280,7 +281,7 @@ function SelectOrgContent(): React.ReactElement {
   return (
     <Col className="min-h-screen items-center justify-center">
       <div className="absolute top-6 right-6">
-        <SignOutButton redirectUrl={`/select-org?${searchParams.toString()}`}>
+        <SignOutButton redirectUrl={buildSelectOrgRedirectUrl(searchParams)}>
           <button className="border-[0.5px] border-foreground px-4 py-2 text-sm cursor-pointer hover:underline">
             switch account
           </button>

--- a/src/app/select-org/page.tsx
+++ b/src/app/select-org/page.tsx
@@ -2,7 +2,7 @@
 
 import {
   CreateOrganization,
-  UserButton,
+  SignOutButton,
   useAuth,
   useOrganizationList,
   useUser,
@@ -243,9 +243,11 @@ function SelectOrgContent(): React.ReactElement {
     return (
       <Col className="min-h-screen items-center justify-center">
         <div className="absolute top-6 right-6">
-          <UserButton
-            afterSignOutUrl={`/select-org?${searchParams.toString()}`}
-          />
+          <SignOutButton redirectUrl={`/select-org?${searchParams.toString()}`}>
+            <button className="border-[0.5px] border-foreground px-4 py-2 text-sm cursor-pointer hover:underline">
+              switch account
+            </button>
+          </SignOutButton>
         </div>
         <Col className="text-center max-w-md mx-auto p-8 gap-8">
           <Col className="items-center gap-4">
@@ -278,9 +280,11 @@ function SelectOrgContent(): React.ReactElement {
   return (
     <Col className="min-h-screen items-center justify-center">
       <div className="absolute top-6 right-6">
-        <UserButton
-          afterSignOutUrl={`/select-org?${searchParams.toString()}`}
-        />
+        <SignOutButton redirectUrl={`/select-org?${searchParams.toString()}`}>
+          <button className="border-[0.5px] border-foreground px-4 py-2 text-sm cursor-pointer hover:underline">
+            switch account
+          </button>
+        </SignOutButton>
       </div>
 
       <Col className="max-w-md w-full mx-auto p-8 gap-8">


### PR DESCRIPTION
## summary

- add a Kernel-branded `/oauth-consent` route using Clerk’s prebuilt consent component
- upgrade Clerk’s Next.js SDK and migrate the existing appearance variables to the v7 names
- preserve OAuth parameters when switching accounts and protect the consent page from framing

## rollout

- stacked on #138 so the organization/project scope selection remains the first authorization step
- after deployment, configure Clerk’s OAuth consent component path to `/oauth-consent`

## testing

- `bun test`
- `bun run build`
- verified `/oauth-consent` returns `frame-ancestors 'none'` and `X-Frame-Options: DENY`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the OAuth authorization UX and upgrades a major Clerk SDK version used across auth flows. Anti-framing headers reduce clickjacking risk on the new consent page.
> 
> **Overview**
> Adds a Kernel-branded **`/oauth-consent`** page using Clerk’s `OAuthConsent` component, so final OAuth approval can use custom branding after org/scope selection.
> 
> **Upgrades `@clerk/nextjs` from v6 → v7** and renames appearance theme variables (`colorText` → `colorForeground`, etc.) for compatibility. Also locks the consent page against clickjacking with `frame-ancestors 'none'` and `X-Frame-Options: DENY`.
> 
> On `/select-org`, replaces `UserButton` with a **switch account** `SignOutButton` that preserves OAuth/PKCE query params via `buildSelectOrgRedirectUrl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8bf2439378a6cad6565bcbe736cd3a615cc4936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->