### PR TITLE
Expose region param on manage_browsers create and list

### DIFF
--- a/src/lib/mcp/tools/browsers.test.ts
+++ b/src/lib/mcp/tools/browsers.test.ts
@@ -342,6 +342,57 @@ describe("manage_browsers telemetry", () => {
   });
 });
 
+describe("manage_browsers region", () => {
+  test("passes region to create and list", async () => {
+    const createCalls: unknown[] = [];
+    const listCalls: unknown[] = [];
+    const kernelClient = {
+      browsers: {
+        create: async (params: unknown) => {
+          createCalls.push(params);
+          return { session_id: "brr_123" };
+        },
+        list: async (params: unknown) => {
+          listCalls.push(params);
+          return {
+            getPaginatedItems: () => [
+              { session_id: "brr_eu", cdp_ws_url: "ws://example.test" },
+            ],
+            has_more: false,
+            next_offset: null,
+          };
+        },
+      },
+    };
+    const { client, close } = await connectTestMcp(
+      registerBrowserCapabilities,
+      kernelClient,
+    );
+
+    try {
+      const created = toolResultJSON(
+        await client.callTool({
+          name: "manage_browsers",
+          arguments: { action: "create", region: "eu-west", stealth: true },
+        }),
+      );
+      expect(createCalls).toEqual([{ stealth: true, region: "eu-west" }]);
+      expect(created.browser.session_id).toBe("brr_123");
+
+      const listed = toolResultJSON(
+        await client.callTool({
+          name: "manage_browsers",
+          arguments: { action: "list", region: "eu-west" },
+        }),
+      );
+      expect(listCalls).toEqual([{ region: "eu-west" }]);
+      expect(listed.items).toEqual([{ session_id: "brr_eu" }]);
+    } finally {
+      await close();
+    }
+  });
+});
+
 describe("browser resources", () => {
   test("uses injected dependencies", async () => {
     const kernelClient = {

--- a/src/lib/mcp/tools/browsers.ts
+++ b/src/lib/mcp/tools/browsers.ts
@@ -472,6 +472,12 @@ export function registerBrowserCapabilities(
         .boolean()
         .describe("(create) Avoid bot detection. Recommended for scraping.")
         .optional(),
+      region: z
+        .enum(["us-east", "eu-west"])
+        .describe(
+          "(create) Geographic region for the browser session. Fixed once created; requires Start-Up or Enterprise plan, defaults to us-east. (list) Filter sessions by region.",
+        )
+        .optional(),
       timeout_seconds: z
         .number()
         .int()
@@ -660,6 +666,8 @@ export function registerBrowserCapabilities(
             if (params.gpu !== undefined) createParams.gpu = params.gpu;
             if (params.stealth !== undefined)
               createParams.stealth = params.stealth;
+            if (params.region !== undefined)
+              createParams.region = params.region;
             if (params.timeout_seconds !== undefined)
               createParams.timeout_seconds = params.timeout_seconds;
             if (params.kiosk_mode !== undefined)
@@ -743,6 +751,7 @@ export function registerBrowserCapabilities(
           case "list": {
             const page = await client.browsers.list({
               ...(params.status && { status: params.status }),
+              ...(params.region && { region: params.region }),
               ...(params.limit !== undefined && { limit: params.limit }),
               ...(params.offset !== undefined && { offset: params.offset }),
             });


### PR DESCRIPTION
## Summary

`POST /browsers` accepts a `region` param (`us-east` | `eu-west`, fixed at create, plan-gated to Start-Up/Enterprise, defaults to `us-east`), and `GET /browsers` can filter by it. The pinned `@onkernel/sdk@0.90.0` already types both, but the `manage_browsers` tool schema never exposed the field — so MCP clients couldn't select or filter by region.

## Changes

- Add `region` to the `manage_browsers` input schema, described for both `(create)` and `(list)`.
- Pass `region` through on create and as a filter on list.
- Test covering both pass-throughs.

## Testing

`bun test src/lib/mcp` — 177 pass, 0 fail. `bunx tsc --noEmit` clean. `bun run format:check` flags only the pre-existing AGENTS.md formatting issue on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin schema and pass-through wiring to an already-typed SDK; no auth or data-model changes.
> 
> **Overview**
> Exposes **`region`** (`us-east` | `eu-west`) on the **`manage_browsers`** MCP tool so clients can match the REST API: set region at session **create** (fixed afterward, plan-gated) and filter **list** by region.
> 
> The tool input schema documents both uses; create forwards `region` into `browsers.create`, and list passes it as a list filter. A unit test asserts both pass-throughs against a mocked Kernel client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f4fa57e6692eedb1cc7a89b6f5839d04ca4bfd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->