### PR TITLE
Polish OAuth authorization transitions

### DIFF
--- a/src/app/select-org/page.tsx
+++ b/src/app/select-org/page.tsx
@@ -311,7 +311,7 @@ function SelectOrgContent(): React.ReactElement {
           <KernelWordmark className="text-foreground" width={100} height={22} />
           <p className="text-muted-foreground text-sm">
             {stage === "organization"
-              ? "select an organization to authorize access."
+              ? "select an organization."
               : `choose access for ${selectedOrg?.name || "this organization"}.`}
           </p>
         </Col>
@@ -383,7 +383,7 @@ function SelectOrgContent(): React.ReactElement {
             <div className="bg-[#faf9f2] border-[0.5px] border-[#e1dccf]">
               <ScopeButton
                 label="entire organization"
-                detail="access every project and select projects per request"
+                detail="access all current and future projects"
                 selected={selectedScope === "organization"}
                 onClick={() => setSelectedScope("organization")}
               />

--- a/src/app/select-org/page.tsx
+++ b/src/app/select-org/page.tsx
@@ -14,13 +14,16 @@ import { Row } from "@/components/row";
 import { LoadingState } from "@/components/spinner/loading-state";
 import { KernelWordmark } from "@/components/icons";
 import { buildSelectOrgRedirectUrl } from "./oauth-params";
+import {
+  primaryActionLabel,
+  type SelectionScope,
+  type SelectionStage,
+} from "./primary-action";
 
 interface OAuthProject {
   id: string;
   name: string;
 }
-
-type SelectionStage = "organization" | "scope";
 
 function SelectOrgContent(): React.ReactElement {
   const { isLoaded, setActive, userMemberships } = useOrganizationList({
@@ -277,6 +280,21 @@ function SelectOrgContent(): React.ReactElement {
   const selectedOrg = memberships.find(
     (membership) => membership.organization.id === selectedOrgId,
   )?.organization;
+  const selectedScopeKind: SelectionScope = !selectedScope
+    ? "none"
+    : selectedScope.startsWith("project:")
+      ? "project"
+      : "organization";
+  const primaryActionDisabled =
+    isSelecting ||
+    !selectedOrgId ||
+    (stage === "scope" && selectedScopeKind === "none");
+  const primaryAction = primaryActionLabel({
+    stage,
+    isPending: isSelecting,
+    organizationName: selectedOrg?.name,
+    scope: selectedScopeKind,
+  });
 
   return (
     <Col className="min-h-screen items-center justify-center">
@@ -479,7 +497,7 @@ function SelectOrgContent(): React.ReactElement {
             <button
               onClick={() => setStage("organization")}
               disabled={isSelecting}
-              className="border-[0.5px] border-foreground py-3 px-4 text-sm disabled:opacity-50 cursor-pointer"
+              className="border-[0.5px] border-foreground py-3 px-4 text-sm disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
             >
               back
             </button>
@@ -488,20 +506,17 @@ function SelectOrgContent(): React.ReactElement {
             onClick={
               stage === "organization" ? handleOrgConfirm : handleAuthorize
             }
-            disabled={
-              isSelecting ||
-              !selectedOrgId ||
-              (stage === "scope" && !selectedScope)
-            }
-            className="flex-1 bg-foreground text-background py-3 px-4 font-[250] text-sm hover:underline disabled:opacity-50 cursor-pointer"
+            disabled={primaryActionDisabled}
+            aria-busy={isSelecting}
+            className={`flex-1 py-3 px-4 font-[250] text-sm ${
+              isSelecting
+                ? "bg-secondary text-secondary-foreground cursor-wait"
+                : primaryActionDisabled
+                  ? "bg-secondary text-secondary-foreground cursor-not-allowed"
+                  : "bg-primary text-primary-foreground hover:underline cursor-pointer"
+            }`}
           >
-            {isSelecting
-              ? stage === "organization"
-                ? "loading projects..."
-                : "authorizing..."
-              : stage === "organization"
-                ? "continue"
-                : "authorize"}
+            <span aria-live="polite">{primaryAction}</span>
           </button>
         </Row>
       </Col>

--- a/src/app/select-org/page.tsx
+++ b/src/app/select-org/page.tsx
@@ -292,7 +292,6 @@ function SelectOrgContent(): React.ReactElement {
   const primaryAction = primaryActionLabel({
     stage,
     isPending: isSelecting,
-    organizationName: selectedOrg?.name,
     scope: selectedScopeKind,
   });
 

--- a/src/app/select-org/primary-action.test.ts
+++ b/src/app/select-org/primary-action.test.ts
@@ -2,53 +2,51 @@ import { describe, expect, test } from "bun:test";
 import { primaryActionLabel } from "./primary-action";
 
 describe("select organization primary action", () => {
-  test("describes the selected organization and pending access-options load", () => {
+  test("labels organization selection and its pending state", () => {
     expect(
       primaryActionLabel({
         stage: "organization",
         isPending: false,
-        organizationName: "Kernel",
         scope: "organization",
       }),
-    ).toBe("choose access for Kernel");
+    ).toBe("select organization");
     expect(
       primaryActionLabel({
         stage: "organization",
         isPending: true,
-        organizationName: "Kernel",
         scope: "organization",
       }),
-    ).toBe("loading access options...");
+    ).toBe("selecting organization...");
   });
 
-  test("describes organization, project, unselected, and pending consent states", () => {
+  test("labels organization, project, unselected, and pending scope states", () => {
     expect(
       primaryActionLabel({
         stage: "scope",
         isPending: false,
         scope: "organization",
       }),
-    ).toBe("review organization-wide access");
+    ).toBe("select organization scope");
     expect(
       primaryActionLabel({
         stage: "scope",
         isPending: false,
         scope: "project",
       }),
-    ).toBe("review project access");
+    ).toBe("select project scope");
     expect(
       primaryActionLabel({
         stage: "scope",
         isPending: false,
         scope: "none",
       }),
-    ).toBe("select access to continue");
+    ).toBe("select scope");
     expect(
       primaryActionLabel({
         stage: "scope",
         isPending: true,
         scope: "project",
       }),
-    ).toBe("opening consent...");
+    ).toBe("selecting scope...");
   });
 });

--- a/src/app/select-org/primary-action.test.ts
+++ b/src/app/select-org/primary-action.test.ts
@@ -10,7 +10,7 @@ describe("select organization primary action", () => {
         organizationName: "Kernel",
         scope: "organization",
       }),
-    ).toBe("continue with Kernel");
+    ).toBe("choose access for Kernel");
     expect(
       primaryActionLabel({
         stage: "organization",
@@ -21,21 +21,21 @@ describe("select organization primary action", () => {
     ).toBe("loading access options...");
   });
 
-  test("describes organization, project, unselected, and pending authorization", () => {
+  test("describes organization, project, unselected, and pending consent states", () => {
     expect(
       primaryActionLabel({
         stage: "scope",
         isPending: false,
         scope: "organization",
       }),
-    ).toBe("authorize organization-wide");
+    ).toBe("review organization-wide access");
     expect(
       primaryActionLabel({
         stage: "scope",
         isPending: false,
         scope: "project",
       }),
-    ).toBe("authorize selected project");
+    ).toBe("review project access");
     expect(
       primaryActionLabel({
         stage: "scope",
@@ -49,6 +49,6 @@ describe("select organization primary action", () => {
         isPending: true,
         scope: "project",
       }),
-    ).toBe("authorizing...");
+    ).toBe("opening consent...");
   });
 });

--- a/src/app/select-org/primary-action.test.ts
+++ b/src/app/select-org/primary-action.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { primaryActionLabel } from "./primary-action";
+
+describe("select organization primary action", () => {
+  test("describes the selected organization and pending access-options load", () => {
+    expect(
+      primaryActionLabel({
+        stage: "organization",
+        isPending: false,
+        organizationName: "Kernel",
+        scope: "organization",
+      }),
+    ).toBe("continue with Kernel");
+    expect(
+      primaryActionLabel({
+        stage: "organization",
+        isPending: true,
+        organizationName: "Kernel",
+        scope: "organization",
+      }),
+    ).toBe("loading access options...");
+  });
+
+  test("describes organization, project, unselected, and pending authorization", () => {
+    expect(
+      primaryActionLabel({
+        stage: "scope",
+        isPending: false,
+        scope: "organization",
+      }),
+    ).toBe("authorize organization-wide");
+    expect(
+      primaryActionLabel({
+        stage: "scope",
+        isPending: false,
+        scope: "project",
+      }),
+    ).toBe("authorize selected project");
+    expect(
+      primaryActionLabel({
+        stage: "scope",
+        isPending: false,
+        scope: "none",
+      }),
+    ).toBe("select access to continue");
+    expect(
+      primaryActionLabel({
+        stage: "scope",
+        isPending: true,
+        scope: "project",
+      }),
+    ).toBe("authorizing...");
+  });
+});

--- a/src/app/select-org/primary-action.ts
+++ b/src/app/select-org/primary-action.ts
@@ -15,14 +15,16 @@ export function primaryActionLabel({
   if (isPending) {
     return stage === "organization"
       ? "loading access options..."
-      : "authorizing...";
+      : "opening consent...";
   }
 
   if (stage === "organization") {
-    return organizationName ? `continue with ${organizationName}` : "continue";
+    return organizationName
+      ? `choose access for ${organizationName}`
+      : "choose access";
   }
 
-  if (scope === "organization") return "authorize organization-wide";
-  if (scope === "project") return "authorize selected project";
+  if (scope === "organization") return "review organization-wide access";
+  if (scope === "project") return "review project access";
   return "select access to continue";
 }

--- a/src/app/select-org/primary-action.ts
+++ b/src/app/select-org/primary-action.ts
@@ -1,0 +1,28 @@
+export type SelectionStage = "organization" | "scope";
+export type SelectionScope = "organization" | "project" | "none";
+
+export function primaryActionLabel({
+  stage,
+  isPending,
+  organizationName,
+  scope,
+}: {
+  stage: SelectionStage;
+  isPending: boolean;
+  organizationName?: string;
+  scope: SelectionScope;
+}): string {
+  if (isPending) {
+    return stage === "organization"
+      ? "loading access options..."
+      : "authorizing...";
+  }
+
+  if (stage === "organization") {
+    return organizationName ? `continue with ${organizationName}` : "continue";
+  }
+
+  if (scope === "organization") return "authorize organization-wide";
+  if (scope === "project") return "authorize selected project";
+  return "select access to continue";
+}

--- a/src/app/select-org/primary-action.ts
+++ b/src/app/select-org/primary-action.ts
@@ -4,27 +4,20 @@ export type SelectionScope = "organization" | "project" | "none";
 export function primaryActionLabel({
   stage,
   isPending,
-  organizationName,
   scope,
 }: {
   stage: SelectionStage;
   isPending: boolean;
-  organizationName?: string;
   scope: SelectionScope;
 }): string {
   if (isPending) {
     return stage === "organization"
-      ? "loading access options..."
-      : "opening consent...";
+      ? "selecting organization..."
+      : "selecting scope...";
   }
 
-  if (stage === "organization") {
-    return organizationName
-      ? `choose access for ${organizationName}`
-      : "choose access";
-  }
-
-  if (scope === "organization") return "review organization-wide access";
-  if (scope === "project") return "review project access";
-  return "select access to continue";
+  if (stage === "organization") return "select organization";
+  if (scope === "organization") return "select organization scope";
+  if (scope === "project") return "select project scope";
+  return "select scope";
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,6 +7,7 @@ const isPublicRoute = createRouteMatcher([
   "/(.well-known)(.*)",
   "/register",
   "/authorize",
+  "/oauth-consent",
   "/token",
   // Public only at this narrow relay boundary. The route itself accepts an
   // unauthenticated single-use exchange and validates scoped managed-auth JWTs


### PR DESCRIPTION
## summary

- let the branded OAuth consent route handle signed-out users directly instead of forcing a middleware sign-in hop
- make organization and scope CTAs describe the selected action and distinguish ready, disabled, and pending states
- add focused coverage for every primary-action label state

## tests

- `bun test` (188 passing)
- `bun run build` with test build-time configuration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth middleware by widening public routes for the OAuth consent flow; page-level sign-in gating remains, and the rest is UI/copy polish.
> 
> **Overview**
> Improves OAuth authorization UX by letting the branded consent page handle signed-out users itself, and by clarifying organization/scope selection CTAs.
> 
> **Public consent routing:** Adds `/oauth-consent` to the middleware public-route list so signed-out users reach the branded page (which still redirects to sign-in) instead of a middleware auth hop.
> 
> **Select-org primary actions:** Extracts `primaryActionLabel` so the continue button reflects stage, selected scope, and pending state. Distinguishes ready, disabled, and pending styles with `aria-busy` / live text, and tightens copy for org selection and org-wide scope. Adds unit coverage for every label state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaff84424171e2a4baa24224f82128ec7a353e27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->