### PR TITLE
Track OAuth token exchange outcomes

### DIFF
--- a/src/app/token/route.test.ts
+++ b/src/app/token/route.test.ts
@@ -54,6 +54,9 @@ function dependencies({
     verifications: [] as string[],
     memberships: [] as Array<{ clerkUserId: string; clerkOrgId: string }>,
     persisted: [] as Parameters<TokenDependencies["persistContexts"]>[0][],
+    outcomes: [] as Parameters<
+      NonNullable<TokenDependencies["recordExchange"]>
+    >[0][],
   };
 
   return {
@@ -85,6 +88,9 @@ function dependencies({
       },
       persistContexts: async (value) => {
         calls.persisted.push(value);
+      },
+      recordExchange: (value) => {
+        calls.outcomes.push(value);
       },
     } satisfies TokenDependencies,
   };
@@ -131,6 +137,16 @@ describe("POST /token", () => {
     expect(deps.calls.exchanges[0].has("project_id")).toBe(false);
     expect(deps.calls.exchanges[0].has("access_scope")).toBe(false);
     expect(deps.calls.persisted[0]).not.toHaveProperty("oldRefreshToken");
+    expect(deps.calls.outcomes).toEqual([
+      expect.objectContaining({
+        grantType: "authorization_code",
+        clientType: "registered_client",
+        accessScope: "organization",
+        stage: "complete",
+        outcome: "success",
+        statusCode: 200,
+      }),
+    ]);
   });
 
   test("returns the server-bound project scope", async () => {
@@ -155,6 +171,13 @@ describe("POST /token", () => {
       org_id: "org_1",
       access_scope: "project",
       project_id: "proj_1",
+    });
+    expect(deps.calls.outcomes[0]).toMatchObject({
+      grantType: "authorization_code",
+      clientType: "registered_client",
+      accessScope: "project",
+      stage: "complete",
+      outcome: "success",
     });
   });
 
@@ -200,6 +223,13 @@ describe("POST /token", () => {
     expect(deps.calls.verifications).toHaveLength(0);
     expect(deps.calls.exchanges[0].has("org_id")).toBe(false);
     expect(deps.calls.exchanges[0].has("project_id")).toBe(false);
+    expect(deps.calls.outcomes[0]).toMatchObject({
+      grantType: "refresh_token",
+      clientType: "kernel_cli",
+      accessScope: "project",
+      stage: "complete",
+      outcome: "success",
+    });
   });
 
   test("checks refresh membership before asking Clerk to rotate", async () => {
@@ -218,6 +248,15 @@ describe("POST /token", () => {
     expect(response.status).toBe(500);
     expect(deps.calls.exchanges).toHaveLength(0);
     expect(deps.calls.persisted).toHaveLength(0);
+    expect(deps.calls.outcomes[0]).toMatchObject({
+      grantType: "refresh_token",
+      clientType: "registered_client",
+      accessScope: "organization",
+      stage: "membership_validation",
+      outcome: "error",
+      errorCode: "server_error",
+      statusCode: 500,
+    });
   });
 
   test("keeps post-exchange validation for legacy refresh context", async () => {
@@ -289,6 +328,12 @@ describe("POST /token", () => {
     );
     expect(failedResponse.status).toBe(400);
     expect(providerFailure.calls.persisted).toHaveLength(0);
+    expect(providerFailure.calls.outcomes[0]).toMatchObject({
+      stage: "provider_exchange",
+      outcome: "error",
+      errorCode: "invalid_grant",
+      statusCode: 400,
+    });
 
     const missingRefresh = dependencies({
       clerkTokens: {

--- a/src/app/token/route.test.ts
+++ b/src/app/token/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import type { TokenDependencies } from "./route";
 import {
   organizationAuthorizationContext,
@@ -31,6 +31,7 @@ function dependencies({
   member = true,
   clerkStatus = 200,
   membershipError,
+  contextError,
   clerkTokens = {
     access_token: "clerk-access",
     id_token: "header.payload.signature",
@@ -46,6 +47,14 @@ function dependencies({
   member?: boolean;
   clerkStatus?: number;
   membershipError?: Error;
+  contextError?: {
+    error:
+      | "invalid_request"
+      | "invalid_grant"
+      | "unsupported_grant_type"
+      | "server_error";
+    status: number;
+  };
   clerkTokens?: Record<string, unknown>;
 } = {}) {
   const calls = {
@@ -64,6 +73,15 @@ function dependencies({
     value: {
       resolveContext: async (value) => {
         calls.resolve.push(value);
+        if (contextError) {
+          return {
+            authorizationContext: null,
+            error: NextResponse.json(
+              { error: contextError.error },
+              { status: contextError.status },
+            ),
+          };
+        }
         return {
           authorizationContext,
           ...(value.grantType === "authorization_code"
@@ -229,6 +247,28 @@ describe("POST /token", () => {
       accessScope: "project",
       stage: "complete",
       outcome: "success",
+    });
+  });
+
+  test("records the OAuth error returned by context resolution", async () => {
+    const deps = dependencies({
+      contextError: { error: "server_error", status: 500 },
+    });
+    const response = await tokenRequest(
+      request({
+        grant_type: "refresh_token",
+        client_id: "client_1",
+        refresh_token: "refresh-old",
+      }),
+      deps.value,
+    );
+
+    expect(response.status).toBe(500);
+    expect(deps.calls.outcomes[0]).toMatchObject({
+      stage: "context_resolution",
+      outcome: "error",
+      errorCode: "server_error",
+      statusCode: 500,
     });
   });
 

--- a/src/app/token/route.ts
+++ b/src/app/token/route.ts
@@ -144,6 +144,23 @@ function normalizedGrantType(
     : "unknown";
 }
 
+async function oauthErrorCode(response: NextResponse): Promise<OAuthErrorCode> {
+  try {
+    const body = (await response.clone().json()) as { error?: unknown };
+    if (
+      body.error === "invalid_request" ||
+      body.error === "invalid_grant" ||
+      body.error === "unsupported_grant_type" ||
+      body.error === "server_error"
+    ) {
+      return body.error;
+    }
+  } catch {
+    // Fall back to the status without logging the response body.
+  }
+  return response.status >= 500 ? "server_error" : "invalid_grant";
+}
+
 export async function tokenRequest(
   request: NextRequest,
   dependencies: TokenDependencies = tokenDependencies,
@@ -225,7 +242,10 @@ export async function tokenRequest(
     refreshToken,
   });
   if (contextResult.error) {
-    return finish(contextResult.error, "invalid_grant");
+    return finish(
+      contextResult.error,
+      await oauthErrorCode(contextResult.error),
+    );
   }
   const authorizationContext = contextResult.authorizationContext;
   if (!authorizationContext) {

--- a/src/app/token/route.ts
+++ b/src/app/token/route.ts
@@ -1,9 +1,14 @@
 import { clerkClient, verifyToken } from "@clerk/nextjs/server";
-import { NextRequest, NextResponse } from "next/server";
+import { after, NextRequest, NextResponse } from "next/server";
 import { persistOAuthTokenContexts } from "@/lib/redis";
 import { resolveAuthorizationContext } from "@/lib/org-utils";
 import { REFRESH_TOKEN_ORG_TTL_SECONDS } from "@/lib/const";
 import { normalizeLocalhostUri } from "@/lib/auth-utils";
+import {
+  captureOAuthTokenExchange,
+  flushMcpAnalytics,
+  type OAuthTokenExchangeAnalytics,
+} from "@/lib/mcp/analytics";
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
@@ -23,8 +28,10 @@ export async function OPTIONS(): Promise<NextResponse> {
   return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
 }
 
+type OAuthErrorCode = NonNullable<OAuthTokenExchangeAnalytics["errorCode"]>;
+
 function createErrorResponse(
-  error: string,
+  error: OAuthErrorCode,
   errorDescription: string,
   status = 400,
 ) {
@@ -105,6 +112,7 @@ export interface TokenDependencies {
   ) => Promise<{ sub?: string }>;
   hasMembership: typeof hasOrganizationMembership;
   persistContexts: typeof persistOAuthTokenContexts;
+  recordExchange?: (exchange: OAuthTokenExchangeAnalytics) => void;
 }
 
 const tokenDependencies: TokenDependencies = {
@@ -113,15 +121,72 @@ const tokenDependencies: TokenDependencies = {
   verify: verifyToken,
   hasMembership: hasOrganizationMembership,
   persistContexts: persistOAuthTokenContexts,
+  recordExchange: captureOAuthTokenExchange,
 };
+
+function clientType(
+  clientId: string | null,
+): OAuthTokenExchangeAnalytics["clientType"] {
+  if (!clientId) return "unknown";
+  const cliClientIds = [
+    process.env.KERNEL_CLI_PROD_CLIENT_ID,
+    process.env.KERNEL_CLI_STAGING_CLIENT_ID,
+    process.env.KERNEL_CLI_DEV_CLIENT_ID,
+  ].filter(Boolean);
+  return cliClientIds.includes(clientId) ? "kernel_cli" : "registered_client";
+}
+
+function normalizedGrantType(
+  grantType: string,
+): OAuthTokenExchangeAnalytics["grantType"] {
+  return grantType === "authorization_code" || grantType === "refresh_token"
+    ? grantType
+    : "unknown";
+}
 
 export async function tokenRequest(
   request: NextRequest,
   dependencies: TokenDependencies = tokenDependencies,
 ): Promise<NextResponse> {
+  const startedAt = Date.now();
+  let grantTypeForAnalytics: OAuthTokenExchangeAnalytics["grantType"] =
+    "unknown";
+  let clientTypeForAnalytics: OAuthTokenExchangeAnalytics["clientType"] =
+    "unknown";
+  let accessScopeForAnalytics: OAuthTokenExchangeAnalytics["accessScope"] =
+    "unknown";
+  let stage: OAuthTokenExchangeAnalytics["stage"] = "request_validation";
+
+  const finish = (
+    response: NextResponse,
+    errorCode?: OAuthErrorCode,
+  ): NextResponse => {
+    try {
+      dependencies.recordExchange?.({
+        grantType: grantTypeForAnalytics,
+        clientType: clientTypeForAnalytics,
+        accessScope: accessScopeForAnalytics,
+        stage,
+        outcome: response.ok ? "success" : "error",
+        ...(errorCode ? { errorCode } : {}),
+        statusCode: response.status,
+        durationMs: Date.now() - startedAt,
+      });
+    } catch (error) {
+      console.error("Failed to record OAuth token exchange outcome", error);
+    }
+    return response;
+  };
+  const fail = (
+    error: OAuthErrorCode,
+    description: string,
+    status = 400,
+  ): NextResponse =>
+    finish(createErrorResponse(error, description, status), error);
+
   const contentType = request.headers.get("content-type");
   if (!contentType?.includes("application/x-www-form-urlencoded")) {
-    return createErrorResponse(
+    return fail(
       "invalid_request",
       "Content-Type must be application/x-www-form-urlencoded",
     );
@@ -129,11 +194,7 @@ export async function tokenRequest(
 
   const clerkDomain = process.env.NEXT_PUBLIC_CLERK_DOMAIN;
   if (!clerkDomain) {
-    return createErrorResponse(
-      "server_error",
-      "Server configuration error",
-      500,
-    );
+    return fail("server_error", "Server configuration error", 500);
   }
 
   const body = await request.formData();
@@ -148,29 +209,32 @@ export async function tokenRequest(
   }
 
   const grantType = body.get("grant_type")?.toString() || "";
+  grantTypeForAnalytics = normalizedGrantType(grantType);
   const { clientId } = clientCredentials(request, body, params);
+  clientTypeForAnalytics = clientType(clientId);
   if (!clientId) {
-    return createErrorResponse(
-      "invalid_request",
-      "Missing required parameter: client_id",
-    );
+    return fail("invalid_request", "Missing required parameter: client_id");
   }
 
   const refreshToken = body.get("refresh_token")?.toString();
+  stage = "context_resolution";
   const contextResult = await dependencies.resolveContext({
     grantType,
     clientId,
     codeVerifier: body.get("code_verifier")?.toString(),
     refreshToken,
   });
-  if (contextResult.error) return contextResult.error;
+  if (contextResult.error) {
+    return finish(contextResult.error, "invalid_grant");
+  }
   const authorizationContext = contextResult.authorizationContext;
   if (!authorizationContext) {
-    return createErrorResponse(
+    return fail(
       "invalid_grant",
       "Authorization context not found. Please re-authorize.",
     );
   }
+  accessScopeForAnalytics = authorizationContext.access_scope;
 
   let persistedAuthorizationContext = authorizationContext;
 
@@ -188,6 +252,7 @@ export async function tokenRequest(
       : undefined;
 
   try {
+    stage = "membership_validation";
     if (
       refreshContextUserId &&
       !(await dependencies.hasMembership(
@@ -195,12 +260,13 @@ export async function tokenRequest(
         authorizationContext.clerk_org_id,
       ))
     ) {
-      return createErrorResponse(
+      return fail(
         "invalid_grant",
         "Organization membership is no longer active",
       );
     }
 
+    stage = "provider_exchange";
     const clerkResponse = await dependencies.exchange(
       `https://${clerkDomain}/oauth/token`,
       {
@@ -210,7 +276,7 @@ export async function tokenRequest(
       },
     );
     if (!clerkResponse.ok) {
-      return createErrorResponse(
+      return fail(
         "invalid_grant",
         grantType === "refresh_token"
           ? "Failed to refresh token"
@@ -218,9 +284,10 @@ export async function tokenRequest(
       );
     }
 
+    stage = "provider_response_validation";
     const clerkTokens = (await clerkResponse.json()) as ClerkTokenResponse;
     if (!clerkTokens.id_token) {
-      return createErrorResponse(
+      return fail(
         "invalid_grant",
         "Failed to retrieve id_token from OAuth provider",
       );
@@ -229,7 +296,7 @@ export async function tokenRequest(
       !Number.isFinite(clerkTokens.expires_in) ||
       clerkTokens.expires_in <= 0
     ) {
-      return createErrorResponse(
+      return fail(
         "invalid_grant",
         "OAuth provider returned an invalid token lifetime",
       );
@@ -240,7 +307,7 @@ export async function tokenRequest(
         secretKey: process.env.CLERK_SECRET_KEY,
       });
       if (!payload.sub) {
-        return createErrorResponse(
+        return fail(
           "invalid_grant",
           "OAuth provider returned a token without a subject",
         );
@@ -249,18 +316,19 @@ export async function tokenRequest(
         authorizationContext.clerk_user_id &&
         authorizationContext.clerk_user_id !== payload.sub
       ) {
-        return createErrorResponse(
+        return fail(
           "invalid_grant",
           "OAuth token subject does not match authorization context",
         );
       }
+      stage = "membership_validation";
       if (
         !(await dependencies.hasMembership(
           payload.sub,
           authorizationContext.clerk_org_id,
         ))
       ) {
-        return createErrorResponse(
+        return fail(
           "invalid_grant",
           "Organization membership is no longer active",
         );
@@ -273,9 +341,10 @@ export async function tokenRequest(
       }
     }
 
+    stage = "provider_response_validation";
     const issuedRefreshToken = clerkTokens.refresh_token;
     if (!issuedRefreshToken) {
-      return createErrorResponse(
+      return fail(
         "invalid_grant",
         grantType === "refresh_token"
           ? "OAuth provider did not rotate the refresh token"
@@ -284,18 +353,16 @@ export async function tokenRequest(
     }
     const finalJwt = clerkTokens.id_token;
     if (grantType === "refresh_token" && !refreshToken) {
-      return createErrorResponse(
-        "invalid_grant",
-        "Missing required parameter: refresh_token",
-      );
+      return fail("invalid_grant", "Missing required parameter: refresh_token");
     }
     if (grantType !== "authorization_code" && grantType !== "refresh_token") {
-      return createErrorResponse(
+      return fail(
         "unsupported_grant_type",
         `Grant type '${grantType}' is not supported`,
       );
     }
 
+    stage = "persistence";
     await dependencies.persistContexts({
       jwt: finalJwt,
       newRefreshToken: issuedRefreshToken,
@@ -315,25 +382,30 @@ export async function tokenRequest(
         : {}),
     });
 
-    return NextResponse.json(
-      {
-        ...clerkTokens,
-        access_token: finalJwt,
-        expires_in: clerkTokens.expires_in,
-        org_id: authorizationContext.clerk_org_id,
-        access_scope: authorizationContext.access_scope,
-        ...(authorizationContext.project_id
-          ? { project_id: authorizationContext.project_id }
-          : {}),
-      },
-      { headers: CORS_HEADERS },
+    stage = "complete";
+    return finish(
+      NextResponse.json(
+        {
+          ...clerkTokens,
+          access_token: finalJwt,
+          expires_in: clerkTokens.expires_in,
+          org_id: authorizationContext.clerk_org_id,
+          access_scope: authorizationContext.access_scope,
+          ...(authorizationContext.project_id
+            ? { project_id: authorizationContext.project_id }
+            : {}),
+        },
+        { headers: CORS_HEADERS },
+      ),
     );
   } catch (error) {
     console.error("[token] token exchange failed", { error });
-    return createErrorResponse("server_error", "Internal server error", 500);
+    return fail("server_error", "Internal server error", 500);
   }
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  return tokenRequest(request);
+  const response = await tokenRequest(request);
+  after(flushMcpAnalytics);
+  return response;
 }

--- a/src/lib/mcp/analytics.test.ts
+++ b/src/lib/mcp/analytics.test.ts
@@ -6,8 +6,10 @@ import {
   PostHogMCPAnalyticsProperty,
 } from "@posthog/mcp";
 import {
+  captureOAuthTokenExchange,
   enrichMcpAnalyticsEvent,
   instrumentMcpAnalytics,
+  OAUTH_TOKEN_EXCHANGE_EVENT,
   sanitizeMcpAnalyticsEvent,
 } from "@/lib/mcp/analytics";
 
@@ -280,6 +282,49 @@ describe("sanitizeMcpAnalyticsEvent", () => {
     event.event = PostHogMCPAnalyticsEvent.Exception;
 
     expect(await sanitizeMcpAnalyticsEvent(event)).toBeNull();
+  });
+});
+
+describe("captureOAuthTokenExchange", () => {
+  test("captures only bounded outcome metadata", () => {
+    const captured: unknown[] = [];
+    const fakePosthog = {
+      capture: (event: unknown) => captured.push(event),
+    } as unknown as PostHog;
+
+    captureOAuthTokenExchange(
+      {
+        grantType: "refresh_token",
+        clientType: "kernel_cli",
+        accessScope: "project",
+        stage: "complete",
+        outcome: "success",
+        statusCode: 200,
+        durationMs: 42,
+      },
+      fakePosthog,
+    );
+
+    expect(captured).toEqual([
+      {
+        distinctId: "oauth-token-exchange",
+        event: OAUTH_TOKEN_EXCHANGE_EVENT,
+        properties: {
+          $process_person_profile: false,
+          oauth_grant_type: "refresh_token",
+          oauth_client_type: "kernel_cli",
+          oauth_access_scope: "project",
+          oauth_stage: "complete",
+          oauth_outcome: "success",
+          oauth_error_code: undefined,
+          http_status_code: 200,
+          duration_ms: 42,
+        },
+      },
+    ]);
+    expect(JSON.stringify(captured)).not.toContain("access_token");
+    expect(JSON.stringify(captured)).not.toContain("refresh_token_hash");
+    expect(JSON.stringify(captured)).not.toContain("code_verifier");
   });
 });
 

--- a/src/lib/mcp/analytics.ts
+++ b/src/lib/mcp/analytics.ts
@@ -15,6 +15,30 @@ import type {
 
 const projectToken = process.env.POSTHOG_PROJECT_TOKEN;
 
+export type OAuthTokenExchangeAnalytics = {
+  grantType: "authorization_code" | "refresh_token" | "unknown";
+  clientType: "kernel_cli" | "registered_client" | "unknown";
+  accessScope: "organization" | "project" | "unknown";
+  stage:
+    | "request_validation"
+    | "context_resolution"
+    | "membership_validation"
+    | "provider_exchange"
+    | "provider_response_validation"
+    | "persistence"
+    | "complete";
+  outcome: "success" | "error";
+  errorCode?:
+    | "invalid_request"
+    | "invalid_grant"
+    | "unsupported_grant_type"
+    | "server_error";
+  statusCode: number;
+  durationMs: number;
+};
+
+export const OAUTH_TOKEN_EXCHANGE_EVENT = "oauth_token_exchange";
+
 if (!projectToken && process.env.NODE_ENV !== "production") {
   console.error(
     "POSTHOG_PROJECT_TOKEN variable required by PostHog is missing or un-configured, this causes events to be silently missed. This error stops appearing once POSTHOG_PROJECT_TOKEN is configured",
@@ -257,6 +281,38 @@ export function enrichMcpAnalyticsEvent(event: {
 
 export function isMcpAnalyticsEnabled() {
   return posthog !== null;
+}
+
+export function captureOAuthTokenExchange(
+  exchange: OAuthTokenExchangeAnalytics,
+  client: PostHog | null = posthog,
+) {
+  const properties = {
+    oauth_grant_type: exchange.grantType,
+    oauth_client_type: exchange.clientType,
+    oauth_access_scope: exchange.accessScope,
+    oauth_stage: exchange.stage,
+    oauth_outcome: exchange.outcome,
+    oauth_error_code: exchange.errorCode,
+    http_status_code: exchange.statusCode,
+    duration_ms: exchange.durationMs,
+  };
+
+  console.info("[oauth] token exchange outcome", properties);
+  if (!client) return;
+
+  try {
+    client.capture({
+      distinctId: "oauth-token-exchange",
+      event: OAUTH_TOKEN_EXCHANGE_EVENT,
+      properties: {
+        $process_person_profile: false,
+        ...properties,
+      },
+    });
+  } catch (error) {
+    console.error("Failed to capture OAuth token exchange analytics", error);
+  }
 }
 
 export function instrumentMcpAnalytics(


### PR DESCRIPTION
## summary

- emit privacy-safe OAuth token exchange outcomes for authorization-code and refresh grants
- classify events by client type, scope, stage, outcome, status, and duration without capturing OAuth credentials or request data
- flush queued analytics after the token response and cover successful and failed paths

## tests

- `bun test` (187 passing)
- `bun run build` with test build-time configuration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on the security-sensitive OAuth token route, but exchange and validation logic are unchanged; risk is mainly added side effects (logging, PostHog) and ensuring no credentials leak into events.
> 
> **Overview**
> **OAuth `/token` now records one analytics outcome per request** (success or error) with grant type, client type (`kernel_cli` vs registered), access scope, pipeline **stage**, HTTP status, duration, and optional OAuth error code—without logging codes, verifiers, or tokens.
> 
> The handler routes every response through **`finish` / `fail`** so recording runs on validation failures, context resolution errors, membership checks, Clerk exchange failures, and successful issuance. **`POST`** schedules **`flushMcpAnalytics`** via Next **`after()`** so PostHog flush does not block the token response.
> 
> New **`captureOAuthTokenExchange`** in MCP analytics emits the `oauth_token_exchange` event (and a structured console line) using a fixed anonymous distinct id and `$process_person_profile: false`. Tests stub **`recordExchange`** and assert outcomes across happy paths and failure stages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8929df7140ddb9aa69b6c89795bec80f4c20075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->