### PR TITLE
Track client-declared MCP capabilities

### DIFF
--- a/src/app/[transport]/route.ts
+++ b/src/app/[transport]/route.ts
@@ -8,11 +8,9 @@ import { after, NextRequest } from "next/server";
 import { isValidJwtFormat } from "@/lib/auth-utils";
 import {
   captureMcpConnectionScopeFailure,
-  clientCapabilityAnalyticsFromInitialize,
   flushMcpAnalytics,
   instrumentMcpAnalytics,
   isMcpAnalyticsEnabled,
-  type McpClientCapabilityAnalytics,
 } from "@/lib/mcp/analytics";
 import {
   connectionAnalyticsFromContext,
@@ -132,7 +130,6 @@ async function handleMcpRequestWithIdentity({
   transportSessionId,
   connectionContextCacheIdentity,
   observeConnection,
-  clientCapabilityAnalytics,
 }: {
   req: NextRequest;
   token: string;
@@ -143,7 +140,6 @@ async function handleMcpRequestWithIdentity({
   transportSessionId: string | null;
   connectionContextCacheIdentity?: string;
   observeConnection: boolean;
-  clientCapabilityAnalytics: McpClientCapabilityAnalytics | null;
 }) {
   const [mcpApps, connection] = await Promise.all([
     requestUsesMcpApps(req, {
@@ -184,7 +180,6 @@ async function handleMcpRequestWithIdentity({
         ...authInfoExtra,
         connectionContext,
         connectionAnalytics,
-        clientCapabilityAnalytics,
       },
     }),
     {
@@ -199,7 +194,6 @@ async function handleAuthenticatedRequest(
   req: NextRequest,
   transportSessionId: string | null = null,
   observeConnection = false,
-  clientCapabilityAnalytics: McpClientCapabilityAnalytics | null = null,
 ): Promise<Response> {
   const authHeader = req.headers.get("Authorization");
   const token = authHeader?.startsWith("Bearer ")
@@ -225,7 +219,6 @@ async function handleAuthenticatedRequest(
       credentialType: "api_key",
       transportSessionId,
       observeConnection,
-      clientCapabilityAnalytics,
     });
   }
 
@@ -263,7 +256,6 @@ async function handleAuthenticatedRequest(
       ? `${authSubject}\0${transportSessionId}`
       : undefined,
     observeConnection,
-    clientCapabilityAnalytics,
   });
 }
 
@@ -294,9 +286,6 @@ export async function POST(req: NextRequest): Promise<Response> {
   }
   const isInitialize = parsed?.method === "initialize";
   const initializeParams = isInitialize ? parsed?.params : undefined;
-  const clientCapabilityAnalytics = isInitialize
-    ? clientCapabilityAnalyticsFromInitialize(parsed)
-    : null;
   const isStreamableInitialize =
     new URL(req.url).pathname.endsWith("/mcp") && isInitialize;
   const session = isStreamableInitialize
@@ -321,7 +310,6 @@ export async function POST(req: NextRequest): Promise<Response> {
     }),
     session?.id ?? null,
     isInitialize,
-    clientCapabilityAnalytics,
   );
 
   if (!session) return response;

--- a/src/app/[transport]/route.ts
+++ b/src/app/[transport]/route.ts
@@ -8,9 +8,11 @@ import { after, NextRequest } from "next/server";
 import { isValidJwtFormat } from "@/lib/auth-utils";
 import {
   captureMcpConnectionScopeFailure,
+  clientCapabilityAnalyticsFromInitialize,
   flushMcpAnalytics,
   instrumentMcpAnalytics,
   isMcpAnalyticsEnabled,
+  type McpClientCapabilityAnalytics,
 } from "@/lib/mcp/analytics";
 import {
   connectionAnalyticsFromContext,
@@ -130,6 +132,7 @@ async function handleMcpRequestWithIdentity({
   transportSessionId,
   connectionContextCacheIdentity,
   observeConnection,
+  clientCapabilityAnalytics,
 }: {
   req: NextRequest;
   token: string;
@@ -140,6 +143,7 @@ async function handleMcpRequestWithIdentity({
   transportSessionId: string | null;
   connectionContextCacheIdentity?: string;
   observeConnection: boolean;
+  clientCapabilityAnalytics: McpClientCapabilityAnalytics | null;
 }) {
   const [mcpApps, connection] = await Promise.all([
     requestUsesMcpApps(req, {
@@ -180,6 +184,7 @@ async function handleMcpRequestWithIdentity({
         ...authInfoExtra,
         connectionContext,
         connectionAnalytics,
+        clientCapabilityAnalytics,
       },
     }),
     {
@@ -194,6 +199,7 @@ async function handleAuthenticatedRequest(
   req: NextRequest,
   transportSessionId: string | null = null,
   observeConnection = false,
+  clientCapabilityAnalytics: McpClientCapabilityAnalytics | null = null,
 ): Promise<Response> {
   const authHeader = req.headers.get("Authorization");
   const token = authHeader?.startsWith("Bearer ")
@@ -219,6 +225,7 @@ async function handleAuthenticatedRequest(
       credentialType: "api_key",
       transportSessionId,
       observeConnection,
+      clientCapabilityAnalytics,
     });
   }
 
@@ -256,6 +263,7 @@ async function handleAuthenticatedRequest(
       ? `${authSubject}\0${transportSessionId}`
       : undefined,
     observeConnection,
+    clientCapabilityAnalytics,
   });
 }
 
@@ -286,6 +294,9 @@ export async function POST(req: NextRequest): Promise<Response> {
   }
   const isInitialize = parsed?.method === "initialize";
   const initializeParams = isInitialize ? parsed?.params : undefined;
+  const clientCapabilityAnalytics = isInitialize
+    ? clientCapabilityAnalyticsFromInitialize(parsed)
+    : null;
   const isStreamableInitialize =
     new URL(req.url).pathname.endsWith("/mcp") && isInitialize;
   const session = isStreamableInitialize
@@ -310,6 +321,7 @@ export async function POST(req: NextRequest): Promise<Response> {
     }),
     session?.id ?? null,
     isInitialize,
+    clientCapabilityAnalytics,
   );
 
   if (!session) return response;

--- a/src/lib/mcp/analytics.test.ts
+++ b/src/lib/mcp/analytics.test.ts
@@ -8,8 +8,16 @@ import {
 import {
   captureMcpConnectionScopeFailure,
   captureOAuthTokenExchange,
+  clientCapabilityAnalyticsFromInitialize,
   enrichMcpAnalyticsEvent,
   instrumentMcpAnalytics,
+  MCP_CLIENT_ELICITATION_MODE_PROPERTY,
+  MCP_CLIENT_SUPPORTS_APPS_PROPERTY,
+  MCP_CLIENT_SUPPORTS_ENTERPRISE_AUTH_PROPERTY,
+  MCP_CLIENT_SUPPORTS_OAUTH_CLIENT_CREDENTIALS_PROPERTY,
+  MCP_CLIENT_SUPPORTS_SAMPLING_PROPERTY,
+  MCP_CLIENT_SUPPORTS_SAMPLING_TOOLS_PROPERTY,
+  MCP_CLIENT_SUPPORTS_TASKS_PROPERTY,
   MCP_CONNECTION_SCOPE_FAILURE_EVENT,
   MCP_USED_PROJECT_ID_PROPERTY,
   MCP_USED_PROJECT_PROPERTY,
@@ -18,6 +26,79 @@ import {
 } from "@/lib/mcp/analytics";
 
 const privateContextProperty = "__mcp_connection_analytics_context";
+
+function initialize(capabilities: Record<string, unknown>) {
+  return {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-11-25",
+      capabilities,
+      clientInfo: { name: "test-client", version: "1.0.0" },
+    },
+  };
+}
+
+describe("clientCapabilityAnalyticsFromInitialize", () => {
+  test("records unsupported capabilities as explicit false values", () => {
+    expect(clientCapabilityAnalyticsFromInitialize(initialize({}))).toEqual({
+      [MCP_CLIENT_SUPPORTS_SAMPLING_PROPERTY]: false,
+      [MCP_CLIENT_SUPPORTS_SAMPLING_TOOLS_PROPERTY]: false,
+      [MCP_CLIENT_ELICITATION_MODE_PROPERTY]: "none",
+      [MCP_CLIENT_SUPPORTS_APPS_PROPERTY]: false,
+      [MCP_CLIENT_SUPPORTS_TASKS_PROPERTY]: false,
+      [MCP_CLIENT_SUPPORTS_OAUTH_CLIENT_CREDENTIALS_PROPERTY]: false,
+      [MCP_CLIENT_SUPPORTS_ENTERPRISE_AUTH_PROPERTY]: false,
+    });
+  });
+
+  test("reduces standard capabilities and allowlisted extensions", () => {
+    const result = clientCapabilityAnalyticsFromInitialize(
+      initialize({
+        sampling: { tools: {} },
+        elicitation: {},
+        extensions: {
+          "io.modelcontextprotocol/ui": { mimeTypes: ["text/html"] },
+          "io.modelcontextprotocol/tasks": {},
+          "io.modelcontextprotocol/oauth-client-credentials": {},
+          "io.modelcontextprotocol/enterprise-managed-authorization": {},
+          "com.example/private-extension": { secret: "do-not-capture" },
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      [MCP_CLIENT_SUPPORTS_SAMPLING_PROPERTY]: true,
+      [MCP_CLIENT_SUPPORTS_SAMPLING_TOOLS_PROPERTY]: true,
+      [MCP_CLIENT_ELICITATION_MODE_PROPERTY]: "form",
+      [MCP_CLIENT_SUPPORTS_APPS_PROPERTY]: true,
+      [MCP_CLIENT_SUPPORTS_TASKS_PROPERTY]: true,
+      [MCP_CLIENT_SUPPORTS_OAUTH_CLIENT_CREDENTIALS_PROPERTY]: true,
+      [MCP_CLIENT_SUPPORTS_ENTERPRISE_AUTH_PROPERTY]: true,
+    });
+    expect(JSON.stringify(result)).not.toContain("private-extension");
+    expect(JSON.stringify(result)).not.toContain("do-not-capture");
+  });
+
+  test("distinguishes URL elicitation and legacy core tasks", () => {
+    const result = clientCapabilityAnalyticsFromInitialize(
+      initialize({ elicitation: { form: {}, url: {} }, tasks: {} }),
+    );
+
+    expect(result?.[MCP_CLIENT_ELICITATION_MODE_PROPERTY]).toBe("form_and_url");
+    expect(result?.[MCP_CLIENT_SUPPORTS_TASKS_PROPERTY]).toBe(true);
+  });
+
+  test("ignores non-initialize payloads", () => {
+    expect(
+      clientCapabilityAnalyticsFromInitialize({
+        method: "tools/list",
+        params: { capabilities: { sampling: {} } },
+      }),
+    ).toBeNull();
+  });
+});
 
 function initializeEvent(
   sessionId: string,
@@ -459,12 +540,17 @@ describe("instrumentMcpAnalytics (SDK integration)", () => {
     params: Record<string, unknown>,
   ) {
     const server = makeServer(captured);
+    const request = { jsonrpc: "2.0", id: 1, method, params };
     const extra = {
       authInfo: {
         token: "sk_test",
         clientId: "mcp-server",
         scopes: ["apikey"],
-        extra: { connectionContext: { scope: { organizationId: ORG } } },
+        extra: {
+          connectionContext: { scope: { organizationId: ORG } },
+          clientCapabilityAnalytics:
+            clientCapabilityAnalyticsFromInitialize(request),
+        },
       },
       signal: new AbortController().signal,
       requestInfo: { headers: {} },
@@ -479,7 +565,7 @@ describe("instrumentMcpAnalytics (SDK integration)", () => {
     )._requestHandlers;
     const handler = handlers.get(method);
     if (!handler) throw new Error(`no handler registered for ${method}`);
-    await handler({ jsonrpc: "2.0", id: 1, method, params }, extra);
+    await handler(request, extra);
     // The SDK's event sink captures fire-and-forget; give it a tick to flush.
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
@@ -489,7 +575,11 @@ describe("instrumentMcpAnalytics (SDK integration)", () => {
 
     await simulateRequest(captured, "initialize", {
       protocolVersion: "2025-03-26",
-      capabilities: {},
+      capabilities: {
+        sampling: { tools: {} },
+        elicitation: { url: {} },
+        extensions: { "io.modelcontextprotocol/ui": {} },
+      },
       clientInfo: { name: "test-client", version: "0.0.0" },
     });
     await simulateRequest(captured, "tools/list", {});
@@ -512,6 +602,14 @@ describe("instrumentMcpAnalytics (SDK integration)", () => {
       distinctId: string;
       properties: Record<string, unknown>;
     };
+
+    expect(initialize.properties).toMatchObject({
+      [MCP_CLIENT_SUPPORTS_SAMPLING_PROPERTY]: true,
+      [MCP_CLIENT_SUPPORTS_SAMPLING_TOOLS_PROPERTY]: true,
+      [MCP_CLIENT_ELICITATION_MODE_PROPERTY]: "form_and_url",
+      [MCP_CLIENT_SUPPORTS_APPS_PROPERTY]: true,
+      [MCP_CLIENT_SUPPORTS_TASKS_PROPERTY]: false,
+    });
 
     // Every captured event carries org attribution...
     for (const event of [initialize, toolsList, toolCall]) {

--- a/src/lib/mcp/analytics.test.ts
+++ b/src/lib/mcp/analytics.test.ts
@@ -81,13 +81,19 @@ describe("clientCapabilityAnalyticsFromInitialize", () => {
     expect(JSON.stringify(result)).not.toContain("do-not-capture");
   });
 
-  test("distinguishes URL elicitation and legacy core tasks", () => {
-    const result = clientCapabilityAnalyticsFromInitialize(
+  test("distinguishes URL-only, form-and-URL, and legacy task support", () => {
+    const urlOnly = clientCapabilityAnalyticsFromInitialize(
+      initialize({ elicitation: { url: {} } }),
+    );
+    const formAndUrl = clientCapabilityAnalyticsFromInitialize(
       initialize({ elicitation: { form: {}, url: {} }, tasks: {} }),
     );
 
-    expect(result?.[MCP_CLIENT_ELICITATION_MODE_PROPERTY]).toBe("form_and_url");
-    expect(result?.[MCP_CLIENT_SUPPORTS_TASKS_PROPERTY]).toBe(true);
+    expect(urlOnly?.[MCP_CLIENT_ELICITATION_MODE_PROPERTY]).toBe("url");
+    expect(formAndUrl?.[MCP_CLIENT_ELICITATION_MODE_PROPERTY]).toBe(
+      "form_and_url",
+    );
+    expect(formAndUrl?.[MCP_CLIENT_SUPPORTS_TASKS_PROPERTY]).toBe(true);
   });
 
   test("ignores non-initialize payloads", () => {
@@ -606,7 +612,7 @@ describe("instrumentMcpAnalytics (SDK integration)", () => {
     expect(initialize.properties).toMatchObject({
       [MCP_CLIENT_SUPPORTS_SAMPLING_PROPERTY]: true,
       [MCP_CLIENT_SUPPORTS_SAMPLING_TOOLS_PROPERTY]: true,
-      [MCP_CLIENT_ELICITATION_MODE_PROPERTY]: "form_and_url",
+      [MCP_CLIENT_ELICITATION_MODE_PROPERTY]: "url",
       [MCP_CLIENT_SUPPORTS_APPS_PROPERTY]: true,
       [MCP_CLIENT_SUPPORTS_TASKS_PROPERTY]: false,
     });

--- a/src/lib/mcp/analytics.test.ts
+++ b/src/lib/mcp/analytics.test.ts
@@ -81,6 +81,32 @@ describe("clientCapabilityAnalyticsFromInitialize", () => {
     expect(JSON.stringify(result)).not.toContain("do-not-capture");
   });
 
+  test("rejects malformed capability and extension declarations", () => {
+    const result = clientCapabilityAnalyticsFromInitialize(
+      initialize({
+        sampling: { tools: null },
+        elicitation: { url: null },
+        tasks: false,
+        extensions: {
+          "io.modelcontextprotocol/ui": null,
+          "io.modelcontextprotocol/tasks": false,
+          "io.modelcontextprotocol/oauth-client-credentials": "enabled",
+          "io.modelcontextprotocol/enterprise-managed-authorization": [],
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      [MCP_CLIENT_SUPPORTS_SAMPLING_PROPERTY]: true,
+      [MCP_CLIENT_SUPPORTS_SAMPLING_TOOLS_PROPERTY]: false,
+      [MCP_CLIENT_ELICITATION_MODE_PROPERTY]: "none",
+      [MCP_CLIENT_SUPPORTS_APPS_PROPERTY]: false,
+      [MCP_CLIENT_SUPPORTS_TASKS_PROPERTY]: false,
+      [MCP_CLIENT_SUPPORTS_OAUTH_CLIENT_CREDENTIALS_PROPERTY]: false,
+      [MCP_CLIENT_SUPPORTS_ENTERPRISE_AUTH_PROPERTY]: false,
+    });
+  });
+
   test("distinguishes URL-only, form-and-URL, and legacy task support", () => {
     const urlOnly = clientCapabilityAnalyticsFromInitialize(
       initialize({ elicitation: { url: {} } }),
@@ -552,11 +578,7 @@ describe("instrumentMcpAnalytics (SDK integration)", () => {
         token: "sk_test",
         clientId: "mcp-server",
         scopes: ["apikey"],
-        extra: {
-          connectionContext: { scope: { organizationId: ORG } },
-          clientCapabilityAnalytics:
-            clientCapabilityAnalyticsFromInitialize(request),
-        },
+        extra: { connectionContext: { scope: { organizationId: ORG } } },
       },
       signal: new AbortController().signal,
       requestInfo: { headers: {} },

--- a/src/lib/mcp/analytics.ts
+++ b/src/lib/mcp/analytics.ts
@@ -68,6 +68,39 @@ const posthog = projectToken
 
 export const MCP_USED_PROJECT_ID_PROPERTY = "$mcp_used_project_id";
 export const MCP_USED_PROJECT_PROPERTY = "$mcp_used_project";
+export const MCP_CLIENT_SUPPORTS_SAMPLING_PROPERTY =
+  "$mcp_client_supports_sampling";
+export const MCP_CLIENT_SUPPORTS_SAMPLING_TOOLS_PROPERTY =
+  "$mcp_client_supports_sampling_tools";
+export const MCP_CLIENT_ELICITATION_MODE_PROPERTY =
+  "$mcp_client_elicitation_mode";
+export const MCP_CLIENT_SUPPORTS_APPS_PROPERTY = "$mcp_client_supports_apps";
+export const MCP_CLIENT_SUPPORTS_TASKS_PROPERTY = "$mcp_client_supports_tasks";
+export const MCP_CLIENT_SUPPORTS_OAUTH_CLIENT_CREDENTIALS_PROPERTY =
+  "$mcp_client_supports_oauth_client_credentials";
+export const MCP_CLIENT_SUPPORTS_ENTERPRISE_AUTH_PROPERTY =
+  "$mcp_client_supports_enterprise_auth";
+
+export type McpClientCapabilityAnalytics = {
+  [MCP_CLIENT_SUPPORTS_SAMPLING_PROPERTY]: boolean;
+  [MCP_CLIENT_SUPPORTS_SAMPLING_TOOLS_PROPERTY]: boolean;
+  [MCP_CLIENT_ELICITATION_MODE_PROPERTY]: "none" | "form" | "form_and_url";
+  [MCP_CLIENT_SUPPORTS_APPS_PROPERTY]: boolean;
+  [MCP_CLIENT_SUPPORTS_TASKS_PROPERTY]: boolean;
+  [MCP_CLIENT_SUPPORTS_OAUTH_CLIENT_CREDENTIALS_PROPERTY]: boolean;
+  [MCP_CLIENT_SUPPORTS_ENTERPRISE_AUTH_PROPERTY]: boolean;
+};
+
+// Official extensions listed at https://modelcontextprotocol.io/extensions.
+// Keep this explicit: arbitrary extension identifiers and settings must not enter analytics.
+const CLIENT_EXTENSION_PROPERTIES = {
+  "io.modelcontextprotocol/ui": MCP_CLIENT_SUPPORTS_APPS_PROPERTY,
+  "io.modelcontextprotocol/tasks": MCP_CLIENT_SUPPORTS_TASKS_PROPERTY,
+  "io.modelcontextprotocol/oauth-client-credentials":
+    MCP_CLIENT_SUPPORTS_OAUTH_CLIENT_CREDENTIALS_PROPERTY,
+  "io.modelcontextprotocol/enterprise-managed-authorization":
+    MCP_CLIENT_SUPPORTS_ENTERPRISE_AUTH_PROPERTY,
+} as const;
 
 // Every property this integration sends. An allow-list rather than a deny-list so a
 // property the pinned SDK doesn't emit today — a renamed payload field, a new one —
@@ -84,6 +117,13 @@ const SENT_PROPERTIES = new Set<string>([
   "$mcp_scope_source",
   MCP_USED_PROJECT_ID_PROPERTY,
   MCP_USED_PROJECT_PROPERTY,
+  MCP_CLIENT_SUPPORTS_SAMPLING_PROPERTY,
+  MCP_CLIENT_SUPPORTS_SAMPLING_TOOLS_PROPERTY,
+  MCP_CLIENT_ELICITATION_MODE_PROPERTY,
+  MCP_CLIENT_SUPPORTS_APPS_PROPERTY,
+  MCP_CLIENT_SUPPORTS_TASKS_PROPERTY,
+  MCP_CLIENT_SUPPORTS_OAUTH_CLIENT_CREDENTIALS_PROPERTY,
+  MCP_CLIENT_SUPPORTS_ENTERPRISE_AUTH_PROPERTY,
   PostHogMCPAnalyticsProperty.ClientName,
   PostHogMCPAnalyticsProperty.ClientVersion,
   PostHogMCPAnalyticsProperty.DurationMs,
@@ -139,6 +179,63 @@ const INTENT_REDACTIONS: readonly [RegExp, string][] = [
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+/**
+ * Reduces the client-controlled initialize capability map to bounded analytics.
+ * Presence is the signal: MCP uses empty objects to declare baseline support.
+ */
+export function clientCapabilityAnalyticsFromInitialize(
+  body: unknown,
+): McpClientCapabilityAnalytics | null {
+  if (
+    !isRecord(body) ||
+    body.method !== "initialize" ||
+    !isRecord(body.params)
+  ) {
+    return null;
+  }
+
+  const capabilities = isRecord(body.params.capabilities)
+    ? body.params.capabilities
+    : {};
+  const sampling = isRecord(capabilities.sampling)
+    ? capabilities.sampling
+    : null;
+  const elicitation = isRecord(capabilities.elicitation)
+    ? capabilities.elicitation
+    : null;
+  const extensions = isRecord(capabilities.extensions)
+    ? capabilities.extensions
+    : null;
+
+  const properties: McpClientCapabilityAnalytics = {
+    [MCP_CLIENT_SUPPORTS_SAMPLING_PROPERTY]: sampling !== null,
+    [MCP_CLIENT_SUPPORTS_SAMPLING_TOOLS_PROPERTY]:
+      sampling !== null && hasOwn(sampling, "tools"),
+    [MCP_CLIENT_ELICITATION_MODE_PROPERTY]: elicitation
+      ? hasOwn(elicitation, "url")
+        ? "form_and_url"
+        : "form"
+      : "none",
+    [MCP_CLIENT_SUPPORTS_APPS_PROPERTY]: false,
+    [MCP_CLIENT_SUPPORTS_TASKS_PROPERTY]: hasOwn(capabilities, "tasks"),
+    [MCP_CLIENT_SUPPORTS_OAUTH_CLIENT_CREDENTIALS_PROPERTY]: false,
+    [MCP_CLIENT_SUPPORTS_ENTERPRISE_AUTH_PROPERTY]: false,
+  };
+
+  for (const [extension, property] of Object.entries(
+    CLIENT_EXTENSION_PROPERTIES,
+  )) {
+    if (extensions && hasOwn(extensions, extension))
+      properties[property] = true;
+  }
+
+  return properties;
 }
 
 function hasNonEmptyParam(
@@ -275,6 +372,15 @@ function connectionAnalyticsContext(extra: unknown) {
     | { connectionAnalytics?: McpConnectionAnalyticsContext }
     | undefined;
   return authExtra?.connectionAnalytics;
+}
+
+function clientCapabilityAnalyticsContext(extra: unknown) {
+  const authInfo = (extra as { authInfo?: { extra?: unknown } } | undefined)
+    ?.authInfo;
+  const authExtra = authInfo?.extra as
+    | { clientCapabilityAnalytics?: McpClientCapabilityAnalytics }
+    | undefined;
+  return authExtra?.clientCapabilityAnalytics;
 }
 
 // The route resolves the Kernel connection context at auth time and attaches it to
@@ -435,6 +541,8 @@ export function instrumentMcpAnalytics(
       if (request.method === "initialize") {
         const context = connectionAnalyticsContext(extra);
         if (context) properties[ANALYTICS_CONTEXT_PROPERTY] = context;
+        const capabilities = clientCapabilityAnalyticsContext(extra);
+        if (capabilities) Object.assign(properties, capabilities);
       }
       return Object.keys(properties).length > 0 ? properties : null;
     },

--- a/src/lib/mcp/analytics.ts
+++ b/src/lib/mcp/analytics.ts
@@ -81,10 +81,12 @@ export const MCP_CLIENT_SUPPORTS_OAUTH_CLIENT_CREDENTIALS_PROPERTY =
 export const MCP_CLIENT_SUPPORTS_ENTERPRISE_AUTH_PROPERTY =
   "$mcp_client_supports_enterprise_auth";
 
+type McpClientElicitationMode = "none" | "form" | "url" | "form_and_url";
+
 export type McpClientCapabilityAnalytics = {
   [MCP_CLIENT_SUPPORTS_SAMPLING_PROPERTY]: boolean;
   [MCP_CLIENT_SUPPORTS_SAMPLING_TOOLS_PROPERTY]: boolean;
-  [MCP_CLIENT_ELICITATION_MODE_PROPERTY]: "none" | "form" | "form_and_url";
+  [MCP_CLIENT_ELICITATION_MODE_PROPERTY]: McpClientElicitationMode;
   [MCP_CLIENT_SUPPORTS_APPS_PROPERTY]: boolean;
   [MCP_CLIENT_SUPPORTS_TASKS_PROPERTY]: boolean;
   [MCP_CLIENT_SUPPORTS_OAUTH_CLIENT_CREDENTIALS_PROPERTY]: boolean;
@@ -213,15 +215,22 @@ export function clientCapabilityAnalyticsFromInitialize(
     ? capabilities.extensions
     : null;
 
+  const hasElicitationForm =
+    elicitation !== null &&
+    (hasOwn(elicitation, "form") || !hasOwn(elicitation, "url"));
+  const hasElicitationUrl = elicitation !== null && hasOwn(elicitation, "url");
+  let elicitationMode: McpClientElicitationMode = "none";
+  if (hasElicitationForm) {
+    elicitationMode = hasElicitationUrl ? "form_and_url" : "form";
+  } else if (hasElicitationUrl) {
+    elicitationMode = "url";
+  }
+
   const properties: McpClientCapabilityAnalytics = {
     [MCP_CLIENT_SUPPORTS_SAMPLING_PROPERTY]: sampling !== null,
     [MCP_CLIENT_SUPPORTS_SAMPLING_TOOLS_PROPERTY]:
       sampling !== null && hasOwn(sampling, "tools"),
-    [MCP_CLIENT_ELICITATION_MODE_PROPERTY]: elicitation
-      ? hasOwn(elicitation, "url")
-        ? "form_and_url"
-        : "form"
-      : "none",
+    [MCP_CLIENT_ELICITATION_MODE_PROPERTY]: elicitationMode,
     [MCP_CLIENT_SUPPORTS_APPS_PROPERTY]: false,
     [MCP_CLIENT_SUPPORTS_TASKS_PROPERTY]: hasOwn(capabilities, "tasks"),
     [MCP_CLIENT_SUPPORTS_OAUTH_CLIENT_CREDENTIALS_PROPERTY]: false,

--- a/src/lib/mcp/analytics.ts
+++ b/src/lib/mcp/analytics.ts
@@ -12,6 +12,16 @@ import type {
   McpConnectionAnalyticsContext,
   McpConnectionContext,
 } from "@/lib/mcp/auth-context";
+import {
+  clientDeclaresExtension,
+  clientElicitationModes,
+  initializeClientCapabilities,
+  isRecord,
+  MCP_APPS_EXTENSION,
+  MCP_ENTERPRISE_MANAGED_AUTHORIZATION_EXTENSION,
+  MCP_OAUTH_CLIENT_CREDENTIALS_EXTENSION,
+  MCP_TASKS_EXTENSION,
+} from "@/lib/mcp/client-capabilities";
 
 const projectToken = process.env.POSTHOG_PROJECT_TOKEN;
 
@@ -83,7 +93,7 @@ export const MCP_CLIENT_SUPPORTS_ENTERPRISE_AUTH_PROPERTY =
 
 type McpClientElicitationMode = "none" | "form" | "url" | "form_and_url";
 
-export type McpClientCapabilityAnalytics = {
+type McpClientCapabilityAnalytics = {
   [MCP_CLIENT_SUPPORTS_SAMPLING_PROPERTY]: boolean;
   [MCP_CLIENT_SUPPORTS_SAMPLING_TOOLS_PROPERTY]: boolean;
   [MCP_CLIENT_ELICITATION_MODE_PROPERTY]: McpClientElicitationMode;
@@ -96,11 +106,11 @@ export type McpClientCapabilityAnalytics = {
 // Official extensions listed at https://modelcontextprotocol.io/extensions.
 // Keep this explicit: arbitrary extension identifiers and settings must not enter analytics.
 const CLIENT_EXTENSION_PROPERTIES = {
-  "io.modelcontextprotocol/ui": MCP_CLIENT_SUPPORTS_APPS_PROPERTY,
-  "io.modelcontextprotocol/tasks": MCP_CLIENT_SUPPORTS_TASKS_PROPERTY,
-  "io.modelcontextprotocol/oauth-client-credentials":
+  [MCP_APPS_EXTENSION]: MCP_CLIENT_SUPPORTS_APPS_PROPERTY,
+  [MCP_TASKS_EXTENSION]: MCP_CLIENT_SUPPORTS_TASKS_PROPERTY,
+  [MCP_OAUTH_CLIENT_CREDENTIALS_EXTENSION]:
     MCP_CLIENT_SUPPORTS_OAUTH_CLIENT_CREDENTIALS_PROPERTY,
-  "io.modelcontextprotocol/enterprise-managed-authorization":
+  [MCP_ENTERPRISE_MANAGED_AUTHORIZATION_EXTENSION]:
     MCP_CLIENT_SUPPORTS_ENTERPRISE_AUTH_PROPERTY,
 } as const;
 
@@ -179,60 +189,35 @@ const INTENT_REDACTIONS: readonly [RegExp, string][] = [
   ],
 ];
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object" && !Array.isArray(value);
-}
-
-function hasOwn(record: Record<string, unknown>, key: string): boolean {
-  return Object.prototype.hasOwnProperty.call(record, key);
-}
-
 /**
  * Reduces the client-controlled initialize capability map to bounded analytics.
- * Presence is the signal: MCP uses empty objects to declare baseline support.
+ * MCP capability declarations count only when their settings are objects.
  */
 export function clientCapabilityAnalyticsFromInitialize(
   body: unknown,
 ): McpClientCapabilityAnalytics | null {
-  if (
-    !isRecord(body) ||
-    body.method !== "initialize" ||
-    !isRecord(body.params)
-  ) {
-    return null;
-  }
+  const capabilities = initializeClientCapabilities(body);
+  if (!capabilities) return null;
 
-  const capabilities = isRecord(body.params.capabilities)
-    ? body.params.capabilities
-    : {};
   const sampling = isRecord(capabilities.sampling)
     ? capabilities.sampling
     : null;
-  const elicitation = isRecord(capabilities.elicitation)
-    ? capabilities.elicitation
-    : null;
-  const extensions = isRecord(capabilities.extensions)
-    ? capabilities.extensions
-    : null;
-
-  const hasElicitationForm =
-    elicitation !== null &&
-    (hasOwn(elicitation, "form") || !hasOwn(elicitation, "url"));
-  const hasElicitationUrl = elicitation !== null && hasOwn(elicitation, "url");
+  const { supportsFormMode, supportsUrlMode } =
+    clientElicitationModes(capabilities);
   let elicitationMode: McpClientElicitationMode = "none";
-  if (hasElicitationForm) {
-    elicitationMode = hasElicitationUrl ? "form_and_url" : "form";
-  } else if (hasElicitationUrl) {
+  if (supportsFormMode) {
+    elicitationMode = supportsUrlMode ? "form_and_url" : "form";
+  } else if (supportsUrlMode) {
     elicitationMode = "url";
   }
 
   const properties: McpClientCapabilityAnalytics = {
     [MCP_CLIENT_SUPPORTS_SAMPLING_PROPERTY]: sampling !== null,
     [MCP_CLIENT_SUPPORTS_SAMPLING_TOOLS_PROPERTY]:
-      sampling !== null && hasOwn(sampling, "tools"),
+      sampling !== null && isRecord(sampling.tools),
     [MCP_CLIENT_ELICITATION_MODE_PROPERTY]: elicitationMode,
     [MCP_CLIENT_SUPPORTS_APPS_PROPERTY]: false,
-    [MCP_CLIENT_SUPPORTS_TASKS_PROPERTY]: hasOwn(capabilities, "tasks"),
+    [MCP_CLIENT_SUPPORTS_TASKS_PROPERTY]: isRecord(capabilities.tasks),
     [MCP_CLIENT_SUPPORTS_OAUTH_CLIENT_CREDENTIALS_PROPERTY]: false,
     [MCP_CLIENT_SUPPORTS_ENTERPRISE_AUTH_PROPERTY]: false,
   };
@@ -240,8 +225,9 @@ export function clientCapabilityAnalyticsFromInitialize(
   for (const [extension, property] of Object.entries(
     CLIENT_EXTENSION_PROPERTIES,
   )) {
-    if (extensions && hasOwn(extensions, extension))
+    if (clientDeclaresExtension(capabilities, extension)) {
       properties[property] = true;
+    }
   }
 
   return properties;
@@ -381,15 +367,6 @@ function connectionAnalyticsContext(extra: unknown) {
     | { connectionAnalytics?: McpConnectionAnalyticsContext }
     | undefined;
   return authExtra?.connectionAnalytics;
-}
-
-function clientCapabilityAnalyticsContext(extra: unknown) {
-  const authInfo = (extra as { authInfo?: { extra?: unknown } } | undefined)
-    ?.authInfo;
-  const authExtra = authInfo?.extra as
-    | { clientCapabilityAnalytics?: McpClientCapabilityAnalytics }
-    | undefined;
-  return authExtra?.clientCapabilityAnalytics;
 }
 
 // The route resolves the Kernel connection context at auth time and attaches it to
@@ -550,7 +527,7 @@ export function instrumentMcpAnalytics(
       if (request.method === "initialize") {
         const context = connectionAnalyticsContext(extra);
         if (context) properties[ANALYTICS_CONTEXT_PROPERTY] = context;
-        const capabilities = clientCapabilityAnalyticsContext(extra);
+        const capabilities = clientCapabilityAnalyticsFromInitialize(request);
         if (capabilities) Object.assign(properties, capabilities);
       }
       return Object.keys(properties).length > 0 ? properties : null;

--- a/src/lib/mcp/client-capabilities.ts
+++ b/src/lib/mcp/client-capabilities.ts
@@ -1,0 +1,60 @@
+import { getSupportedElicitationModes } from "@modelcontextprotocol/sdk/client/index.js";
+import type { ClientCapabilities } from "@modelcontextprotocol/sdk/types.js";
+
+export const MCP_APPS_EXTENSION = "io.modelcontextprotocol/ui";
+export const MCP_TASKS_EXTENSION = "io.modelcontextprotocol/tasks";
+export const MCP_OAUTH_CLIENT_CREDENTIALS_EXTENSION =
+  "io.modelcontextprotocol/oauth-client-credentials";
+export const MCP_ENTERPRISE_MANAGED_AUTHORIZATION_EXTENSION =
+  "io.modelcontextprotocol/enterprise-managed-authorization";
+
+export type RawClientCapabilities = Record<string, unknown>;
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+export function initializeClientCapabilities(
+  body: unknown,
+): RawClientCapabilities | null {
+  if (
+    !isRecord(body) ||
+    body.method !== "initialize" ||
+    !isRecord(body.params) ||
+    !isRecord(body.params.capabilities)
+  ) {
+    return null;
+  }
+
+  return body.params.capabilities;
+}
+
+export function clientDeclaresExtension(
+  capabilities: unknown,
+  extension: string,
+): boolean {
+  if (!isRecord(capabilities)) return false;
+  const extensions = capabilities.extensions;
+  return isRecord(extensions) && isRecord(extensions[extension]);
+}
+
+export function clientElicitationModes(capabilities: unknown) {
+  if (!isRecord(capabilities) || !isRecord(capabilities.elicitation)) {
+    return { supportsFormMode: false, supportsUrlMode: false };
+  }
+
+  const raw = capabilities.elicitation;
+  const normalized: NonNullable<ClientCapabilities["elicitation"]> = {};
+  if (isRecord(raw.form)) normalized.form = raw.form;
+  if (isRecord(raw.url)) normalized.url = raw.url;
+
+  const hasInvalidMode =
+    (Object.prototype.hasOwnProperty.call(raw, "form") &&
+      !isRecord(raw.form)) ||
+    (Object.prototype.hasOwnProperty.call(raw, "url") && !isRecord(raw.url));
+  if (hasInvalidMode && !normalized.form && !normalized.url) {
+    return { supportsFormMode: false, supportsUrlMode: false };
+  }
+
+  return getSupportedElicitationModes(normalized);
+}

--- a/src/lib/mcp/tools/auth-login-app.test.ts
+++ b/src/lib/mcp/tools/auth-login-app.test.ts
@@ -306,6 +306,18 @@ describe("managed-auth MCP App registration", () => {
       }),
     ).toBe(true);
     expect(
+      initializeDeclaresMcpApps({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          capabilities: {
+            extensions: { "io.modelcontextprotocol/ui": null },
+          },
+        },
+      }),
+    ).toBe(false);
+    expect(
       initializeDeclaresMcpApps([
         { jsonrpc: "2.0", method: "notifications/initialized" },
         {

--- a/src/lib/mcp/tools/mcp-apps-gate.ts
+++ b/src/lib/mcp/tools/mcp-apps-gate.ts
@@ -1,10 +1,13 @@
 import { decodeSessionId, MCP_SESSION_HEADER } from "@posthog/mcp";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  clientDeclaresExtension,
+  initializeClientCapabilities,
+  MCP_APPS_EXTENSION,
+} from "@/lib/mcp/client-capabilities";
 import { hasMcpAppsClient } from "@/lib/redis";
 
-// MCP Apps (SEP-1865) extension identifier. Clients that render MCP Apps
-// declare it in their initialize capabilities.
-export const MCP_APPS_EXTENSION = "io.modelcontextprotocol/ui";
+export { MCP_APPS_EXTENSION };
 
 // Sliding TTL for the Redis capability marker. Long enough that an active App
 // never loses it mid-flow; refreshed on every gated call.
@@ -16,15 +19,8 @@ const MCP_APPS_MARKER_TTL_SECONDS = 24 * 60 * 60;
  * invoke an app-only tool in the same HTTP request.
  */
 export function initializeDeclaresMcpApps(body: unknown): boolean {
-  if (!body || typeof body !== "object" || Array.isArray(body)) return false;
-  const request = body as {
-    method?: unknown;
-    params?: { capabilities?: { extensions?: Record<string, unknown> } };
-  };
-  return (
-    request.method === "initialize" &&
-    Boolean(request.params?.capabilities?.extensions?.[MCP_APPS_EXTENSION])
-  );
+  const capabilities = initializeClientCapabilities(body);
+  return clientDeclaresExtension(capabilities, MCP_APPS_EXTENSION);
 }
 
 /**
@@ -51,10 +47,8 @@ export async function clientSupportsMcpApps(
   authSubject: string,
   transportSessionId: string | null,
 ): Promise<boolean> {
-  const capabilities = server.server.getClientCapabilities() as
-    | { extensions?: Record<string, unknown> }
-    | undefined;
-  if (capabilities?.extensions?.[MCP_APPS_EXTENSION]) return true;
+  const capabilities = server.server.getClientCapabilities();
+  if (clientDeclaresExtension(capabilities, MCP_APPS_EXTENSION)) return true;
   if (!transportSessionId) return false;
   try {
     return await hasMcpAppsClient({


### PR DESCRIPTION
## summary

- add bounded capability properties to each `$mcp_initialize` analytics event
- distinguish sampling with tool support and elicitation form versus URL support
- track an explicit allowlist of official MCP extensions without retaining extension settings or unknown identifiers
- normalize legacy core task support with the Tasks extension

## validation

- `bun test`
- `bunx tsc --noEmit`
- `bunx prettier --check src/lib/mcp/analytics.ts src/lib/mcp/analytics.test.ts src/app/[transport]/route.ts`
- `bun run build` compiled and passed TypeScript, then stopped during page-data collection because `KERNEL_CLI_PROD_CLIENT_ID` is not available locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only bounded booleans on initialize plus a stricter MCP Apps extension check; no auth or credential handling changes.
> 
> **Overview**
> **$mcp_initialize** events now include **bounded, allow-listed** properties derived from the client’s `initialize` capability map—sampling (and sampling tools), elicitation mode (`none` / `form` / `url` / `form_and_url`), legacy core `tasks`, and a fixed set of official MCP extensions (UI/apps, tasks, OAuth client credentials, enterprise auth). Unknown extension IDs and extension settings are **not** stored; malformed declarations are normalized to safe false/none values.
> 
> Capability parsing is **centralized** in `client-capabilities.ts` and reused by MCP Apps gating so an extension counts only when its entry is an object (e.g. `null` no longer counts as MCP Apps support). Integration tests assert these fields flow through instrumented analytics on initialize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a9dd11421cbc068c49c35335a000e2bc143d5ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->