### PR TITLE
Add feedback reporting tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Many other MCP-capable tools accept:
 
 Configure these values wherever the tool expects MCP server settings.
 
-## Tools (18 model-facing, plus 1 app-only helper)
+## Tools (19 model-facing, plus 1 app-only helper)
 
 Each Kernel feature has a single `manage_*` tool with an `action` parameter, keeping the tool set small and consistent. Standalone tools handle high-frequency and interactive workflows.
 
@@ -288,6 +288,7 @@ Call `get_connection_context` before deciding whether to create or select a proj
 - `execute_playwright_code` - Execute Playwright/TypeScript code against an existing browser session. Does not create or delete browsers - use `manage_browsers` for session lifecycle.
 - `exec_command` - Run shell commands inside a browser VM. Returns decoded stdout/stderr.
 - `search_docs` - Search Kernel platform documentation and guides.
+- `submit_feedback` - send product, mcp, or documentation feedback directly to the KERNEL team without interrupting the current task.
 - `open_auth_login` - Open a secure interactive Managed Auth MCP App after user consent. Registered only for clients that declare MCP Apps support; credentials and MFA never enter MCP/model traffic.
 
 ## Resources

--- a/src/lib/mcp/analytics-context.ts
+++ b/src/lib/mcp/analytics-context.ts
@@ -1,0 +1,6 @@
+export const MCP_INTENT_ARGUMENT_DESCRIPTION =
+  "Why this tool is being called and how it fits the user's overall goal, in 15-25 words, " +
+  "third person. Used for product analytics. Never restate argument values, and never " +
+  "include credentials, tokens, URLs, file contents, or personal data. Example: " +
+  '"Inspecting a running browser session to diagnose a checkout automation that stopped ' +
+  'responding partway through the flow."';

--- a/src/lib/mcp/analytics.test.ts
+++ b/src/lib/mcp/analytics.test.ts
@@ -6,6 +6,7 @@ import {
   MCP_SESSION_HEADER,
   PostHogMCPAnalyticsEvent,
   PostHogMCPAnalyticsProperty,
+  type McpAnalytics,
 } from "@posthog/mcp";
 import {
   captureMcpConnectionScopeFailure,
@@ -555,13 +556,15 @@ describe("captureMcpConnectionScopeFailure", () => {
 });
 
 describe("captureMcpFeedback", () => {
-  test("records feedback with authenticated organization attribution", () => {
+  test("routes redacted feedback through contextual MCP analytics", async () => {
     const captured: unknown[] = [];
-    const fakePosthog = {
-      capture: (event: unknown) => captured.push(event),
-    } as unknown as PostHog;
+    const analytics = {
+      capture: async (event: unknown) => {
+        captured.push(event);
+      },
+    } as McpAnalytics;
 
-    captureMcpFeedback(
+    await captureMcpFeedback(
       {
         summary: "Browser timeout guidance was unclear",
         feedback_type: "product",
@@ -577,29 +580,19 @@ describe("captureMcpFeedback", () => {
       {
         authInfo: {
           extra: {
-            userId: "user_analytics",
             connectionContext: {
               scope: { organizationId: "org_analytics" },
             },
           },
         },
-        requestInfo: {
-          headers: {
-            [MCP_SESSION_HEADER]: encodeSessionId({
-              sessionId: "ses_feedback",
-            }),
-          },
-        },
       },
-      fakePosthog,
+      analytics,
     );
 
     expect(captured).toEqual([
       {
-        distinctId: "ses_feedback",
         event: MCP_FEEDBACK_SUBMITTED_EVENT,
         properties: {
-          $process_person_profile: false,
           $groups: { organization: "org_analytics" },
           feedback_summary: "Browser timeout guidance was unclear",
           feedback_type: "product",
@@ -617,43 +610,37 @@ describe("captureMcpFeedback", () => {
       },
     ]);
   });
-
-  test("does not collapse submissions without transport context", () => {
-    const captured: Array<{ distinctId: string }> = [];
-    const fakePosthog = {
-      capture: (event: { distinctId: string }) => captured.push(event),
-    } as unknown as PostHog;
-    const feedback = {
-      summary: "The docs search result was useful",
-      feedback_type: "docs" as const,
-      sentiment: "positive" as const,
-    };
-
-    captureMcpFeedback(feedback, {}, fakePosthog);
-    captureMcpFeedback(feedback, {}, fakePosthog);
-
-    expect(captured[0].distinctId).toStartWith("ses_");
-    expect(captured[1].distinctId).toStartWith("ses_");
-    expect(captured[0].distinctId).not.toBe(captured[1].distinctId);
-  });
 });
 
 describe("instrumentMcpAnalytics (SDK integration)", () => {
   const ORG = "org_integration";
 
-  test("keeps the feedback tool available when analytics is disabled", async () => {
-    const { client, close } = await connectTestMcp(
+  test("keeps the feedback tool schema stable when analytics is disabled", async () => {
+    const disabled = await connectTestMcp(
       (server) => instrumentMcpAnalytics(server, null),
+      {},
+    );
+    const enabled = await connectTestMcp(
+      (server) =>
+        instrumentMcpAnalytics(server, {
+          capture: () => undefined,
+        } as unknown as PostHog),
       {},
     );
 
     try {
-      const tools = await client.listTools();
-      expect(tools.tools.map(({ name }) => name)).toContain(
-        KERNEL_FEEDBACK_TOOL_NAME,
+      const disabledTool = (await disabled.client.listTools()).tools.find(
+        ({ name }) => name === KERNEL_FEEDBACK_TOOL_NAME,
       );
+      const enabledTool = (await enabled.client.listTools()).tools.find(
+        ({ name }) => name === KERNEL_FEEDBACK_TOOL_NAME,
+      );
+      expect(disabledTool).toBeDefined();
+      expect(disabledTool?.inputSchema).toEqual(enabledTool?.inputSchema);
+      expect(disabledTool?.inputSchema.required).toContain("context");
     } finally {
-      await close();
+      await disabled.close();
+      await enabled.close();
     }
   });
 
@@ -687,7 +674,16 @@ describe("instrumentMcpAnalytics (SDK integration)", () => {
         extra: { connectionContext: { scope: { organizationId: ORG } } },
       },
       signal: new AbortController().signal,
-      requestInfo: { headers: {} },
+      requestInfo: {
+        headers: {
+          [MCP_SESSION_HEADER]: encodeSessionId({
+            sessionId: "ses_integration",
+            clientName: "test-client",
+            clientVersion: "0.0.0",
+            protocolVersion: "2025-03-26",
+          }),
+        },
+      },
     };
     const handlers = (
       server.server as unknown as {
@@ -761,6 +757,51 @@ describe("instrumentMcpAnalytics (SDK integration)", () => {
 
     // identify stays unwired, so no $identify event is ever published.
     expect(byEvent.has("$identify")).toBe(false);
+  });
+
+  test("captures feedback with the surrounding MCP session metadata", async () => {
+    const captured: { event?: string }[] = [];
+
+    await simulateRequest(captured, "tools/call", {
+      name: KERNEL_FEEDBACK_TOOL_NAME,
+      arguments: {
+        context:
+          "Reporting that browser timeout guidance did not explain when the caller should retry.",
+        summary: "Browser timeout guidance was unclear",
+        feedback_type: "product",
+        sentiment: "mixed",
+        product_area: "browsers",
+      },
+    });
+
+    const feedback = captured.find(
+      ({ event }) => event === MCP_FEEDBACK_SUBMITTED_EVENT,
+    ) as { distinctId: string; properties: Record<string, unknown> };
+    const toolCall = captured.find(
+      ({ event }) => event === "$mcp_tool_call",
+    ) as {
+      distinctId: string;
+      properties: Record<string, unknown>;
+    };
+
+    expect(feedback.distinctId).toBe("ses_integration");
+    expect(feedback.distinctId).toBe(toolCall.distinctId);
+    expect(feedback.properties).toMatchObject({
+      $groups: { organization: ORG },
+      [PostHogMCPAnalyticsProperty.SessionId]: "ses_integration",
+      [PostHogMCPAnalyticsProperty.ClientName]: "test-client",
+      [PostHogMCPAnalyticsProperty.ClientVersion]: "0.0.0",
+      [PostHogMCPAnalyticsProperty.ProtocolVersion]: "2025-03-26",
+      [PostHogMCPAnalyticsProperty.ServerName]: "test",
+      [PostHogMCPAnalyticsProperty.ServerVersion]: "0.0.0",
+      feedback_summary: "Browser timeout guidance was unclear",
+      feedback_type: "product",
+      feedback_sentiment: "mixed",
+      feedback_product_area: "browsers",
+    });
+    expect(toolCall.properties[PostHogMCPAnalyticsProperty.Intent]).toBe(
+      "Reporting that browser timeout guidance did not explain when the caller should retry.",
+    );
   });
 
   test("stays anonymous when no connection context is attached", async () => {

--- a/src/lib/mcp/analytics.test.ts
+++ b/src/lib/mcp/analytics.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@posthog/mcp";
 import {
   captureMcpConnectionScopeFailure,
+  captureMcpFeedback,
   captureOAuthTokenExchange,
   clientCapabilityAnalyticsFromInitialize,
   enrichMcpAnalyticsEvent,
@@ -19,11 +20,14 @@ import {
   MCP_CLIENT_SUPPORTS_SAMPLING_TOOLS_PROPERTY,
   MCP_CLIENT_SUPPORTS_TASKS_PROPERTY,
   MCP_CONNECTION_SCOPE_FAILURE_EVENT,
+  MCP_FEEDBACK_SUBMITTED_EVENT,
   MCP_USED_PROJECT_ID_PROPERTY,
   MCP_USED_PROJECT_PROPERTY,
   OAUTH_TOKEN_EXCHANGE_EVENT,
   sanitizeMcpAnalyticsEvent,
 } from "@/lib/mcp/analytics";
+import { connectTestMcp } from "@/lib/mcp/mcp-test-fixtures";
+import { KERNEL_FEEDBACK_TOOL_NAME } from "@/lib/mcp/tools/feedback";
 
 const privateContextProperty = "__mcp_connection_analytics_context";
 
@@ -548,8 +552,82 @@ describe("captureMcpConnectionScopeFailure", () => {
   });
 });
 
+describe("captureMcpFeedback", () => {
+  test("records feedback with authenticated organization attribution", () => {
+    const captured: unknown[] = [];
+    const fakePosthog = {
+      capture: (event: unknown) => captured.push(event),
+    } as unknown as PostHog;
+
+    captureMcpFeedback(
+      {
+        summary: "Browser timeout guidance was unclear",
+        feedback_type: "product",
+        sentiment: "mixed",
+        product_area: "browsers",
+        task_completed: true,
+        tools_used: ["manage_browsers"],
+        friction_points: "- The response did not say when to retry.",
+        suggested_improvement: "Include a retry interval in the response.",
+        details:
+          "The error linked to https://example.com/support for user@example.com.",
+      },
+      {
+        authInfo: {
+          extra: {
+            userId: "user_analytics",
+            connectionContext: {
+              scope: { organizationId: "org_analytics" },
+            },
+          },
+        },
+      },
+      fakePosthog,
+    );
+
+    expect(captured).toEqual([
+      {
+        distinctId: "user_analytics",
+        event: MCP_FEEDBACK_SUBMITTED_EVENT,
+        properties: {
+          $process_person_profile: false,
+          $groups: { organization: "org_analytics" },
+          feedback_summary: "Browser timeout guidance was unclear",
+          feedback_type: "product",
+          feedback_sentiment: "mixed",
+          feedback_product_area: "browsers",
+          feedback_category: undefined,
+          feedback_task_completed: true,
+          feedback_tools_used: ["manage_browsers"],
+          feedback_friction_points: "- The response did not say when to retry.",
+          feedback_suggested_improvement:
+            "Include a retry interval in the response.",
+          feedback_user_request: undefined,
+          feedback_details: "The error linked to [url] for [email]",
+        },
+      },
+    ]);
+  });
+});
+
 describe("instrumentMcpAnalytics (SDK integration)", () => {
   const ORG = "org_integration";
+
+  test("keeps the feedback tool available when analytics is disabled", async () => {
+    const { client, close } = await connectTestMcp(
+      (server) => instrumentMcpAnalytics(server, null),
+      {},
+    );
+
+    try {
+      const tools = await client.listTools();
+      expect(tools.tools.map(({ name }) => name)).toContain(
+        KERNEL_FEEDBACK_TOOL_NAME,
+      );
+    } finally {
+      await close();
+    }
+  });
 
   // mcp-handler builds a fresh McpServer per HTTP request, so each simulated request
   // gets its own instrumented server and the SDK's per-session identity cache starts

--- a/src/lib/mcp/analytics.test.ts
+++ b/src/lib/mcp/analytics.test.ts
@@ -29,7 +29,7 @@ import {
   OAUTH_TOKEN_EXCHANGE_EVENT,
   sanitizeMcpAnalyticsEvent,
 } from "@/lib/mcp/analytics";
-import { connectTestMcp } from "@/lib/mcp/mcp-test-fixtures";
+import { connectTestMcp, toolResultJSON } from "@/lib/mcp/mcp-test-fixtures";
 import { KERNEL_FEEDBACK_TOOL_NAME } from "@/lib/mcp/tools/feedback";
 
 const privateContextProperty = "__mcp_connection_analytics_context";
@@ -638,6 +638,21 @@ describe("instrumentMcpAnalytics (SDK integration)", () => {
       expect(disabledTool).toBeDefined();
       expect(disabledTool?.inputSchema).toEqual(enabledTool?.inputSchema);
       expect(disabledTool?.inputSchema.required).toContain("context");
+
+      const result = await disabled.client.callTool({
+        name: KERNEL_FEEDBACK_TOOL_NAME,
+        arguments: {
+          context:
+            "Reporting product feedback while analytics delivery is unavailable for this server instance.",
+          summary: "Feedback analytics are unavailable",
+          feedback_type: "mcp",
+          sentiment: "negative",
+        },
+      });
+      expect(toolResultJSON(result)).toMatchObject({
+        recorded: false,
+        status: "unavailable",
+      });
     } finally {
       await disabled.close();
       await enabled.close();

--- a/src/lib/mcp/analytics.test.ts
+++ b/src/lib/mcp/analytics.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { PostHog } from "posthog-node";
 import {
+  encodeSessionId,
+  MCP_SESSION_HEADER,
   PostHogMCPAnalyticsEvent,
   PostHogMCPAnalyticsProperty,
 } from "@posthog/mcp";
@@ -581,13 +583,20 @@ describe("captureMcpFeedback", () => {
             },
           },
         },
+        requestInfo: {
+          headers: {
+            [MCP_SESSION_HEADER]: encodeSessionId({
+              sessionId: "ses_feedback",
+            }),
+          },
+        },
       },
       fakePosthog,
     );
 
     expect(captured).toEqual([
       {
-        distinctId: "user_analytics",
+        distinctId: "ses_feedback",
         event: MCP_FEEDBACK_SUBMITTED_EVENT,
         properties: {
           $process_person_profile: false,
@@ -607,6 +616,25 @@ describe("captureMcpFeedback", () => {
         },
       },
     ]);
+  });
+
+  test("does not collapse submissions without transport context", () => {
+    const captured: Array<{ distinctId: string }> = [];
+    const fakePosthog = {
+      capture: (event: { distinctId: string }) => captured.push(event),
+    } as unknown as PostHog;
+    const feedback = {
+      summary: "The docs search result was useful",
+      feedback_type: "docs" as const,
+      sentiment: "positive" as const,
+    };
+
+    captureMcpFeedback(feedback, {}, fakePosthog);
+    captureMcpFeedback(feedback, {}, fakePosthog);
+
+    expect(captured[0].distinctId).toStartWith("ses_");
+    expect(captured[1].distinctId).toStartWith("ses_");
+    expect(captured[0].distinctId).not.toBe(captured[1].distinctId);
   });
 });
 

--- a/src/lib/mcp/analytics.ts
+++ b/src/lib/mcp/analytics.ts
@@ -13,6 +13,10 @@ import type {
   McpConnectionContext,
 } from "@/lib/mcp/auth-context";
 import {
+  type KernelFeedback,
+  registerFeedbackTool,
+} from "@/lib/mcp/tools/feedback";
+import {
   clientDeclaresExtension,
   clientElicitationModes,
   initializeClientCapabilities,
@@ -60,6 +64,7 @@ export type McpConnectionScopeFailureAnalytics = {
 
 export const MCP_CONNECTION_SCOPE_FAILURE_EVENT =
   "mcp_connection_scope_failure";
+export const MCP_FEEDBACK_SUBMITTED_EVENT = "mcp_feedback_submitted";
 
 if (!projectToken && process.env.NODE_ENV !== "production") {
   console.error(
@@ -262,13 +267,16 @@ function annotateProjectParamUsage(properties: Record<string, unknown>) {
   properties[MCP_USED_PROJECT_PROPERTY] = hasNonEmptyParam(args, "project");
 }
 
-function sanitizeIntent(intent: string) {
-  const redacted = INTENT_REDACTIONS.reduce(
-    (text, [pattern, replacement]) => text.replace(pattern, replacement),
-    intent.trim(),
+function redactAnalyticsText(text: string) {
+  return INTENT_REDACTIONS.reduce(
+    (redacted, [pattern, replacement]) =>
+      redacted.replace(pattern, replacement),
+    text.trim(),
   );
+}
 
-  return redacted.slice(0, INTENT_MAX_LENGTH);
+function sanitizeIntent(intent: string) {
+  return redactAnalyticsText(intent).slice(0, INTENT_MAX_LENGTH);
 }
 
 // Must stay the SDK's default name: reportMissing advertises a tool under this name and
@@ -355,11 +363,7 @@ export const sanitizeMcpAnalyticsEvent: BeforeSendFn = (event) => {
   return event;
 };
 
-/**
- * Captures every tool call, tools/list, and initialize handled by the server as a
- * `$mcp_*` PostHog event, and advertises the tool agents use to report a capability the
- * server doesn't have. No-op when POSTHOG_PROJECT_TOKEN is unset.
- */
+/** Extracts the analytics identity resolved during MCP authentication. */
 function connectionAnalyticsContext(extra: unknown) {
   const authInfo = (extra as { authInfo?: { extra?: unknown } } | undefined)
     ?.authInfo;
@@ -379,6 +383,15 @@ function connectionOrgId(extra: unknown) {
     | { connectionContext?: McpConnectionContext | null }
     | undefined;
   return authExtra?.connectionContext?.scope.organizationId;
+}
+
+function connectionUserId(extra: unknown) {
+  const authInfo = (extra as { authInfo?: { extra?: unknown } } | undefined)
+    ?.authInfo;
+  const authExtra = authInfo?.extra as { userId?: unknown } | undefined;
+  return typeof authExtra?.userId === "string" && authExtra.userId
+    ? authExtra.userId
+    : undefined;
 }
 
 export function enrichMcpAnalyticsEvent(event: {
@@ -486,11 +499,61 @@ export function captureMcpConnectionScopeFailure(
   }
 }
 
+export function captureMcpFeedback(
+  feedback: KernelFeedback,
+  extra: unknown,
+  client: PostHog | null = posthog,
+) {
+  if (!client) return;
+
+  const organizationId = connectionOrgId(extra);
+  const userId = connectionUserId(extra);
+
+  client.capture({
+    distinctId: userId ?? "mcp-feedback",
+    event: MCP_FEEDBACK_SUBMITTED_EVENT,
+    properties: {
+      $process_person_profile: false,
+      ...(organizationId && { $groups: { organization: organizationId } }),
+      feedback_summary: redactAnalyticsText(feedback.summary),
+      feedback_type: feedback.feedback_type,
+      feedback_sentiment: feedback.sentiment,
+      feedback_product_area: feedback.product_area
+        ? redactAnalyticsText(feedback.product_area)
+        : undefined,
+      feedback_category: feedback.category,
+      feedback_task_completed: feedback.task_completed,
+      feedback_tools_used: feedback.tools_used?.map(redactAnalyticsText),
+      feedback_friction_points: feedback.friction_points
+        ? redactAnalyticsText(feedback.friction_points)
+        : undefined,
+      feedback_suggested_improvement: feedback.suggested_improvement
+        ? redactAnalyticsText(feedback.suggested_improvement)
+        : undefined,
+      feedback_user_request: feedback.user_request
+        ? redactAnalyticsText(feedback.user_request)
+        : undefined,
+      feedback_details: feedback.details
+        ? redactAnalyticsText(feedback.details)
+        : undefined,
+    },
+  });
+}
+
+/**
+ * Captures MCP protocol analytics and registers the analytics-backed reporting tools.
+ * Feedback remains available when analytics is disabled so the tool contract is stable.
+ */
 export function instrumentMcpAnalytics(
   server: McpServer,
   client: PostHog | null = posthog,
 ) {
-  if (!client) return;
+  const captureFeedback = (feedback: KernelFeedback, extra: unknown) =>
+    captureMcpFeedback(feedback, extra, client);
+  if (!client) {
+    registerFeedbackTool(server, captureFeedback);
+    return;
+  }
 
   instrument(server, client, {
     // Records a `$mcp_missing_capability` event, carrying the reported gap as $mcp_intent,
@@ -541,6 +604,7 @@ export function instrumentMcpAnalytics(
   });
 
   registerMissingCapabilityTool(server);
+  registerFeedbackTool(server, captureFeedback);
 }
 
 /**

--- a/src/lib/mcp/analytics.ts
+++ b/src/lib/mcp/analytics.ts
@@ -1,6 +1,10 @@
 import {
+  decodeSessionId,
+  deriveSessionIdFromMCPSession,
   getMoreToolsResult,
   instrument,
+  MCP_SESSION_HEADER,
+  newSessionId,
   PostHogMCPAnalyticsEvent,
   PostHogMCPAnalyticsProperty,
   type BeforeSendFn,
@@ -385,13 +389,25 @@ function connectionOrgId(extra: unknown) {
   return authExtra?.connectionContext?.scope.organizationId;
 }
 
-function connectionUserId(extra: unknown) {
-  const authInfo = (extra as { authInfo?: { extra?: unknown } } | undefined)
-    ?.authInfo;
-  const authExtra = authInfo?.extra as { userId?: unknown } | undefined;
-  return typeof authExtra?.userId === "string" && authExtra.userId
-    ? authExtra.userId
-    : undefined;
+function connectionSessionId(extra: unknown) {
+  const requestExtra = extra as
+    | { requestInfo?: { headers?: unknown }; sessionId?: unknown }
+    | undefined;
+  const headers = requestExtra?.requestInfo?.headers;
+  if (headers && typeof headers === "object") {
+    const record = headers as Record<string, unknown>;
+    const key = Object.keys(record).find(
+      (candidate) => candidate.toLowerCase() === MCP_SESSION_HEADER,
+    );
+    const value = key ? record[key] : undefined;
+    const token = Array.isArray(value) ? value[0] : value;
+    const decoded = decodeSessionId(token);
+    if (decoded) return decoded.sessionId;
+  }
+
+  return typeof requestExtra?.sessionId === "string" && requestExtra.sessionId
+    ? deriveSessionIdFromMCPSession(requestExtra.sessionId)
+    : newSessionId();
 }
 
 export function enrichMcpAnalyticsEvent(event: {
@@ -507,10 +523,9 @@ export function captureMcpFeedback(
   if (!client) return;
 
   const organizationId = connectionOrgId(extra);
-  const userId = connectionUserId(extra);
 
   client.capture({
-    distinctId: userId ?? "mcp-feedback",
+    distinctId: connectionSessionId(extra),
     event: MCP_FEEDBACK_SUBMITTED_EVENT,
     properties: {
       $process_person_profile: false,

--- a/src/lib/mcp/analytics.ts
+++ b/src/lib/mcp/analytics.ts
@@ -1,13 +1,10 @@
 import {
-  decodeSessionId,
-  deriveSessionIdFromMCPSession,
   getMoreToolsResult,
   instrument,
-  MCP_SESSION_HEADER,
-  newSessionId,
   PostHogMCPAnalyticsEvent,
   PostHogMCPAnalyticsProperty,
   type BeforeSendFn,
+  type McpAnalytics,
 } from "@posthog/mcp";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { PostHog } from "posthog-node";
@@ -16,6 +13,7 @@ import type {
   McpConnectionAnalyticsContext,
   McpConnectionContext,
 } from "@/lib/mcp/auth-context";
+import { MCP_INTENT_ARGUMENT_DESCRIPTION } from "@/lib/mcp/analytics-context";
 import {
   type KernelFeedback,
   registerFeedbackTool,
@@ -162,14 +160,18 @@ const SENT_PROPERTIES = new Set<string>([
   PostHogMCPAnalyticsProperty.ToolCategory,
   PostHogMCPAnalyticsProperty.ToolDescription,
   PostHogMCPAnalyticsProperty.ToolName,
+  "feedback_summary",
+  "feedback_type",
+  "feedback_sentiment",
+  "feedback_product_area",
+  "feedback_category",
+  "feedback_task_completed",
+  "feedback_tools_used",
+  "feedback_friction_points",
+  "feedback_suggested_improvement",
+  "feedback_user_request",
+  "feedback_details",
 ]);
-
-const INTENT_ARGUMENT_DESCRIPTION =
-  "Why this tool is being called and how it fits the user's overall goal, in 15-25 words, " +
-  "third person. Used for product analytics. Never restate argument values, and never " +
-  "include credentials, tokens, URLs, file contents, or personal data. Example: " +
-  '"Inspecting a running browser session to diagnose a checkout automation that stopped ' +
-  'responding partway through the flow."';
 
 // Intent is the only free-form text this captures, and an agent writes it. Long enough for
 // the 15-25 words asked for, short enough that a client ignoring the instruction can't
@@ -389,25 +391,20 @@ function connectionOrgId(extra: unknown) {
   return authExtra?.connectionContext?.scope.organizationId;
 }
 
-function connectionSessionId(extra: unknown) {
-  const requestExtra = extra as
-    | { requestInfo?: { headers?: unknown }; sessionId?: unknown }
-    | undefined;
-  const headers = requestExtra?.requestInfo?.headers;
-  if (headers && typeof headers === "object") {
-    const record = headers as Record<string, unknown>;
-    const key = Object.keys(record).find(
-      (candidate) => candidate.toLowerCase() === MCP_SESSION_HEADER,
-    );
-    const value = key ? record[key] : undefined;
-    const token = Array.isArray(value) ? value[0] : value;
-    const decoded = decodeSessionId(token);
-    if (decoded) return decoded.sessionId;
-  }
-
-  return typeof requestExtra?.sessionId === "string" && requestExtra.sessionId
-    ? deriveSessionIdFromMCPSession(requestExtra.sessionId)
-    : newSessionId();
+export function captureMcpCustomEvent(
+  analytics: McpAnalytics,
+  extra: unknown,
+  event: string,
+  properties: Record<string, unknown>,
+) {
+  const organizationId = connectionOrgId(extra);
+  return analytics.capture({
+    event,
+    properties: {
+      ...properties,
+      ...(organizationId && { $groups: { organization: organizationId } }),
+    },
+  });
 }
 
 export function enrichMcpAnalyticsEvent(event: {
@@ -518,40 +515,30 @@ export function captureMcpConnectionScopeFailure(
 export function captureMcpFeedback(
   feedback: KernelFeedback,
   extra: unknown,
-  client: PostHog | null = posthog,
+  analytics: McpAnalytics,
 ) {
-  if (!client) return;
-
-  const organizationId = connectionOrgId(extra);
-
-  client.capture({
-    distinctId: connectionSessionId(extra),
-    event: MCP_FEEDBACK_SUBMITTED_EVENT,
-    properties: {
-      $process_person_profile: false,
-      ...(organizationId && { $groups: { organization: organizationId } }),
-      feedback_summary: redactAnalyticsText(feedback.summary),
-      feedback_type: feedback.feedback_type,
-      feedback_sentiment: feedback.sentiment,
-      feedback_product_area: feedback.product_area
-        ? redactAnalyticsText(feedback.product_area)
-        : undefined,
-      feedback_category: feedback.category,
-      feedback_task_completed: feedback.task_completed,
-      feedback_tools_used: feedback.tools_used?.map(redactAnalyticsText),
-      feedback_friction_points: feedback.friction_points
-        ? redactAnalyticsText(feedback.friction_points)
-        : undefined,
-      feedback_suggested_improvement: feedback.suggested_improvement
-        ? redactAnalyticsText(feedback.suggested_improvement)
-        : undefined,
-      feedback_user_request: feedback.user_request
-        ? redactAnalyticsText(feedback.user_request)
-        : undefined,
-      feedback_details: feedback.details
-        ? redactAnalyticsText(feedback.details)
-        : undefined,
-    },
+  return captureMcpCustomEvent(analytics, extra, MCP_FEEDBACK_SUBMITTED_EVENT, {
+    feedback_summary: redactAnalyticsText(feedback.summary),
+    feedback_type: feedback.feedback_type,
+    feedback_sentiment: feedback.sentiment,
+    feedback_product_area: feedback.product_area
+      ? redactAnalyticsText(feedback.product_area)
+      : undefined,
+    feedback_category: feedback.category,
+    feedback_task_completed: feedback.task_completed,
+    feedback_tools_used: feedback.tools_used?.map(redactAnalyticsText),
+    feedback_friction_points: feedback.friction_points
+      ? redactAnalyticsText(feedback.friction_points)
+      : undefined,
+    feedback_suggested_improvement: feedback.suggested_improvement
+      ? redactAnalyticsText(feedback.suggested_improvement)
+      : undefined,
+    feedback_user_request: feedback.user_request
+      ? redactAnalyticsText(feedback.user_request)
+      : undefined,
+    feedback_details: feedback.details
+      ? redactAnalyticsText(feedback.details)
+      : undefined,
   });
 }
 
@@ -563,14 +550,12 @@ export function instrumentMcpAnalytics(
   server: McpServer,
   client: PostHog | null = posthog,
 ) {
-  const captureFeedback = (feedback: KernelFeedback, extra: unknown) =>
-    captureMcpFeedback(feedback, extra, client);
   if (!client) {
-    registerFeedbackTool(server, captureFeedback);
+    registerFeedbackTool(server, () => undefined);
     return;
   }
 
-  instrument(server, client, {
+  const analytics = instrument(server, client, {
     // Records a `$mcp_missing_capability` event, carrying the reported gap as $mcp_intent,
     // when an agent calls the tool registered by registerMissingCapabilityTool.
     reportMissing: true,
@@ -579,7 +564,7 @@ export function instrumentMcpAnalytics(
     // with why it is making the call. Recorded as $mcp_intent. The description replaces
     // the SDK default: it repeats per tool in every tools/list response, so it stays
     // short, and it names the arguments agents must not copy into it.
-    context: { description: INTENT_ARGUMENT_DESCRIPTION },
+    context: { description: MCP_INTENT_ARGUMENT_DESCRIPTION },
     // A failed tool call otherwise fans out into a second `$exception` event whose
     // `$exception_list` is built from the text the tool returned.
     enableExceptionAutocapture: false,
@@ -619,7 +604,9 @@ export function instrumentMcpAnalytics(
   });
 
   registerMissingCapabilityTool(server);
-  registerFeedbackTool(server, captureFeedback);
+  registerFeedbackTool(server, (feedback, extra) =>
+    captureMcpFeedback(feedback, extra, analytics),
+  );
 }
 
 /**

--- a/src/lib/mcp/analytics.ts
+++ b/src/lib/mcp/analytics.ts
@@ -551,7 +551,7 @@ export function instrumentMcpAnalytics(
   client: PostHog | null = posthog,
 ) {
   if (!client) {
-    registerFeedbackTool(server, () => undefined);
+    registerFeedbackTool(server);
     return;
   }
 

--- a/src/lib/mcp/tools/feedback.test.ts
+++ b/src/lib/mcp/tools/feedback.test.ts
@@ -23,6 +23,7 @@ describe("submit_feedback", () => {
         ({ name }) => name === KERNEL_FEEDBACK_TOOL_NAME,
       );
       expect(tool?.title).toBe("submit KERNEL feedback");
+      expect(tool?.annotations?.readOnlyHint).toBe(false);
       expect(tool?.inputSchema.required).toEqual([
         "context",
         "summary",
@@ -48,7 +49,8 @@ describe("submit_feedback", () => {
       });
 
       expect(toolResultJSON(result)).toMatchObject({
-        received: true,
+        recorded: true,
+        status: "recorded",
         summary: "Browser creation needs clearer timeout guidance",
         feedback_type: "product",
         sentiment: "mixed",
@@ -93,8 +95,39 @@ describe("submit_feedback", () => {
       });
 
       expect(toolResultJSON(result)).toMatchObject({
-        received: true,
+        recorded: false,
+        status: "failed",
         summary: "The MCP response was easy to use",
+        message: expect.stringContaining("was not recorded"),
+      });
+    } finally {
+      await close();
+    }
+  });
+
+  test("reports when feedback analytics are unavailable", async () => {
+    const { client, close } = await connectTestMcp(
+      (server) => registerFeedbackTool(server),
+      {},
+    );
+
+    try {
+      const result = await client.callTool({
+        name: KERNEL_FEEDBACK_TOOL_NAME,
+        arguments: {
+          context:
+            "Reporting product feedback while analytics delivery is unavailable for this server instance.",
+          summary: "Browser feedback could not be delivered",
+          feedback_type: "product",
+          sentiment: "negative",
+        },
+      });
+
+      expect(toolResultJSON(result)).toMatchObject({
+        recorded: false,
+        status: "unavailable",
+        summary: "Browser feedback could not be delivered",
+        message: expect.stringContaining("was not recorded"),
       });
     } finally {
       await close();

--- a/src/lib/mcp/tools/feedback.test.ts
+++ b/src/lib/mcp/tools/feedback.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { connectTestMcp, toolResultJSON } from "@/lib/mcp/mcp-test-fixtures";
+import {
+  KERNEL_FEEDBACK_TOOL_NAME,
+  type KernelFeedback,
+  registerFeedbackTool,
+} from "@/lib/mcp/tools/feedback";
+
+describe("submit_feedback", () => {
+  test("advertises the feedback schema and records a submission", async () => {
+    const captured: KernelFeedback[] = [];
+    const { client, close } = await connectTestMcp(
+      (server) =>
+        registerFeedbackTool(server, (feedback) => {
+          captured.push(feedback);
+        }),
+      {},
+    );
+
+    try {
+      const tools = await client.listTools();
+      const tool = tools.tools.find(
+        ({ name }) => name === KERNEL_FEEDBACK_TOOL_NAME,
+      );
+      expect(tool?.title).toBe("submit KERNEL feedback");
+      expect(tool?.inputSchema.required).toEqual([
+        "summary",
+        "feedback_type",
+        "sentiment",
+      ]);
+
+      const result = await client.callTool({
+        name: KERNEL_FEEDBACK_TOOL_NAME,
+        arguments: {
+          summary: "Browser creation needs clearer timeout guidance",
+          feedback_type: "product",
+          sentiment: "mixed",
+          product_area: "browsers",
+          friction_points: "- The timeout response did not suggest a retry.",
+          suggested_improvement:
+            "Include retry timing in browser creation timeout responses.",
+          task_completed: true,
+          tools_used: ["manage_browsers"],
+        },
+      });
+
+      expect(toolResultJSON(result)).toMatchObject({
+        received: true,
+        summary: "Browser creation needs clearer timeout guidance",
+        feedback_type: "product",
+        sentiment: "mixed",
+      });
+      expect(captured).toEqual([
+        {
+          summary: "Browser creation needs clearer timeout guidance",
+          feedback_type: "product",
+          sentiment: "mixed",
+          product_area: "browsers",
+          friction_points: "- The timeout response did not suggest a retry.",
+          suggested_improvement:
+            "Include retry timing in browser creation timeout responses.",
+          task_completed: true,
+          tools_used: ["manage_browsers"],
+        },
+      ]);
+    } finally {
+      await close();
+    }
+  });
+
+  test("keeps analytics failures from failing the tool call", async () => {
+    const { client, close } = await connectTestMcp(
+      (server) =>
+        registerFeedbackTool(server, () => {
+          throw new Error("analytics unavailable");
+        }),
+      {},
+    );
+
+    try {
+      const result = await client.callTool({
+        name: KERNEL_FEEDBACK_TOOL_NAME,
+        arguments: {
+          summary: "The MCP response was easy to use",
+          feedback_type: "mcp",
+          sentiment: "positive",
+        },
+      });
+
+      expect(toolResultJSON(result)).toMatchObject({
+        received: true,
+        summary: "The MCP response was easy to use",
+      });
+    } finally {
+      await close();
+    }
+  });
+});

--- a/src/lib/mcp/tools/feedback.test.ts
+++ b/src/lib/mcp/tools/feedback.test.ts
@@ -24,6 +24,7 @@ describe("submit_feedback", () => {
       );
       expect(tool?.title).toBe("submit KERNEL feedback");
       expect(tool?.inputSchema.required).toEqual([
+        "context",
         "summary",
         "feedback_type",
         "sentiment",
@@ -32,6 +33,8 @@ describe("submit_feedback", () => {
       const result = await client.callTool({
         name: KERNEL_FEEDBACK_TOOL_NAME,
         arguments: {
+          context:
+            "Reporting that browser creation timeout responses did not explain when callers should retry.",
           summary: "Browser creation needs clearer timeout guidance",
           feedback_type: "product",
           sentiment: "mixed",
@@ -81,6 +84,8 @@ describe("submit_feedback", () => {
       const result = await client.callTool({
         name: KERNEL_FEEDBACK_TOOL_NAME,
         arguments: {
+          context:
+            "Reporting that the MCP response directly supported the user's task without additional parsing.",
           summary: "The MCP response was easy to use",
           feedback_type: "mcp",
           sentiment: "positive",

--- a/src/lib/mcp/tools/feedback.ts
+++ b/src/lib/mcp/tools/feedback.ts
@@ -1,10 +1,12 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { MCP_INTENT_ARGUMENT_DESCRIPTION } from "@/lib/mcp/analytics-context";
 import { jsonResponse } from "@/lib/mcp/responses";
 
 export const KERNEL_FEEDBACK_TOOL_NAME = "submit_feedback";
 
 const feedbackFields = {
+  context: z.string().describe(MCP_INTENT_ARGUMENT_DESCRIPTION),
   summary: z
     .string()
     .trim()
@@ -99,7 +101,10 @@ const feedbackFields = {
     ),
 };
 
-export type KernelFeedback = z.infer<z.ZodObject<typeof feedbackFields>>;
+export type KernelFeedback = Omit<
+  z.infer<z.ZodObject<typeof feedbackFields>>,
+  "context"
+>;
 export type KernelFeedbackCapture = (
   feedback: KernelFeedback,
   extra: unknown,
@@ -129,7 +134,7 @@ export function registerFeedbackTool(
         openWorldHint: false,
       },
     },
-    async (feedback, extra) => {
+    async ({ context: _context, ...feedback }, extra) => {
       try {
         await capture(feedback, extra);
       } catch {

--- a/src/lib/mcp/tools/feedback.ts
+++ b/src/lib/mcp/tools/feedback.ts
@@ -1,0 +1,148 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { jsonResponse } from "@/lib/mcp/responses";
+
+export const KERNEL_FEEDBACK_TOOL_NAME = "submit_feedback";
+
+const feedbackFields = {
+  summary: z
+    .string()
+    .trim()
+    .min(1)
+    .max(300)
+    .describe(
+      'a one-sentence headline capturing the feedback (e.g. "browser creation timed out without recovery guidance", "manage_browsers returned exactly the context needed", or "the proxy docs need a residential example").',
+    ),
+  feedback_type: z
+    .enum(["product", "mcp", "docs", "other"])
+    .describe(
+      'what this feedback is about. "product" = any KERNEL product or feature, such as browsers, apps, profiles, proxies, browser pools, replays, telemetry, managed auth, credentials, extensions, projects, or api keys. "mcp" = this mcp server itself, including a tool, input schema, response format, error, or its instructions. "docs" = KERNEL documentation. "other" = anything that does not fit the other types.',
+    ),
+  sentiment: z
+    .enum(["positive", "neutral", "negative", "mixed"])
+    .describe(
+      'the overall tone. use "negative" for something broken or blocking, "mixed" for mostly fine with a concrete problem, "neutral" for a suggestion or feature request with no strong sentiment, and "positive" for praise or something that worked well. all sentiments are welcome.',
+    ),
+  product_area: z
+    .string()
+    .trim()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe(
+      'the KERNEL product or area this is about, in free text (e.g. "browsers", "apps", "managed auth", "browser pools", "proxies", or "telemetry"). most useful for product feedback; for mcp feedback put the tool name in `details` or `friction_points` instead.',
+    ),
+  category: z
+    .enum([
+      "tool_correctness",
+      "tool_description",
+      "tool_input_schema",
+      "tool_output_format",
+      "missing_tool",
+      "instructions_clarity",
+      "performance",
+      "error_message",
+      "other",
+    ])
+    .optional()
+    .describe(
+      'for mcp feedback (`feedback_type: "mcp"`) only: the single category that best describes the dominant theme. use "missing_tool" when a capability is absent, "tool_description" when tool documentation is unclear, "tool_input_schema" when arguments are confusing, "tool_output_format" when a response is hard to consume, "instructions_clarity" when mcp instructions are unclear, "tool_correctness" when a tool returns wrong data, "error_message" when an error is unhelpful, and "performance" when latency is the issue. omit for product, docs, or other feedback.',
+    ),
+  task_completed: z
+    .boolean()
+    .optional()
+    .describe(
+      'whether the user\'s task was completed. be honest: `false` is useful signal. most relevant when `feedback_type` is "mcp".',
+    ),
+  tools_used: z
+    .array(z.string().trim().min(1).max(100))
+    .max(50)
+    .optional()
+    .describe(
+      'the mcp tool names called while working on the user\'s task (e.g. ["manage_browsers", "execute_playwright_code"]).',
+    ),
+  friction_points: z
+    .string()
+    .trim()
+    .min(1)
+    .max(5000)
+    .optional()
+    .describe(
+      "clear, concise bullet points describing what was confusing, broken, slow, or missing. quote the exact product surface, tool name, parameter, or error text when possible. omit for purely positive feedback.",
+    ),
+  suggested_improvement: z
+    .string()
+    .trim()
+    .min(1)
+    .max(3000)
+    .optional()
+    .describe(
+      "the single most impactful, concrete change that would address this feedback, when one can be named. optional for praise or observations.",
+    ),
+  user_request: z
+    .string()
+    .trim()
+    .min(1)
+    .max(1000)
+    .optional()
+    .describe(
+      "a short, anonymized paraphrase of what the user originally asked. do not include personal data, customer or account names, target urls, or sensitive browser content.",
+    ),
+  details: z
+    .string()
+    .trim()
+    .min(1)
+    .max(5000)
+    .optional()
+    .describe(
+      "additional context that does not fit the other fields. keep it to clear, concise bullet points.",
+    ),
+};
+
+export type KernelFeedback = z.infer<z.ZodObject<typeof feedbackFields>>;
+export type KernelFeedbackCapture = (
+  feedback: KernelFeedback,
+  extra: unknown,
+) => void | Promise<void>;
+
+const TOOL_DESCRIPTION =
+  "send feedback about anything KERNEL to the KERNEL team. set `feedback_type` to route it: `product` for any KERNEL product or feature, `mcp` for this mcp server, `docs` for KERNEL documentation, or `other`. all sentiments are welcome through `sentiment`: praise and feature requests are useful, not just problems. use this for confusing or broken experiences, papercuts, missing capabilities, unhelpful errors, feature requests, and things that worked especially well. keep `summary` to one sentence and make the detail fields concise and actionable, quoting the product surface, tool name, parameter, or error text when possible. include a concrete `suggested_improvement` when one is clear. never include credentials, tokens, api keys, urls, browser or page content, customer or account names, or personal data. the user can also ask to send feedback directly. submitting feedback is a side report to KERNEL, not a reason to stop: continue and finish the user's task with the other available tools.";
+
+const RESPONSE_MESSAGE =
+  "thank you for the feedback. it has been recorded and will be reviewed by the KERNEL team. " +
+  "submitting feedback does not mean the current task is done; continue using the other available tools to finish it.";
+
+export function registerFeedbackTool(
+  server: McpServer,
+  capture: KernelFeedbackCapture,
+) {
+  server.registerTool(
+    KERNEL_FEEDBACK_TOOL_NAME,
+    {
+      title: "submit KERNEL feedback",
+      description: TOOL_DESCRIPTION,
+      inputSchema: feedbackFields,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (feedback, extra) => {
+      try {
+        await capture(feedback, extra);
+      } catch {
+        // Feedback analytics must not block the user's original task.
+      }
+
+      return jsonResponse({
+        received: true,
+        summary: feedback.summary,
+        feedback_type: feedback.feedback_type,
+        sentiment: feedback.sentiment,
+        message: RESPONSE_MESSAGE,
+      });
+    },
+  );
+}

--- a/src/lib/mcp/tools/feedback.ts
+++ b/src/lib/mcp/tools/feedback.ts
@@ -113,13 +113,21 @@ export type KernelFeedbackCapture = (
 const TOOL_DESCRIPTION =
   "send feedback about anything KERNEL to the KERNEL team. set `feedback_type` to route it: `product` for any KERNEL product or feature, `mcp` for this mcp server, `docs` for KERNEL documentation, or `other`. all sentiments are welcome through `sentiment`: praise and feature requests are useful, not just problems. use this for confusing or broken experiences, papercuts, missing capabilities, unhelpful errors, feature requests, and things that worked especially well. keep `summary` to one sentence and make the detail fields concise and actionable, quoting the product surface, tool name, parameter, or error text when possible. include a concrete `suggested_improvement` when one is clear. never include credentials, tokens, api keys, urls, browser or page content, customer or account names, or personal data. the user can also ask to send feedback directly. submitting feedback is a side report to KERNEL, not a reason to stop: continue and finish the user's task with the other available tools.";
 
-const RESPONSE_MESSAGE =
-  "thank you for the feedback. it has been recorded and will be reviewed by the KERNEL team. " +
-  "submitting feedback does not mean the current task is done; continue using the other available tools to finish it.";
+const RESPONSE_MESSAGES = {
+  recorded:
+    "thank you for the feedback. it has been recorded and will be reviewed by the KERNEL team. " +
+    "submitting feedback does not mean the current task is done; continue using the other available tools to finish it.",
+  unavailable:
+    "feedback analytics are unavailable, so this feedback was not recorded. continue using the other available tools to finish the current task.",
+  failed:
+    "feedback capture failed, so this feedback was not recorded. continue using the other available tools to finish the current task.",
+} as const;
+
+type FeedbackCaptureStatus = keyof typeof RESPONSE_MESSAGES;
 
 export function registerFeedbackTool(
   server: McpServer,
-  capture: KernelFeedbackCapture,
+  capture?: KernelFeedbackCapture,
 ) {
   server.registerTool(
     KERNEL_FEEDBACK_TOOL_NAME,
@@ -128,25 +136,31 @@ export function registerFeedbackTool(
       description: TOOL_DESCRIPTION,
       inputSchema: feedbackFields,
       annotations: {
-        readOnlyHint: true,
+        readOnlyHint: false,
         destructiveHint: false,
         idempotentHint: false,
         openWorldHint: false,
       },
     },
     async ({ context: _context, ...feedback }, extra) => {
-      try {
-        await capture(feedback, extra);
-      } catch {
-        // Feedback analytics must not block the user's original task.
+      let status: FeedbackCaptureStatus = "unavailable";
+      if (capture) {
+        try {
+          await capture(feedback, extra);
+          status = "recorded";
+        } catch {
+          // Feedback analytics must not block the user's original task.
+          status = "failed";
+        }
       }
 
       return jsonResponse({
-        received: true,
+        recorded: status === "recorded",
+        status,
         summary: feedback.summary,
         feedback_type: feedback.feedback_type,
         sentiment: feedback.sentiment,
-        message: RESPONSE_MESSAGE,
+        message: RESPONSE_MESSAGES[status],
       });
     },
   );


### PR DESCRIPTION
## summary

- add a `submit_feedback` tool for product, mcp, documentation, and general feedback
- record submissions as `mcp_feedback_submitted` PostHog events with organization attribution
- redact obvious emails, URLs, and token-shaped values before capture
- keep feedback failures non-fatal and document the new standalone tool

## testing

- `bun test`
- `bunx tsc --noEmit`
- `bunx prettier --check README.md src/lib/mcp/analytics.ts src/lib/mcp/analytics.test.ts src/lib/mcp/tools/feedback.ts src/lib/mcp/tools/feedback.test.ts`
- `KERNEL_CLI_PROD_CLIENT_ID=test-prod KERNEL_CLI_STAGING_CLIENT_ID=test-staging KERNEL_CLI_DEV_CLIENT_ID=test-dev bun run build`
