### PR TITLE
Keep MCP project selection optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ One additional Managed Auth helper (`begin_auth_login`) is marked app-only (`_me
 
 Self-hosted deployments can hide sensitive tool families by setting `KERNEL_MCP_DISABLED_TOOLSETS` to a comma-separated list. For example, `KERNEL_MCP_DISABLED_TOOLSETS=api_keys` prevents `manage_api_keys` from being registered.
 
-Call `get_connection_context` before deciding whether to create or select a project. Its canonical `connection_scope` reports whether the connection is organization-wide or fixed to a project. Project-scoped tools always advertise `project_id`: organization-wide connections must pass the selected project, while fixed-project connections may omit it or pass the matching ID. Project resources use project-qualified `kernel://orgs/{organizationId}/projects/{projectId}/...` URIs. Authorization remains enforced by the Kernel API; selecting a project never grants access to it.
+Call `get_connection_context` before deciding whether to create or select a project. Its canonical `connection_scope` reports whether the connection is organization-wide or fixed to a project. Project-scoped tools always advertise an optional `project_id`: organization-wide connections may omit it to preserve organization-wide reads and API default-project behavior, while fixed-project connections may omit it or pass the matching ID. Project resources use project-qualified `kernel://orgs/{organizationId}/projects/{projectId}/...` URIs. Authorization remains enforced by the Kernel API; selecting a project never grants access to it.
 
 ### manage\_\* tools
 

--- a/src/lib/mcp/project-selection.test.ts
+++ b/src/lib/mcp/project-selection.test.ts
@@ -48,9 +48,9 @@ describe("project selection schema", () => {
 });
 
 describe("projectIDForOperation", () => {
-  test("requires a target for organization-wide connections", () => {
+  test("preserves unscoped access for organization-wide connections", () => {
     const info = authInfo(organizationScope);
-    expect(() => projectIDForOperation(info)).toThrow("project_id is required");
+    expect(projectIDForOperation(info)).toBeUndefined();
     expect(projectIDForOperation(info, "proj_123")).toBe("proj_123");
   });
 

--- a/src/lib/mcp/project-selection.ts
+++ b/src/lib/mcp/project-selection.ts
@@ -6,7 +6,7 @@ const projectIDSchema = z
   .string()
   .min(1)
   .describe(
-    "Project ID used to scope this operation. Required on organization-wide connections. On project-scoped connections, omit it or pass the fixed project ID returned by get_connection_context.",
+    "Optional project ID used to scope this operation. On organization-wide connections, omit it to use the API's organization-wide or default-project behavior. On project-scoped connections, omit it or pass the fixed project ID returned by get_connection_context.",
   )
   .optional();
 
@@ -29,14 +29,9 @@ export function connectionContextFromAuthInfo(
 export function projectIDForOperation(
   authInfo: AuthInfo,
   requestedProjectId?: string,
-): string {
+): string | undefined {
   const { scope } = connectionContextFromAuthInfo(authInfo);
   if (scope.kind === "organization") {
-    if (!requestedProjectId) {
-      throw new Error(
-        "project_id is required for project-scoped operations on an organization-wide connection",
-      );
-    }
     return requestedProjectId;
   }
 

--- a/src/lib/mcp/tools/auth-connections.test.ts
+++ b/src/lib/mcp/tools/auth-connections.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { organizationWideAuthInfo } from "@/lib/mcp/auth-context.test-fixtures";
 import { toSafeAuthConnection } from "./managed-auth-state";
 import {
   assertNoSecrets,
@@ -45,7 +46,7 @@ describe("manage_auth_connections programmatic surface", () => {
     expect(schema?.sign_in_option_id).toBeUndefined();
   });
 
-  test("constructs a project-scoped client from the optional selector", async () => {
+  test("passes the optional project selector through to the client", async () => {
     const { handler, schema } = captureHandler();
     let selectedProject: string | undefined;
     kernelClientMock.factory = (_token, projectID) => {
@@ -62,16 +63,16 @@ describe("manage_auth_connections programmatic surface", () => {
         },
       };
     };
-    try {
-      expect(schema?.project_id).toBeDefined();
-      await handler(
-        { action: "list", project_id: "proj_123" },
-        { authInfo: { token: "test-token" } },
-      );
-      expect(selectedProject).toBe("proj_123");
-    } finally {
-      kernelClientMock.factory = () => unusedKernelClient;
-    }
+
+    expect(schema?.project_id).toBeDefined();
+    await handler(
+      { action: "list", project_id: "proj_123" },
+      { authInfo: { token: "test-token" } },
+    );
+    expect(selectedProject).toBe("proj_123");
+
+    await handler({ action: "list" }, { authInfo: organizationWideAuthInfo() });
+    expect(selectedProject).toBeUndefined();
   });
 
   test("forwards replay and browser telemetry settings on create and login", async () => {

--- a/src/lib/mcp/tools/connection-context.test.ts
+++ b/src/lib/mcp/tools/connection-context.test.ts
@@ -19,8 +19,8 @@ describe("get_connection_context", () => {
         source: "api_key",
       },
       authorization: {
-        credential_scope: { project_id: "proj_123" },
-        effective_scope: { project_id: "proj_123" },
+        credential_scope: { project_id: null },
+        effective_scope: { project_id: null },
       },
       organization: { id: "org_123" },
       principal: { id: "key_123", type: "api_key" },
@@ -43,9 +43,9 @@ describe("get_connection_context", () => {
             connectionContext: {
               authContext,
               scope: {
-                kind: "project",
+                kind: "organization",
                 organizationId: "org_123",
-                projectId: "proj_123",
+                projectId: null,
                 source: "credential",
               },
             },
@@ -70,9 +70,9 @@ describe("get_connection_context", () => {
       expect(JSON.parse(result.content[0].text)).toEqual({
         ...authContext,
         connection_scope: {
-          kind: "project",
+          kind: "organization",
           organization_id: "org_123",
-          project_id: "proj_123",
+          project_id: null,
           source: "credential",
           project_id_required: false,
         },

--- a/src/lib/mcp/tools/connection-context.ts
+++ b/src/lib/mcp/tools/connection-context.ts
@@ -5,7 +5,7 @@ import { jsonResponse } from "@/lib/mcp/responses";
 export function registerConnectionContextTool(server: McpServer) {
   server.tool(
     "get_connection_context",
-    "Inspect the authenticated Kernel connection before a project-scoped operation. connection_scope.kind=organization requires project_id on project-scoped tools and resources. connection_scope.kind=project is fixed to connection_scope.project_id; omit project_id or pass that exact value.",
+    "Inspect the authenticated Kernel connection before a project-scoped operation. connection_scope.kind=organization may omit project_id for organization-wide reads and default-project creates, or pass one to select a project. connection_scope.kind=project is fixed to connection_scope.project_id; omit project_id or pass that exact value.",
     {},
     {
       title: "Get Kernel connection context",
@@ -26,7 +26,7 @@ export function registerConnectionContextTool(server: McpServer) {
           organization_id: scope.organizationId,
           project_id: scope.projectId,
           source: scope.source,
-          project_id_required: scope.kind === "organization",
+          project_id_required: false,
         },
       });
     },


### PR DESCRIPTION
## Summary

- allow organization-wide MCP connections to omit `project_id`
- preserve unscoped API behavior for cross-project reads and default-project creates
- keep project-scoped connections locked to their fixed project
- update connection guidance and regression coverage

## Tests

- `bun test`
- `bunx tsc --noEmit`
- `bun run check:managed-auth-app`
- targeted Prettier check for changed files

`bun run format:check` continues to report the pre-existing formatting issue in `AGENTS.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how org-wide connections scope Kernel API calls (undefined vs forced project), which can alter list/create behavior for agents that relied on the previous required `project_id` error.
> 
> **Overview**
> **Organization-wide MCP connections no longer require `project_id` on project-scoped tools.** Omitting it forwards `undefined` to the Kernel client so reads can stay org-wide and creates follow the API’s default-project behavior; passing `project_id` still selects a project explicitly.
> 
> `get_connection_context` now always reports **`project_id_required: false`** and its description/README guidance reflect optional selection on org-wide connections. **Project-scoped connections are unchanged**—they still resolve to the fixed project and reject mismatched overrides.
> 
> Tests cover unscoped org-wide calls (e.g. `manage_auth_connections` list without `project_id`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7d9477ecda508442823e22721815d903f28f34a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->