### PR TITLE
Document fx MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ kernel mcp install --target <target>
 | Windsurf       | `kernel mcp install --target windsurf`    |
 | Zed            | `kernel mcp install --target zed`         |
 | Goose          | `kernel mcp install --target goose`       |
+| fx             | `kernel mcp install --target fx`          |
 
 The CLI automatically locates your tool's config file and adds the Kernel MCP server configuration.
 
@@ -141,7 +142,13 @@ opencode mcp auth kernel
 
 ### fx
 
-Add Kernel to the `mcp` map in `~/.fx/mcp.json`:
+Configure Kernel with the Kernel CLI:
+
+```bash
+kernel mcp install --target fx
+```
+
+Or add Kernel to the `mcp` map in `~/.fx/mcp.json` manually:
 
 ```json
 {
@@ -155,10 +162,15 @@ Add Kernel to the `mcp` map in `~/.fx/mcp.json`:
 }
 ```
 
-In an interactive fx session, reload the configuration and authenticate with Kernel:
+Start fx, or reload the configuration in an existing session:
 
 ```text
 /mcp reload
+```
+
+Then authenticate with Kernel:
+
+```text
 /mcp auth kernel --open
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that p
 
 ## What is this?
 
-The Kernel MCP Server bridges AI assistants (like Claude, Cursor, or other MCP-compatible tools) with the Kernel platform, enabling them to:
+The Kernel MCP Server bridges AI assistants (like Claude, Cursor, fx, or other MCP-compatible tools) with the Kernel platform, enabling them to:
 
 - 🚀 Deploy and manage Kernel apps in the cloud
 - 🌐 Launch and control headless Chromium sessions for web automation
@@ -138,6 +138,31 @@ opencode mcp auth kernel
 opencode mcp logout kernel
 opencode mcp auth kernel
 ```
+
+### fx
+
+Add Kernel to the `mcp` map in `~/.fx/mcp.json`:
+
+```json
+{
+  "mcp": {
+    "kernel": {
+      "type": "http",
+      "url": "https://mcp.onkernel.com/mcp",
+      "oauth": {}
+    }
+  }
+}
+```
+
+In an interactive fx session, reload the configuration and authenticate with Kernel:
+
+```text
+/mcp reload
+/mcp auth kernel --open
+```
+
+Authorize access in the browser window that opens. Run `/mcp list` to verify that Kernel is connected.
 
 ### Goose
 


### PR DESCRIPTION
## Summary

- add fx to the supported MCP client examples and CLI target table
- document automatic setup with `kernel mcp install --target fx`
- document manual Streamable HTTP and OAuth setup in `~/.fx/mcp.json`
- include reload, authentication, and connection verification commands

## Testing

- `bunx prettier --check README.md`
- `bun test` (248 passed)
- `git diff --check`

The repository-wide formatting check still reports the pre-existing `AGENTS.md` formatting difference.