### PR TITLE
Make Kernel own MCP OAuth credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The Kernel MCP Server bridges AI assistants (like Claude, Cursor, or other MCP-c
 
 **Open-source & fully-managed** — the complete codebase is available here, and we run the production instance so you don't need to deploy anything.
 
-The server uses OAuth 2.0 authentication via [Clerk](https://clerk.com) to ensure secure access to your Kernel resources. During authorization, users can grant organization-wide access or restrict the resulting access and refresh tokens to one Kernel project. Project-scoped tokens cannot switch projects; organization-wide authorization remains available for existing workflows.
+The server uses Kernel-issued OAuth 2.1 credentials with [Clerk](https://clerk.com) providing upstream identity and consent. Clerk credentials remain internal to the server and are not passed through as MCP access tokens. During authorization, users can grant organization-wide access or restrict the resulting access and refresh tokens to one Kernel project. Project-scoped tokens cannot switch projects; organization-wide authorization remains available for existing workflows.
 
 For a deeper dive into why and how we built this server, see our blog post: [Introducing Kernel MCP Server](https://blog.onkernel.com/p/introducing-kernel-mcp-server).
 

--- a/docs/oauth-conformance.md
+++ b/docs/oauth-conformance.md
@@ -18,7 +18,7 @@ Sources:
 - [Create a connector API](https://vercel.com/docs/rest-api/connect/create-a-connector)
 - [`connectAuthProvider` implementation](https://github.com/vercel/vercel/blob/17d9ebaf8e9b335d550dea1a243743a74edc772e/packages/connect/src/mcp/connect-auth-provider.ts)
 
-The fixture uses a public client (`token_endpoint_auth_method=none`), authorization code plus refresh grants, `openid`, and S256 PKCE. Kernel preserves `state` exactly through its authorization redirect; Vercel Connect owns mismatch detection when handling its callback.
+The fixture uses a public client (`token_endpoint_auth_method=none`), authorization code plus refresh grants, the `mcp` resource scope, RFC 8707 resource binding, and S256 PKCE. Kernel restores the client's exact `state` after the upstream identity callback and returns its public issuer as required by RFC 9207.
 
 ## Covered behavior
 

--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest } from "next/server";
+import { CLERK_OAUTH_SCOPE, MCP_OAUTH_SCOPE } from "@/lib/oauth-scopes";
+import { isMcpAuthorizationServer } from "@/lib/oauth-server";
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
@@ -11,27 +13,33 @@ export async function OPTIONS(): Promise<Response> {
 }
 
 export async function GET(request: NextRequest): Promise<Response> {
+  const baseUrl = `${request.nextUrl.protocol}//${request.nextUrl.host}`;
+  const mcpAuthorizationServer = isMcpAuthorizationServer(baseUrl);
   const clerkDomain = process.env.NEXT_PUBLIC_CLERK_DOMAIN;
-
-  if (!clerkDomain) {
+  if (!mcpAuthorizationServer && !clerkDomain) {
     return Response.json(
       { error: "server_error", error_description: "Clerk domain not found" },
       { status: 500 },
     );
   }
 
-  const baseUrl = `${request.nextUrl.protocol}//${request.nextUrl.host}`;
-
   const metadata = {
     issuer: baseUrl,
     authorization_endpoint: `${baseUrl}/authorize`,
     token_endpoint: `${baseUrl}/token`,
     registration_endpoint: `${baseUrl}/register`,
-    jwks_uri: `https://${clerkDomain}/.well-known/jwks.json`,
-    scopes_supported: ["openid"],
+    ...(mcpAuthorizationServer
+      ? {}
+      : { jwks_uri: `https://${clerkDomain}/.well-known/jwks.json` }),
+    scopes_supported: [
+      mcpAuthorizationServer ? MCP_OAUTH_SCOPE : CLERK_OAUTH_SCOPE,
+    ],
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
+    ...(mcpAuthorizationServer
+      ? { authorization_response_iss_parameter_supported: true }
+      : {}),
     token_endpoint_auth_methods_supported: [
       "none",
       "client_secret_post",

--- a/src/app/.well-known/oauth-protected-resource/mcp/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/mcp/route.ts
@@ -1,42 +1,25 @@
-import { protectedResourceHandlerClerk } from "@clerk/mcp-tools/next";
 import { NextRequest } from "next/server";
+import { MCP_OAUTH_SCOPE } from "@/lib/oauth-scopes";
 
-const handler = async (request: NextRequest) => {
-  const clerkResponse = await protectedResourceHandlerClerk({
-    scopes_supported: ["openid"],
-  })(request);
-
-  const clerkMetadata = await clerkResponse.json();
-
-  const baseUrl = `${request.nextUrl.protocol}//${request.nextUrl.host}`;
-
-  const modifiedMetadata: Record<string, unknown> = {
-    ...clerkMetadata,
-    resource: baseUrl,
-    authorization_servers: [baseUrl],
-    authorization_endpoint: `${baseUrl}/authorize`,
-    token_endpoint: `${baseUrl}/token`,
-    registration_endpoint: `${baseUrl}/register`,
-    scopes_supported: ["openid"],
-  };
-
-  return Response.json(modifiedMetadata, {
-    headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type, Authorization",
-    },
-  });
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
 };
 
-export const OPTIONS = async (): Promise<Response> =>
-  new Response(null, {
-    status: 204,
-    headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type, Authorization",
-    },
-  });
+export async function OPTIONS(): Promise<Response> {
+  return new Response(null, { status: 204, headers: CORS_HEADERS });
+}
 
-export { handler as GET };
+export async function GET(request: NextRequest): Promise<Response> {
+  const baseUrl = request.nextUrl.origin;
+  return Response.json(
+    {
+      resource: baseUrl,
+      authorization_servers: [baseUrl],
+      bearer_methods_supported: ["header"],
+      scopes_supported: [MCP_OAUTH_SCOPE],
+    },
+    { headers: CORS_HEADERS },
+  );
+}

--- a/src/app/[transport]/route.test.ts
+++ b/src/app/[transport]/route.test.ts
@@ -29,11 +29,11 @@ mock.module("@/lib/mcp/analytics", () => ({
 const originalCreateKernelClient = defaultMcpDependencies.createKernelClient;
 const { POST, connectionScopeFailureResponse } = await import("./route");
 
-function initializeRequest(token = "sk_opaque_key") {
+function initializeRequest(token: string | null = "sk_opaque_key") {
   return new Request("https://mcp.example.test/sse", {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`,
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
       "Content-Type": "application/json",
       Accept: "application/json, text/event-stream",
     },
@@ -72,6 +72,15 @@ afterEach(() => {
 });
 
 describe("connection scope failures through the handler", () => {
+  test("advertises protected-resource metadata in the initial challenge", async () => {
+    const response = await POST(initializeRequest(null));
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toContain(
+      'resource_metadata="https://mcp.example.test/.well-known/oauth-protected-resource/mcp"',
+    );
+  });
+
   test("answers a refused credential with 401 rather than a server error", async () => {
     failingAuthContext(Object.assign(new Error("revoked"), { status: 401 }));
 

--- a/src/app/[transport]/route.ts
+++ b/src/app/[transport]/route.ts
@@ -3,9 +3,7 @@ import {
   createMcpHandler,
   experimental_withMcpAuth as withMcpAuth,
 } from "mcp-handler";
-import { verifyToken } from "@clerk/nextjs/server";
 import { after, NextRequest } from "next/server";
-import { isValidJwtFormat } from "@/lib/auth-utils";
 import {
   captureMcpConnectionScopeFailure,
   flushMcpAnalytics,
@@ -24,6 +22,8 @@ import {
   verifyMcpTransportSession,
 } from "@/lib/mcp-transport-session";
 import { registerMcpCapabilities } from "@/lib/mcp/register";
+import { MCP_OAUTH_SCOPE } from "@/lib/oauth-scopes";
+import { resolvePresentedCredential } from "@/lib/mcp/oauth-credential";
 import { name, version } from "../../../server.json";
 
 export async function OPTIONS(_req: NextRequest): Promise<Response> {
@@ -61,9 +61,13 @@ function errorResponse(
 function createAuthErrorResponse(
   error: string = "invalid_token",
   description: string = "Missing or invalid access token",
+  resourceMetadata?: string,
 ): Response {
+  const metadata = resourceMetadata
+    ? `, resource_metadata="${resourceMetadata}"`
+    : "";
   return errorResponse(401, error, description, {
-    "WWW-Authenticate": `Bearer realm="OAuth", error="${error}", error_description="${description}"`,
+    "WWW-Authenticate": `Bearer realm="OAuth"${metadata}, scope="${MCP_OAUTH_SCOPE}", error="${error}", error_description="${description}"`,
   });
 }
 
@@ -195,6 +199,7 @@ async function handleAuthenticatedRequest(
   transportSessionId: string | null = null,
   observeConnection = false,
 ): Promise<Response> {
+  const resourceMetadata = `${req.nextUrl.origin}/.well-known/oauth-protected-resource/mcp`;
   const authHeader = req.headers.get("Authorization");
   const token = authHeader?.startsWith("Bearer ")
     ? authHeader.substring(7).trim()
@@ -203,17 +208,34 @@ async function handleAuthenticatedRequest(
     return createAuthErrorResponse(
       "invalid_token",
       "Missing or invalid access token",
+      resourceMetadata,
     );
   }
 
-  if (!isValidJwtFormat(token)) {
+  const credential = await resolvePresentedCredential(token, req.url);
+  if (credential.kind === "invalid") {
+    return createAuthErrorResponse(
+      "invalid_token",
+      credential.description,
+      resourceMetadata,
+    );
+  }
+  if (credential.kind === "unavailable") {
+    return errorResponse(
+      503,
+      "temporarily_unavailable",
+      "Unable to validate access token",
+      { "Retry-After": "1" },
+    );
+  }
+  if (credential.kind === "api_key") {
     // Opaque API keys are authenticated by the Kernel API rather than Clerk.
     // Do not cache their context: /auth/context must revalidate the credential
     // on every request so revoked keys cannot keep using a cached scope.
     return await handleMcpRequestWithIdentity({
       req,
-      token,
-      authSubject: mcpAppsAuthSubject({ token }),
+      token: credential.token,
+      authSubject: mcpAppsAuthSubject({ token: credential.token }),
       scopes: ["apikey"],
       authInfoExtra: { userId: null, clerkToken: null },
       credentialType: "api_key",
@@ -222,34 +244,21 @@ async function handleAuthenticatedRequest(
     });
   }
 
-  let userId: string;
-  try {
-    const payload = await verifyToken(token, {
-      secretKey: process.env.CLERK_SECRET_KEY,
-    });
-    if (!payload.sub) {
-      return createAuthErrorResponse(
-        "invalid_token",
-        "Invalid token: No user ID found in token payload",
-      );
-    }
-    userId = payload.sub;
-  } catch (authError) {
-    return createAuthErrorResponse(
-      "invalid_token",
-      `Invalid token: ${authError instanceof Error ? authError.message : "Authentication failed"}`,
-    );
-  }
-
-  // Capability state is keyed only after Clerk verifies the JWT, and uses
-  // the verified user plus this signed MCP transport session.
-  const authSubject = mcpAppsAuthSubject({ token, userId });
+  // The client-facing Kernel token identifies capability state. Only the
+  // internal provider credential is sent to the Kernel API.
+  const authSubject = mcpAppsAuthSubject({
+    token: credential.clientToken,
+    userId: credential.userId,
+  });
   return await handleMcpRequestWithIdentity({
     req,
-    token,
+    token: credential.providerToken,
     authSubject,
-    scopes: ["openid"],
-    authInfoExtra: { userId, clerkToken: token },
+    scopes: [MCP_OAUTH_SCOPE],
+    authInfoExtra: {
+      userId: credential.userId,
+      clerkToken: credential.providerToken,
+    },
     credentialType: "oauth",
     transportSessionId,
     connectionContextCacheIdentity: transportSessionId

--- a/src/app/authorize/route.test.ts
+++ b/src/app/authorize/route.test.ts
@@ -15,14 +15,20 @@ function request(query: string) {
   return new NextRequest(`https://auth.example.test/authorize?${query}`);
 }
 
+function cliRequest(query: string) {
+  return new NextRequest(`https://auth.onkernel.com/authorize?${query}`);
+}
+
 function dependencies({
   userId = "user_1",
   orgId = "org_1",
   projectError,
+  redirectUris = null,
 }: {
   userId?: string | null;
   orgId?: string | null;
   projectError?: Error;
+  redirectUris?: string[] | null;
 } = {}) {
   const requestContexts: Parameters<
     AuthorizeDependencies["setRequestContext"]
@@ -47,6 +53,7 @@ function dependencies({
       setClientContext: async (value) => {
         clientContexts.push(value);
       },
+      getRedirectUris: async () => redirectUris,
       requireProject: async (value) => {
         projects.push(value);
         if (projectError) throw projectError;
@@ -61,7 +68,7 @@ describe("GET /authorize", () => {
     const deps = dependencies();
     const response = await authorizeRequest(
       request(
-        "client_id=client_1&state=opaque&resource=https%3A%2F%2Fmcp.example.test%2Fmcp&code_challenge=challenge&code_challenge_method=S256",
+        "client_id=client_1&state=opaque&resource=https%3A%2F%2Fauth.example.test%2Fmcp&code_challenge=challenge&code_challenge_method=S256",
       ),
       deps.value,
     );
@@ -71,7 +78,7 @@ describe("GET /authorize", () => {
     expect(location.pathname).toBe("/select-org");
     expect(location.searchParams.get("state")).toBe("opaque");
     expect(location.searchParams.get("resource")).toBe(
-      "https://mcp.example.test/mcp",
+      "https://auth.example.test/mcp",
     );
   });
 
@@ -89,6 +96,7 @@ describe("GET /authorize", () => {
     expect(deps.requestContexts[0]).toMatchObject({
       clientId: "client_1",
       codeChallenge: "challenge",
+      resource: "https://auth.example.test",
       authorizationContext: {
         version: 1,
         clerk_user_id: "user_1",
@@ -102,6 +110,60 @@ describe("GET /authorize", () => {
     expect(location.searchParams.get("access_scope")).toBeNull();
     expect(location.searchParams.get("project_id")).toBeNull();
     expect(location.searchParams.get("state")).toBe("opaque");
+  });
+
+  test("keeps the existing CLI authorization alias on Clerk tokens", async () => {
+    const deps = dependencies({
+      redirectUris: ["http://localhost:9999/callback"],
+    });
+    const response = await authorizeRequest(
+      cliRequest(
+        "client_id=cli_prod&org_id=org_1&access_scope=organization&scope=openid%20email&state=opaque&redirect_uri=http%3A%2F%2Flocalhost%3A9999%2Fcallback&code_challenge=challenge&code_challenge_method=S256",
+      ),
+      deps.value,
+    );
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.searchParams.get("redirect_uri")).toBe(
+      "http://localhost:9999/callback",
+    );
+    expect(location.searchParams.get("scope")).toBe("openid email");
+    expect(location.searchParams.get("state")).not.toBe("opaque");
+  });
+
+  test("routes newly registered clients through the issuer callback", async () => {
+    const redirectUri = "http://localhost:58432/callback";
+    const deps = dependencies({ redirectUris: [redirectUri] });
+    const response = await authorizeRequest(
+      request(
+        `client_id=client_1&org_id=org_1&access_scope=organization&state=opaque&redirect_uri=${encodeURIComponent(redirectUri)}&code_challenge=challenge&code_challenge_method=S256`,
+      ),
+      deps.value,
+    );
+
+    const location = new URL(response.headers.get("location")!);
+    expect(location.host).toBe("clerk.example.test");
+    expect(location.searchParams.get("redirect_uri")).toBe(
+      "https://auth.example.test/oauth/callback",
+    );
+    expect(location.searchParams.get("state")).not.toBe("opaque");
+  });
+
+  test("rejects an unregistered redirect before forwarding to Clerk", async () => {
+    const deps = dependencies({
+      redirectUris: ["http://localhost:58432/callback"],
+    });
+    const response = await authorizeRequest(
+      request(
+        "client_id=client_1&org_id=org_1&access_scope=organization&redirect_uri=http%3A%2F%2Flocalhost%3A9999%2Fcallback&code_challenge=challenge&code_challenge_method=S256",
+      ),
+      deps.value,
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: "invalid_request" });
+    expect(deps.requestContexts).toHaveLength(0);
   });
 
   test("validates and stores project scope", async () => {

--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -14,6 +14,17 @@ import {
   OAuthProjectsError,
   requireActiveOAuthProject,
 } from "@/lib/oauth-projects";
+import {
+  encodeOAuthProxyState,
+  oauthProxyCallbackUrl,
+} from "@/lib/oauth-proxy";
+import { resolveOAuthClientRedirectUris } from "@/lib/oauth-clients";
+import { resolveOAuthResource } from "@/lib/oauth-resource";
+import {
+  CLERK_OAUTH_SCOPE,
+  validatePublicOAuthScope,
+} from "@/lib/oauth-scopes";
+import { isMcpAuthorizationServer } from "@/lib/oauth-server";
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
@@ -85,6 +96,7 @@ export interface AuthorizeDependencies {
     clientId: string;
     codeChallenge: string;
     authorizationContext: OAuthAuthorizationContext;
+    resource: string;
     ttlSeconds: number;
   }) => Promise<void>;
   setClientContext: (input: {
@@ -92,6 +104,10 @@ export interface AuthorizeDependencies {
     authorizationContext: OAuthAuthorizationContext;
     ttlSeconds: number;
   }) => Promise<void>;
+  getRedirectUris: (input: {
+    clientId: string;
+    issuer: string;
+  }) => Promise<string[] | null>;
   requireProject: typeof requireActiveOAuthProject;
 }
 
@@ -99,6 +115,7 @@ const authorizeDependencies: AuthorizeDependencies = {
   getAuth: async () => auth(),
   setRequestContext: setAuthorizationContextForRequest,
   setClientContext: setAuthorizationContextForClientId,
+  getRedirectUris: resolveOAuthClientRedirectUris,
   requireProject: requireActiveOAuthProject,
 };
 
@@ -107,6 +124,9 @@ export async function authorizeRequest(
   dependencies: AuthorizeDependencies = authorizeDependencies,
 ): Promise<NextResponse> {
   const searchParams = request.nextUrl.searchParams;
+  const mcpAuthorizationServer = isMcpAuthorizationServer(
+    request.nextUrl.origin,
+  );
   const clientId = searchParams.get("client_id");
   const selectedOrgId = searchParams.get("org_id");
   const originalState = searchParams.get("state");
@@ -114,6 +134,29 @@ export async function authorizeRequest(
   const projectId = searchParams.get("project_id");
   const codeChallenge = searchParams.get("code_challenge");
   const codeChallengeMethod = searchParams.get("code_challenge_method");
+
+  if (mcpAuthorizationServer) {
+    try {
+      validatePublicOAuthScope(searchParams.get("scope"));
+    } catch {
+      return errorResponse("invalid_scope", "Unsupported OAuth scope");
+    }
+  }
+
+  let resource = request.nextUrl.origin;
+  if (mcpAuthorizationServer) {
+    try {
+      resource = resolveOAuthResource({
+        requestedResource: searchParams.get("resource"),
+        issuer: request.nextUrl.origin,
+      });
+    } catch (error) {
+      return errorResponse(
+        "invalid_target",
+        error instanceof Error ? error.message : "Invalid OAuth resource",
+      );
+    }
+  }
 
   if (!clientId) {
     return errorResponse(
@@ -155,6 +198,35 @@ export async function authorizeRequest(
     return errorResponse(
       "invalid_request",
       "OAuth clients require PKCE with S256",
+    );
+  }
+
+  let registeredRedirectUris: string[] | null = null;
+  if (mcpAuthorizationServer) {
+    try {
+      registeredRedirectUris = await dependencies.getRedirectUris({
+        clientId,
+        issuer: request.nextUrl.origin,
+      });
+    } catch (error) {
+      console.error("[authorize] failed to load OAuth client registration", {
+        error,
+      });
+      return errorResponse(
+        "server_error",
+        "Failed to validate OAuth client",
+        500,
+      );
+    }
+  }
+  const clientRedirectUri = searchParams.get("redirect_uri");
+  if (
+    registeredRedirectUris &&
+    (!clientRedirectUri || !registeredRedirectUris.includes(clientRedirectUri))
+  ) {
+    return errorResponse(
+      "invalid_request",
+      "redirect_uri is not registered for this client",
     );
   }
 
@@ -212,6 +284,7 @@ export async function authorizeRequest(
         clientId,
         codeChallenge,
         authorizationContext,
+        resource,
         ttlSeconds: 60 * 60,
       });
     } else {
@@ -249,7 +322,23 @@ export async function authorizeRequest(
       clerkAuthUrl.searchParams.set(key, value);
     }
   });
+  if (registeredRedirectUris && clientRedirectUri) {
+    state = encodeOAuthProxyState({
+      redirectUri: clientRedirectUri,
+      clientState: state,
+    });
+    clerkAuthUrl.searchParams.set(
+      "redirect_uri",
+      oauthProxyCallbackUrl(request.nextUrl.origin),
+    );
+  }
   if (state) clerkAuthUrl.searchParams.set("state", state);
+  if (mcpAuthorizationServer) {
+    clerkAuthUrl.searchParams.set("scope", CLERK_OAUTH_SCOPE);
+  }
+  if (mcpAuthorizationServer && searchParams.has("resource")) {
+    clerkAuthUrl.searchParams.set("resource", resource);
+  }
 
   return NextResponse.redirect(clerkAuthUrl);
 }

--- a/src/app/oauth-conformance/oauth-client-conformance.ts
+++ b/src/app/oauth-conformance/oauth-client-conformance.ts
@@ -10,6 +10,9 @@ import {
 const { GET: authorizationServerMetadata } = await import(
   "@/app/.well-known/oauth-authorization-server/route"
 );
+const { GET: protectedResourceMetadata } = await import(
+  "@/app/.well-known/oauth-protected-resource/mcp/route"
+);
 const { tokenRequest } = await import("@/app/token/route");
 
 export function defineOAuthClientConformance(
@@ -29,12 +32,41 @@ export function defineOAuthClientConformance(
         authorization_endpoint: "https://auth.example.test/authorize",
         token_endpoint: "https://auth.example.test/token",
         registration_endpoint: "https://auth.example.test/register",
-        scopes_supported: ["openid"],
+        scopes_supported: ["mcp"],
         response_types_supported: ["code"],
         grant_types_supported: ["authorization_code", "refresh_token"],
         code_challenge_methods_supported: ["S256"],
+        authorization_response_iss_parameter_supported: true,
         token_endpoint_auth_methods_supported: expect.arrayContaining(["none"]),
       });
+
+      const resourceResponse = await protectedResourceMetadata(
+        new NextRequest(
+          "https://auth.example.test/.well-known/oauth-protected-resource/mcp",
+        ),
+      );
+      expect(resourceResponse.status).toBe(200);
+      expect(await resourceResponse.json()).toEqual({
+        resource: "https://auth.example.test",
+        authorization_servers: ["https://auth.example.test"],
+        bearer_methods_supported: ["header"],
+        scopes_supported: ["mcp"],
+      });
+
+      const cliMetadataResponse = await authorizationServerMetadata(
+        new NextRequest(
+          "https://auth.onkernel.com/.well-known/oauth-authorization-server",
+        ),
+      );
+      const cliMetadata = await cliMetadataResponse.json();
+      expect(cliMetadata).toMatchObject({
+        issuer: "https://auth.onkernel.com",
+        scopes_supported: ["openid"],
+        jwks_uri: "https://clerk.example.test/.well-known/jwks.json",
+      });
+      expect(cliMetadata).not.toHaveProperty(
+        "authorization_response_iss_parameter_supported",
+      );
     });
 
     for (const accessScope of ["organization", "project"] as const) {
@@ -60,6 +92,7 @@ export function defineOAuthClientConformance(
             client_id: clientId,
             refresh_token: initial.refreshToken,
             redirect_uri: contract.redirectUri,
+            resource: "https://auth.example.test",
             access_scope:
               accessScope === "project" ? "organization" : "project",
             project_id: "attempted-scope-escalation",
@@ -160,7 +193,7 @@ export function defineOAuthClientConformance(
       );
       expect(redirectResponse.status).toBe(400);
       expect(await redirectResponse.json()).toMatchObject({
-        error: "invalid_grant",
+        error: "invalid_request",
       });
       expect(redirectFixture.persisted).toHaveLength(0);
 

--- a/src/app/oauth-conformance/oauth-client-fixture.ts
+++ b/src/app/oauth-conformance/oauth-client-fixture.ts
@@ -5,6 +5,7 @@ import type { RegisterDependencies } from "@/app/register/route";
 import type { TokenDependencies } from "@/app/token/route";
 import type { OAuthAuthorizationContext } from "@/lib/oauth-context";
 import { expandLocalhostUris, normalizeLocalhostUri } from "@/lib/auth-utils";
+import { oauthProxyCallbackUrl } from "@/lib/oauth-proxy";
 
 process.env.KERNEL_CLI_PROD_CLIENT_ID ??= "cli_prod";
 process.env.KERNEL_CLI_STAGING_CLIENT_ID ??= "cli_staging";
@@ -15,6 +16,7 @@ process.env.CLERK_SECRET_KEY ??= "clerk-secret";
 const { authorizeRequest } = await import("@/app/authorize/route");
 const { registerRequest } = await import("@/app/register/route");
 const { tokenRequest } = await import("@/app/token/route");
+const { GET: oauthCallback } = await import("@/app/oauth/callback/route");
 const { deriveS256CodeChallenge } = await import("@/lib/oauth-context");
 const { resolveAuthorizationContext } = await import("@/lib/org-utils");
 
@@ -25,7 +27,7 @@ export interface OAuthClientConformanceContract {
   tokenEndpointAuthMethod: "none";
   grantTypes: readonly ["authorization_code", "refresh_token"];
   responseTypes: readonly ["code"];
-  scope: "openid";
+  scope: "mcp";
   codeChallengeMethod: "S256";
 }
 
@@ -52,18 +54,24 @@ export function formRequest(
 
 export function createFixture(contract: OAuthClientConformanceContract) {
   const requestContexts = new Map<string, OAuthAuthorizationContext>();
+  const requestResources = new Map<string, string>();
   const refreshContexts = new Map<string, OAuthAuthorizationContext>();
   const refreshClientIds = new Map<string, string>();
+  const providerRefreshTokens = new Map<string, string>();
   const providerExchanges: URLSearchParams[] = [];
   const persisted: Parameters<TokenDependencies["persistContexts"]>[0][] = [];
+  const clientRedirectUris = new Map<string, string[]>();
   let tokenSequence = 0;
 
   const registerDependencies: RegisterDependencies = {
     createOAuthApplication: async (input) => {
       expect(input).toEqual({
         name: contract.clientName,
-        redirectUris: expandLocalhostUris([contract.redirectUri]),
-        scopes: contract.scope,
+        redirectUris: [
+          ...expandLocalhostUris([contract.redirectUri]),
+          "https://auth.example.test/oauth/callback",
+        ],
+        scopes: "openid",
         public: true,
       });
       return {
@@ -71,6 +79,9 @@ export function createFixture(contract: OAuthClientConformanceContract) {
         clientId: "conformance_client",
         clientSecret: null,
       };
+    },
+    storeRedirectUris: async ({ clientId, redirectUris }) => {
+      clientRedirectUris.set(clientId, redirectUris);
     },
   };
 
@@ -84,12 +95,17 @@ export function createFixture(contract: OAuthClientConformanceContract) {
       clientId,
       codeChallenge,
       authorizationContext,
+      resource,
     }) => {
-      requestContexts.set(`${clientId}:${codeChallenge}`, authorizationContext);
+      const key = `${clientId}:${codeChallenge}`;
+      requestContexts.set(key, authorizationContext);
+      requestResources.set(key, resource);
     },
     setClientContext: async () => {
       throw new Error(`${contract.name} must not use non-PKCE authorization`);
     },
+    getRedirectUris: async ({ clientId }) =>
+      clientRedirectUris.get(clientId) ?? null,
     requireProject: async ({ projectId }) => ({
       id: projectId,
       name: "mason",
@@ -102,6 +118,8 @@ export function createFixture(contract: OAuthClientConformanceContract) {
       resolveAuthorizationContext(input, {
         getRequestContext: async ({ clientId, codeChallenge }) =>
           requestContexts.get(`${clientId}:${codeChallenge}`) ?? null,
+        getRequestResource: async ({ clientId, codeChallenge }) =>
+          requestResources.get(`${clientId}:${codeChallenge}`) ?? null,
         getClientContext: async () => null,
         getRefreshContext: async ({ refreshToken }) =>
           refreshContexts.get(refreshToken) ?? null,
@@ -130,10 +148,11 @@ export function createFixture(contract: OAuthClientConformanceContract) {
         expect(params.has("code_verifier")).toBe(false);
       }
 
-      if (
-        params.get("redirect_uri") !==
-        normalizeLocalhostUri(contract.redirectUri)
-      ) {
+      const expectedRedirectUri =
+        params.get("grant_type") === "authorization_code"
+          ? oauthProxyCallbackUrl("https://auth.example.test")
+          : normalizeLocalhostUri(contract.redirectUri);
+      if (params.get("redirect_uri") !== expectedRedirectUri) {
         return Response.json({ error: "invalid_grant" }, { status: 400 });
       }
       if (params.get("client_secret")) {
@@ -150,7 +169,7 @@ export function createFixture(contract: OAuthClientConformanceContract) {
       tokenSequence += 1;
       return Response.json({
         access_token: `provider-access-${tokenSequence}`,
-        id_token: `kernel-jwt-${tokenSequence}`,
+        id_token: `provider-jwt-${tokenSequence}`,
         refresh_token: `refresh-${tokenSequence}`,
         expires_in: 3600,
         token_type: "Bearer",
@@ -158,23 +177,39 @@ export function createFixture(contract: OAuthClientConformanceContract) {
     },
     verify: async () => ({ sub: "user_1" }),
     hasMembership: async () => true,
+    getRedirectUris: async ({ clientId }) =>
+      clientRedirectUris.get(clientId) ?? null,
+    getProviderRefreshToken: async (refreshToken) =>
+      providerRefreshTokens.get(refreshToken) ?? null,
+    issueTokens: () => ({
+      accessToken: `kmcp_at_${tokenSequence}`,
+      refreshToken: `kmcp_rt_${tokenSequence}`,
+    }),
     persistContexts: async (value) => {
       persisted.push(value);
-      refreshContexts.set(value.newRefreshToken, value.authorizationContext);
+      refreshContexts.set(value.publicRefreshToken, value.authorizationContext);
+      providerRefreshTokens.set(
+        value.publicRefreshToken,
+        value.providerRefreshToken,
+      );
       const clientId =
         value.consumedRequest?.clientId ??
-        (value.oldRefreshToken
-          ? refreshClientIds.get(value.oldRefreshToken)
+        (value.oldPublicRefreshToken
+          ? refreshClientIds.get(value.oldPublicRefreshToken)
           : undefined);
-      if (clientId) refreshClientIds.set(value.newRefreshToken, clientId);
-      if (value.oldRefreshToken) {
-        refreshContexts.delete(value.oldRefreshToken);
-        refreshClientIds.delete(value.oldRefreshToken);
+      if (clientId) {
+        refreshClientIds.set(value.providerRefreshToken, clientId);
+        refreshClientIds.set(value.publicRefreshToken, clientId);
+      }
+      if (value.oldPublicRefreshToken) {
+        refreshContexts.delete(value.oldPublicRefreshToken);
+        providerRefreshTokens.delete(value.oldPublicRefreshToken);
+        refreshClientIds.delete(value.oldPublicRefreshToken);
       }
       if (value.consumedRequest) {
-        requestContexts.delete(
-          `${value.consumedRequest.clientId}:${value.consumedRequest.codeChallenge}`,
-        );
+        const requestKey = `${value.consumedRequest.clientId}:${value.consumedRequest.codeChallenge}`;
+        requestContexts.delete(requestKey);
+        requestResources.delete(requestKey);
       }
     },
   };
@@ -195,7 +230,7 @@ export function createFixture(contract: OAuthClientConformanceContract) {
       }),
       registerDependencies,
     );
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(201);
     const registration = (await response.json()) as {
       client_id: string;
       client_secret?: string;
@@ -210,7 +245,7 @@ export function createFixture(contract: OAuthClientConformanceContract) {
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       redirect_uris: [contract.redirectUri],
-      scope: "openid",
+      scope: "mcp",
     });
     expect(registration.client_id.length).toBeGreaterThan(0);
     expect(registration.client_secret).toBeUndefined();
@@ -233,6 +268,7 @@ export function createFixture(contract: OAuthClientConformanceContract) {
       state,
       code_challenge: CODE_CHALLENGE,
       code_challenge_method: contract.codeChallengeMethod,
+      resource: "https://auth.example.test",
       org_id: "org_1",
       access_scope: accessScope,
       ...(accessScope === "project" ? { project_id: "project_1" } : {}),
@@ -243,15 +279,40 @@ export function createFixture(contract: OAuthClientConformanceContract) {
     );
     expect(response.status).toBe(307);
     const providerUrl = new URL(response.headers.get("location")!);
-    expect(providerUrl.searchParams.get("state")).toBe(state);
+    expect(providerUrl.searchParams.get("state")).not.toBe(state);
     expect(providerUrl.searchParams.get("redirect_uri")).toBe(
-      contract.redirectUri,
+      "https://auth.example.test/oauth/callback",
     );
     expect(providerUrl.searchParams.get("code_challenge")).toBe(CODE_CHALLENGE);
     expect(providerUrl.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(providerUrl.searchParams.get("scope")).toBe("openid");
     expect(providerUrl.searchParams.get("org_id")).toBeNull();
     expect(providerUrl.searchParams.get("access_scope")).toBeNull();
     expect(providerUrl.searchParams.get("project_id")).toBeNull();
+    expect(providerUrl.searchParams.get("resource")).toBe(
+      "https://auth.example.test",
+    );
+
+    const callbackParams = new URLSearchParams({
+      code: "authorization-code",
+      state: providerUrl.searchParams.get("state")!,
+      iss: "https://clerk.example.test",
+    });
+    const callbackResponse = await oauthCallback(
+      new NextRequest(
+        `https://auth.example.test/oauth/callback?${callbackParams}`,
+      ),
+    );
+    expect(callbackResponse.status).toBe(302);
+    const clientCallback = new URL(callbackResponse.headers.get("location")!);
+    expect(clientCallback.origin + clientCallback.pathname).toBe(
+      contract.redirectUri,
+    );
+    expect(clientCallback.searchParams.get("code")).toBe("authorization-code");
+    expect(clientCallback.searchParams.get("state")).toBe(state);
+    expect(clientCallback.searchParams.get("iss")).toBe(
+      "https://auth.example.test",
+    );
   }
 
   async function exchangeCode(clientId: string): Promise<TokenSet> {
@@ -262,6 +323,7 @@ export function createFixture(contract: OAuthClientConformanceContract) {
         code: "authorization-code",
         code_verifier: CODE_VERIFIER,
         redirect_uri: contract.redirectUri,
+        resource: "https://auth.example.test",
       }),
       tokenDependencies,
     );
@@ -272,6 +334,7 @@ export function createFixture(contract: OAuthClientConformanceContract) {
 
   return {
     requestContexts,
+    requestResources,
     refreshContexts,
     refreshClientIds,
     providerExchanges,

--- a/src/app/oauth-conformance/vercel-connect.test.ts
+++ b/src/app/oauth-conformance/vercel-connect.test.ts
@@ -9,6 +9,6 @@ defineOAuthClientConformance({
   tokenEndpointAuthMethod: "none",
   grantTypes: ["authorization_code", "refresh_token"],
   responseTypes: ["code"],
-  scope: "openid",
+  scope: "mcp",
   codeChallengeMethod: "S256",
 });

--- a/src/app/oauth/callback/route.test.ts
+++ b/src/app/oauth/callback/route.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+import { encodeOAuthProxyState } from "@/lib/oauth-proxy";
+import { GET } from "./route";
+
+process.env.CLERK_SECRET_KEY ??= "test-clerk-secret";
+process.env.NEXT_PUBLIC_CLERK_DOMAIN ??= "clerk.example.test";
+
+function request(params: URLSearchParams): NextRequest {
+  return new NextRequest(
+    `https://mcp.example.test/oauth/callback?${params.toString()}`,
+  );
+}
+
+describe("GET /oauth/callback", () => {
+  test("returns the provider code with the public issuer", async () => {
+    const state = encodeOAuthProxyState({
+      redirectUri: "http://localhost:58432/callback?existing=value",
+      clientState: "opaque",
+    });
+    const response = await GET(
+      request(new URLSearchParams({ code: "code_1", state })),
+    );
+
+    expect(response.status).toBe(302);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.origin).toBe("http://localhost:58432");
+    expect(location.pathname).toBe("/callback");
+    expect(location.searchParams.get("existing")).toBe("value");
+    expect(location.searchParams.get("code")).toBe("code_1");
+    expect(location.searchParams.get("state")).toBe("opaque");
+    expect(location.searchParams.get("iss")).toBe("https://mcp.example.test");
+  });
+
+  test("forwards provider errors without exposing its issuer", async () => {
+    const state = encodeOAuthProxyState({
+      redirectUri: "http://localhost:58432/callback",
+      clientState: "opaque",
+    });
+    const response = await GET(
+      request(
+        new URLSearchParams({
+          error: "access_denied",
+          error_description: "Canceled",
+          iss: "https://clerk.example.test",
+          state,
+        }),
+      ),
+    );
+
+    const location = new URL(response.headers.get("location")!);
+    expect(location.searchParams.get("error")).toBe("access_denied");
+    expect(location.searchParams.get("error_description")).toBe("Canceled");
+    expect(location.searchParams.get("iss")).toBe("https://mcp.example.test");
+  });
+
+  test("rejects invalid state and malformed responses", async () => {
+    const invalidState = await GET(
+      request(new URLSearchParams({ code: "code_1", state: "invalid" })),
+    );
+    expect(invalidState.status).toBe(400);
+
+    const state = encodeOAuthProxyState({
+      redirectUri: "http://localhost:58432/callback",
+      clientState: null,
+    });
+    const missingResult = await GET(request(new URLSearchParams({ state })));
+    expect(missingResult.status).toBe(400);
+
+    const wrongIssuer = await GET(
+      request(
+        new URLSearchParams({
+          code: "code_1",
+          state,
+          iss: "https://other.example.test",
+        }),
+      ),
+    );
+    expect(wrongIssuer.status).toBe(400);
+  });
+});

--- a/src/app/oauth/callback/route.ts
+++ b/src/app/oauth/callback/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { decodeOAuthProxyState } from "@/lib/oauth-proxy";
+
+function errorResponse(description: string): NextResponse {
+  return NextResponse.json(
+    { error: "invalid_request", error_description: description },
+    { status: 400, headers: { "Cache-Control": "no-store" } },
+  );
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const params = request.nextUrl.searchParams;
+  const encodedState = params.get("state");
+  if (!encodedState) {
+    return errorResponse("Missing OAuth proxy state");
+  }
+
+  const state = decodeOAuthProxyState(encodedState);
+  if (!state) {
+    return errorResponse("Invalid or expired OAuth proxy state");
+  }
+
+  const providerIssuer = params.get("iss");
+  const clerkDomain = process.env.NEXT_PUBLIC_CLERK_DOMAIN;
+  if (
+    providerIssuer &&
+    (!clerkDomain || providerIssuer !== `https://${clerkDomain}`)
+  ) {
+    return errorResponse("OAuth provider issuer mismatch");
+  }
+
+  const code = params.get("code");
+  const error = params.get("error");
+  if ((!code && !error) || (code && error)) {
+    return errorResponse("Invalid OAuth authorization response");
+  }
+
+  const redirect = new URL(state.redirectUri);
+  if (code) redirect.searchParams.set("code", code);
+  if (error) {
+    redirect.searchParams.set("error", error);
+    for (const key of ["error_description", "error_uri"] as const) {
+      const value = params.get(key);
+      if (value) redirect.searchParams.set(key, value);
+    }
+  }
+  if (state.clientState !== null) {
+    redirect.searchParams.set("state", state.clientState);
+  }
+  redirect.searchParams.set("iss", request.nextUrl.origin);
+
+  const response = NextResponse.redirect(redirect, 302);
+  response.headers.set("Cache-Control", "no-store");
+  return response;
+}

--- a/src/app/register/route.test.ts
+++ b/src/app/register/route.test.ts
@@ -15,6 +15,9 @@ describe("POST /register", () => {
     const createCalls: Parameters<
       RegisterDependencies["createOAuthApplication"]
     >[0][] = [];
+    const storedRegistrations: Parameters<
+      RegisterDependencies["storeRedirectUris"]
+    >[0][] = [];
     const response = await registerRequest(
       request({
         client_name: "Test Client",
@@ -22,7 +25,7 @@ describe("POST /register", () => {
         token_endpoint_auth_method: "none",
         grant_types: ["authorization_code", "refresh_token"],
         response_types: ["code"],
-        scope: "openid",
+        scope: "mcp",
       }),
       {
         createOAuthApplication: async (value) => {
@@ -33,19 +36,32 @@ describe("POST /register", () => {
             clientSecret: null,
           };
         },
+        storeRedirectUris: async (value) => {
+          storedRegistrations.push(value);
+        },
       },
     );
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(201);
     expect(createCalls).toEqual([
       {
         name: "Test Client",
         redirectUris: [
           "http://localhost:58432/callback",
           "http://127.0.0.1:58432/callback",
+          "https://auth.example.test/oauth/callback",
         ],
         scopes: "openid",
         public: true,
+      },
+    ]);
+    expect(storedRegistrations).toEqual([
+      {
+        clientId: "client_1",
+        redirectUris: [
+          "http://localhost:58432/callback",
+          "http://127.0.0.1:58432/callback",
+        ],
       },
     ]);
     expect(await response.json()).toMatchObject({
@@ -53,6 +69,7 @@ describe("POST /register", () => {
       redirect_uris: ["http://localhost:58432/callback"],
       token_endpoint_auth_method: "none",
       grant_types: ["authorization_code", "refresh_token"],
+      scope: "mcp",
     });
   });
 
@@ -62,6 +79,9 @@ describe("POST /register", () => {
       createOAuthApplication: async () => {
         called = true;
         return { id: "unexpected", clientId: "unexpected" };
+      },
+      storeRedirectUris: async () => {
+        called = true;
       },
     };
 
@@ -76,6 +96,15 @@ describe("POST /register", () => {
       deps,
     );
     expect(insecureRedirect.status).toBe(400);
+
+    const unsupportedScope = await registerRequest(
+      request({
+        redirect_uris: ["https://client.example/callback"],
+        scope: "profile",
+      }),
+      deps,
+    );
+    expect(unsupportedScope.status).toBe(400);
     expect(called).toBe(false);
   });
 });

--- a/src/app/register/route.ts
+++ b/src/app/register/route.ts
@@ -1,9 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { clerkClient } from "@clerk/nextjs/server";
 import { expandLocalhostUris } from "@/lib/auth-utils";
+import { setOAuthClientRedirectUris } from "@/lib/redis";
+import { oauthProxyCallbackUrl } from "@/lib/oauth-proxy";
+import {
+  CLERK_OAUTH_SCOPE,
+  MCP_OAUTH_SCOPE,
+  validatePublicOAuthScope,
+} from "@/lib/oauth-scopes";
+import { isMcpAuthorizationServer } from "@/lib/oauth-server";
 
-// Custom registration endpoint needed because Clerk doesn't support custom scopes
-// We only want "openid" scope instead of Clerk's default email/profile scopes
+// Kernel owns the public MCP scope while Clerk receives only the internal
+// identity scope needed for login and consent.
 export async function OPTIONS(): Promise<NextResponse> {
   return new NextResponse(null, {
     status: 204,
@@ -28,6 +36,10 @@ export interface RegisterDependencies {
     clientId: string;
     clientSecret?: string | null;
   }>;
+  storeRedirectUris: (input: {
+    clientId: string;
+    redirectUris: string[];
+  }) => Promise<void>;
 }
 
 const registerDependencies: RegisterDependencies = {
@@ -35,6 +47,7 @@ const registerDependencies: RegisterDependencies = {
     const clerk = await clerkClient();
     return clerk.oauthApplications.create(input);
   },
+  storeRedirectUris: setOAuthClientRedirectUris,
 };
 
 export async function registerRequest(
@@ -62,6 +75,9 @@ export async function registerRequest(
     );
   }
 
+  const mcpAuthorizationServer = isMcpAuthorizationServer(
+    request.nextUrl.origin,
+  );
   const {
     redirect_uris,
     client_name,
@@ -73,8 +89,25 @@ export async function registerRequest(
     token_endpoint_auth_method = "none", // Default to PKCE for public clients
     grant_types = ["authorization_code"],
     response_types = ["code"],
-    scope = "openid",
+    scope = mcpAuthorizationServer ? MCP_OAUTH_SCOPE : CLERK_OAUTH_SCOPE,
   } = body;
+
+  let publicScope: string;
+  try {
+    publicScope = mcpAuthorizationServer
+      ? validatePublicOAuthScope(scope)
+      : typeof scope === "string" && scope.trim()
+        ? scope.trim()
+        : CLERK_OAUTH_SCOPE;
+  } catch {
+    return NextResponse.json(
+      {
+        error: "invalid_scope",
+        error_description: "Unsupported OAuth scope",
+      },
+      { status: 400 },
+    );
+  }
 
   // Validate required parameters
   if (
@@ -136,13 +169,23 @@ export async function registerRequest(
     // This is needed because Vercel normalizes 127.0.0.1 to localhost in query params
     const expandedRedirectUris = expandLocalhostUris(redirect_uris);
 
-    // Register the OAuth application with Clerk
     const oauthApp = await dependencies.createOAuthApplication({
       name: client_name || "MCP Client",
-      redirectUris: expandedRedirectUris,
-      scopes: scope ? scope : "openid",
+      redirectUris: mcpAuthorizationServer
+        ? [
+            ...expandedRedirectUris,
+            oauthProxyCallbackUrl(request.nextUrl.origin),
+          ]
+        : expandedRedirectUris,
+      scopes: mcpAuthorizationServer ? CLERK_OAUTH_SCOPE : publicScope,
       public: true,
     });
+    if (mcpAuthorizationServer) {
+      await dependencies.storeRedirectUris({
+        clientId: oauthApp.clientId,
+        redirectUris: expandedRedirectUris,
+      });
+    }
 
     // Create response in OAuth Dynamic Client Registration format
     const now = Math.floor(Date.now() / 1000);
@@ -160,7 +203,7 @@ export async function registerRequest(
       token_endpoint_auth_method,
       grant_types,
       response_types,
-      scope,
+      scope: publicScope,
       client_id_issued_at: now,
       client_secret_expires_at: 0, // Public clients don't expire
       registration_access_token: oauthApp.id, // Use OAuth app ID as registration token
@@ -168,6 +211,7 @@ export async function registerRequest(
     };
 
     return NextResponse.json(registrationResponse, {
+      status: 201,
       headers: {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Methods": "POST, OPTIONS",

--- a/src/app/token/route.test.ts
+++ b/src/app/token/route.test.ts
@@ -14,8 +14,11 @@ process.env.CLERK_SECRET_KEY ??= "clerk-secret";
 
 const { tokenRequest } = await import("./route");
 
-function request(values: Record<string, string>) {
-  return new NextRequest("https://auth.example.test/token", {
+function request(
+  values: Record<string, string>,
+  origin = "https://auth.example.test",
+) {
+  return new NextRequest(`${origin}/token`, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams(values),
@@ -32,6 +35,9 @@ function dependencies({
   clerkStatus = 200,
   membershipError,
   contextError,
+  redirectUris = null,
+  providerRefreshToken = "provider-refresh-old",
+  requestResource,
   clerkTokens = {
     access_token: "clerk-access",
     id_token: "header.payload.signature",
@@ -55,6 +61,9 @@ function dependencies({
       | "server_error";
     status: number;
   };
+  redirectUris?: string[] | null;
+  providerRefreshToken?: string | null;
+  requestResource?: string;
   clerkTokens?: Record<string, unknown>;
 } = {}) {
   const calls = {
@@ -63,6 +72,7 @@ function dependencies({
     verifications: [] as string[],
     memberships: [] as Array<{ clerkUserId: string; clerkOrgId: string }>,
     persisted: [] as Parameters<TokenDependencies["persistContexts"]>[0][],
+    providerRefreshes: [] as string[],
     outcomes: [] as Parameters<
       NonNullable<TokenDependencies["recordExchange"]>
     >[0][],
@@ -85,7 +95,10 @@ function dependencies({
         return {
           authorizationContext,
           ...(value.grantType === "authorization_code"
-            ? { requestCodeChallenge: "derived-challenge" }
+            ? {
+                requestCodeChallenge: "derived-challenge",
+                ...(requestResource ? { requestResource } : {}),
+              }
             : {}),
         };
       },
@@ -104,6 +117,15 @@ function dependencies({
         if (membershipError) throw membershipError;
         return member;
       },
+      getRedirectUris: async () => redirectUris,
+      getProviderRefreshToken: async (token) => {
+        calls.providerRefreshes.push(token);
+        return providerRefreshToken;
+      },
+      issueTokens: () => ({
+        accessToken: "kmcp_at_test",
+        refreshToken: "kmcp_rt_test",
+      }),
       persistContexts: async (value) => {
         calls.persisted.push(value);
       },
@@ -123,6 +145,7 @@ describe("POST /token", () => {
         client_id: "client_1",
         code: "code_1",
         code_verifier: "verifier_1",
+        scope: "mcp",
         org_id: "forged-org",
         access_scope: "project",
         project_id: "forged-project",
@@ -132,16 +155,28 @@ describe("POST /token", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({
-      access_token: "header.payload.signature",
-      refresh_token: "refresh-new",
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Pragma")).toBe("no-cache");
+    const responseBody = await response.json();
+    expect(responseBody).toMatchObject({
+      access_token: "kmcp_at_test",
+      refresh_token: "kmcp_rt_test",
       org_id: "org_1",
       access_scope: "organization",
     });
+    expect(responseBody).not.toHaveProperty("id_token");
+    expect(JSON.stringify(responseBody)).not.toContain("clerk-access");
+    expect(JSON.stringify(responseBody)).not.toContain(
+      "header.payload.signature",
+    );
+    expect(JSON.stringify(responseBody)).not.toContain("refresh-new");
     expect(deps.calls.persisted).toEqual([
       expect.objectContaining({
-        jwt: "header.payload.signature",
-        newRefreshToken: "refresh-new",
+        providerJwt: "header.payload.signature",
+        publicAccessToken: "kmcp_at_test",
+        providerRefreshToken: "refresh-new",
+        publicRefreshToken: "kmcp_rt_test",
+        resource: "https://auth.example.test",
         authorizationContext: expect.objectContaining({
           access_scope: "organization",
         }),
@@ -154,7 +189,8 @@ describe("POST /token", () => {
     expect(deps.calls.exchanges[0].has("org_id")).toBe(false);
     expect(deps.calls.exchanges[0].has("project_id")).toBe(false);
     expect(deps.calls.exchanges[0].has("access_scope")).toBe(false);
-    expect(deps.calls.persisted[0]).not.toHaveProperty("oldRefreshToken");
+    expect(deps.calls.exchanges[0].get("scope")).toBe("openid");
+    expect(deps.calls.persisted[0]).not.toHaveProperty("oldPublicRefreshToken");
     expect(deps.calls.outcomes).toEqual([
       expect.objectContaining({
         grantType: "authorization_code",
@@ -165,6 +201,98 @@ describe("POST /token", () => {
         statusCode: 200,
       }),
     ]);
+  });
+
+  test("keeps the CLI auth alias on Clerk-issued credentials", async () => {
+    const deps = dependencies();
+    const response = await tokenRequest(
+      request(
+        {
+          grant_type: "authorization_code",
+          client_id: "cli_prod",
+          code: "code_1",
+          code_verifier: "verifier_1",
+          scope: "openid email",
+          redirect_uri: "http://localhost:9999/callback",
+        },
+        "https://auth.onkernel.com",
+      ),
+      deps.value,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      access_token: "header.payload.signature",
+      refresh_token: "refresh-new",
+      id_token: "header.payload.signature",
+    });
+    expect(deps.calls.exchanges[0].get("scope")).toBe("openid email");
+    expect(deps.calls.exchanges[0].get("redirect_uri")).toBe(
+      "http://localhost:9999/callback",
+    );
+    expect(deps.calls.persisted[0]).toMatchObject({
+      publicAccessToken: "header.payload.signature",
+      publicRefreshToken: "refresh-new",
+    });
+  });
+
+  test("rejects a token request for a different MCP resource", async () => {
+    const deps = dependencies({
+      requestResource: "https://auth.example.test/mcp",
+    });
+    const response = await tokenRequest(
+      request({
+        grant_type: "authorization_code",
+        client_id: "client_1",
+        code: "code_1",
+        code_verifier: "verifier_1",
+        resource: "https://auth.example.test",
+      }),
+      deps.value,
+    );
+
+    expect(response.status).toBe(400);
+    expect(deps.calls.exchanges).toHaveLength(0);
+    expect(deps.calls.persisted).toHaveLength(0);
+  });
+
+  test("exchanges proxied codes with the provider callback URI", async () => {
+    const redirectUri = "http://localhost:58432/callback";
+    const deps = dependencies({ redirectUris: [redirectUri] });
+    const response = await tokenRequest(
+      request({
+        grant_type: "authorization_code",
+        client_id: "client_1",
+        code: "code_1",
+        code_verifier: "verifier_1",
+        redirect_uri: redirectUri,
+      }),
+      deps.value,
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.calls.exchanges[0].get("redirect_uri")).toBe(
+      "https://auth.example.test/oauth/callback",
+    );
+  });
+
+  test("rejects an unregistered redirect before exchanging a proxied code", async () => {
+    const deps = dependencies({
+      redirectUris: ["http://localhost:58432/callback"],
+    });
+    const response = await tokenRequest(
+      request({
+        grant_type: "authorization_code",
+        client_id: "client_1",
+        code: "code_1",
+        code_verifier: "verifier_1",
+        redirect_uri: "http://localhost:9999/callback",
+      }),
+      deps.value,
+    );
+
+    expect(response.status).toBe(400);
+    expect(deps.calls.exchanges).toHaveLength(0);
   });
 
   test("returns the server-bound project scope", async () => {
@@ -227,8 +355,9 @@ describe("POST /token", () => {
     });
     expect(deps.calls.persisted).toEqual([
       expect.objectContaining({
-        oldRefreshToken: "refresh-old",
-        newRefreshToken: "refresh-new",
+        oldPublicRefreshToken: "refresh-old",
+        providerRefreshToken: "refresh-new",
+        publicRefreshToken: "kmcp_rt_test",
         authorizationContext: expect.objectContaining({
           access_scope: "project",
           project_id: "proj_1",
@@ -248,6 +377,45 @@ describe("POST /token", () => {
       stage: "complete",
       outcome: "success",
     });
+  });
+
+  test("keeps provider refresh credentials behind the Kernel boundary", async () => {
+    const deps = dependencies();
+    const response = await tokenRequest(
+      request({
+        grant_type: "refresh_token",
+        client_id: "client_1",
+        refresh_token: "kmcp_rt_old",
+        resource: "https://auth.example.test/",
+      }),
+      deps.value,
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.calls.providerRefreshes).toEqual(["kmcp_rt_old"]);
+    expect(deps.calls.exchanges[0].get("refresh_token")).toBe(
+      "provider-refresh-old",
+    );
+    expect(await response.json()).toMatchObject({
+      access_token: "kmcp_at_test",
+      refresh_token: "kmcp_rt_test",
+    });
+  });
+
+  test("rejects an expired Kernel refresh token before provider exchange", async () => {
+    const deps = dependencies({ providerRefreshToken: null });
+    const response = await tokenRequest(
+      request({
+        grant_type: "refresh_token",
+        client_id: "client_1",
+        refresh_token: "kmcp_rt_expired",
+      }),
+      deps.value,
+    );
+
+    expect(response.status).toBe(400);
+    expect(deps.calls.exchanges).toHaveLength(0);
+    expect(deps.calls.persisted).toHaveLength(0);
   });
 
   test("records the OAuth error returned by context resolution", async () => {

--- a/src/app/token/route.ts
+++ b/src/app/token/route.ts
@@ -1,6 +1,10 @@
 import { clerkClient, verifyToken } from "@clerk/nextjs/server";
 import { after, NextRequest, NextResponse } from "next/server";
-import { persistOAuthTokenContexts } from "@/lib/redis";
+import {
+  getOAuthClientRedirectUris,
+  getOAuthProviderRefreshToken,
+  persistOAuthTokenContexts,
+} from "@/lib/redis";
 import { resolveAuthorizationContext } from "@/lib/org-utils";
 import { REFRESH_TOKEN_ORG_TTL_SECONDS } from "@/lib/const";
 import { normalizeLocalhostUri } from "@/lib/auth-utils";
@@ -9,11 +13,24 @@ import {
   flushMcpAnalytics,
   type OAuthTokenExchangeAnalytics,
 } from "@/lib/mcp/analytics";
+import { oauthProxyCallbackUrl } from "@/lib/oauth-proxy";
+import { resolveOAuthResource } from "@/lib/oauth-resource";
+import {
+  isKernelOAuthRefreshToken,
+  issueKernelOAuthTokens,
+} from "@/lib/oauth-tokens";
+import {
+  CLERK_OAUTH_SCOPE,
+  validatePublicOAuthScope,
+} from "@/lib/oauth-scopes";
+import { isMcpAuthorizationServer } from "@/lib/oauth-server";
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Cache-Control": "no-store",
+  Pragma: "no-cache",
 };
 
 interface ClerkTokenResponse {
@@ -111,6 +128,12 @@ export interface TokenDependencies {
     options: { secretKey?: string },
   ) => Promise<{ sub?: string }>;
   hasMembership: typeof hasOrganizationMembership;
+  getRedirectUris: (input: {
+    clientId: string;
+    issuer: string;
+  }) => Promise<string[] | null>;
+  getProviderRefreshToken: typeof getOAuthProviderRefreshToken;
+  issueTokens: typeof issueKernelOAuthTokens;
   persistContexts: typeof persistOAuthTokenContexts;
   recordExchange?: (exchange: OAuthTokenExchangeAnalytics) => void;
 }
@@ -120,6 +143,9 @@ const tokenDependencies: TokenDependencies = {
   resolveContext: resolveAuthorizationContext,
   verify: verifyToken,
   hasMembership: hasOrganizationMembership,
+  getRedirectUris: async ({ clientId }) => getOAuthClientRedirectUris(clientId),
+  getProviderRefreshToken: getOAuthProviderRefreshToken,
+  issueTokens: issueKernelOAuthTokens,
   persistContexts: persistOAuthTokenContexts,
   recordExchange: captureOAuthTokenExchange,
 };
@@ -166,6 +192,9 @@ export async function tokenRequest(
   dependencies: TokenDependencies = tokenDependencies,
 ): Promise<NextResponse> {
   const startedAt = Date.now();
+  const mcpAuthorizationServer = isMcpAuthorizationServer(
+    request.nextUrl.origin,
+  );
   let grantTypeForAnalytics: OAuthTokenExchangeAnalytics["grantType"] =
     "unknown";
   let clientTypeForAnalytics: OAuthTokenExchangeAnalytics["clientType"] =
@@ -233,7 +262,61 @@ export async function tokenRequest(
     return fail("invalid_request", "Missing required parameter: client_id");
   }
 
+  const requestedScope = body.get("scope")?.toString();
+  if (mcpAuthorizationServer) {
+    try {
+      validatePublicOAuthScope(requestedScope);
+    } catch {
+      return fail("invalid_request", "Unsupported OAuth scope");
+    }
+    if (requestedScope) params.set("scope", CLERK_OAUTH_SCOPE);
+  }
+
   const refreshToken = body.get("refresh_token")?.toString();
+  let resource = request.nextUrl.origin;
+  if (mcpAuthorizationServer) {
+    try {
+      resource = resolveOAuthResource({
+        requestedResource: body.get("resource")?.toString(),
+        issuer: request.nextUrl.origin,
+      });
+    } catch (error) {
+      return fail(
+        "invalid_request",
+        error instanceof Error ? error.message : "Invalid OAuth resource",
+      );
+    }
+  }
+
+  let registeredRedirectUris: string[] | null = null;
+  if (mcpAuthorizationServer && grantType === "authorization_code") {
+    try {
+      registeredRedirectUris = await dependencies.getRedirectUris({
+        clientId,
+        issuer: request.nextUrl.origin,
+      });
+    } catch (error) {
+      console.error("[token] failed to load OAuth client registration", {
+        error,
+      });
+      return fail("server_error", "Failed to validate OAuth client", 500);
+    }
+  }
+  if (registeredRedirectUris) {
+    const redirectUri = body.get("redirect_uri")?.toString();
+    if (
+      !redirectUri ||
+      (!registeredRedirectUris.includes(redirectUri) &&
+        !registeredRedirectUris.includes(normalizeLocalhostUri(redirectUri)))
+    ) {
+      return fail(
+        "invalid_request",
+        "redirect_uri is not registered for this client",
+      );
+    }
+    params.set("redirect_uri", oauthProxyCallbackUrl(request.nextUrl.origin));
+  }
+
   stage = "context_resolution";
   const contextResult = await dependencies.resolveContext({
     grantType,
@@ -255,6 +338,16 @@ export async function tokenRequest(
     );
   }
   accessScopeForAnalytics = authorizationContext.access_scope;
+  if (
+    mcpAuthorizationServer &&
+    contextResult.requestResource &&
+    contextResult.requestResource !== resource
+  ) {
+    return fail(
+      "invalid_grant",
+      "Token resource does not match the authorization request",
+    );
+  }
 
   let persistedAuthorizationContext = authorizationContext;
 
@@ -272,6 +365,20 @@ export async function tokenRequest(
       : undefined;
 
   try {
+    if (
+      mcpAuthorizationServer &&
+      grantType === "refresh_token" &&
+      refreshToken &&
+      isKernelOAuthRefreshToken(refreshToken)
+    ) {
+      const providerRefreshToken =
+        await dependencies.getProviderRefreshToken(refreshToken);
+      if (!providerRefreshToken) {
+        return fail("invalid_grant", "Refresh token is invalid or expired");
+      }
+      params.set("refresh_token", providerRefreshToken);
+    }
+
     stage = "membership_validation";
     if (
       refreshContextUserId &&
@@ -362,8 +469,8 @@ export async function tokenRequest(
     }
 
     stage = "provider_response_validation";
-    const issuedRefreshToken = clerkTokens.refresh_token;
-    if (!issuedRefreshToken) {
+    const issuedProviderRefreshToken = clerkTokens.refresh_token;
+    if (!issuedProviderRefreshToken) {
       return fail(
         "invalid_grant",
         grantType === "refresh_token"
@@ -371,7 +478,7 @@ export async function tokenRequest(
           : "OAuth provider did not return a refresh token",
       );
     }
-    const finalJwt = clerkTokens.id_token;
+    const providerJwt = clerkTokens.id_token;
     if (grantType === "refresh_token" && !refreshToken) {
       return fail("invalid_grant", "Missing required parameter: refresh_token");
     }
@@ -382,15 +489,24 @@ export async function tokenRequest(
       );
     }
 
+    const issuedTokens = mcpAuthorizationServer
+      ? dependencies.issueTokens()
+      : {
+          accessToken: providerJwt,
+          refreshToken: issuedProviderRefreshToken,
+        };
     stage = "persistence";
     await dependencies.persistContexts({
-      jwt: finalJwt,
-      newRefreshToken: issuedRefreshToken,
+      providerJwt,
+      publicAccessToken: issuedTokens.accessToken,
+      providerRefreshToken: issuedProviderRefreshToken,
+      publicRefreshToken: issuedTokens.refreshToken,
       ...(grantType === "refresh_token" && refreshToken
-        ? { oldRefreshToken: refreshToken }
+        ? { oldPublicRefreshToken: refreshToken }
         : {}),
       authorizationContext: persistedAuthorizationContext,
-      jwtTtlSeconds: clerkTokens.expires_in,
+      resource,
+      accessTokenTtlSeconds: clerkTokens.expires_in,
       refreshTtlSeconds: REFRESH_TOKEN_ORG_TTL_SECONDS,
       ...(contextResult.requestCodeChallenge
         ? {
@@ -406,8 +522,10 @@ export async function tokenRequest(
     return finish(
       NextResponse.json(
         {
-          ...clerkTokens,
-          access_token: finalJwt,
+          ...(mcpAuthorizationServer ? {} : clerkTokens),
+          access_token: issuedTokens.accessToken,
+          refresh_token: issuedTokens.refreshToken,
+          token_type: "Bearer",
           expires_in: clerkTokens.expires_in,
           org_id: authorizationContext.clerk_org_id,
           access_scope: authorizationContext.access_scope,

--- a/src/lib/mcp/oauth-credential.test.ts
+++ b/src/lib/mcp/oauth-credential.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { resolvePresentedCredential } from "./oauth-credential";
+
+process.env.CLERK_SECRET_KEY ??= "test-clerk-secret";
+
+describe("presented MCP credentials", () => {
+  test("resolves Kernel access tokens to a separate provider credential", async () => {
+    const verified: string[] = [];
+    const result = await resolvePresentedCredential(
+      "kmcp_at_client_token",
+      "https://mcp.example.test/mcp",
+      {
+        getAccessTokenSession: async () => ({
+          providerJwt: "header.payload.signature",
+          resource: "https://mcp.example.test/mcp",
+        }),
+        verify: async (token) => {
+          verified.push(token);
+          return { sub: "user_1" };
+        },
+      },
+    );
+
+    expect(result).toEqual({
+      kind: "oauth",
+      clientToken: "kmcp_at_client_token",
+      providerToken: "header.payload.signature",
+      userId: "user_1",
+    });
+    expect(verified).toEqual(["header.payload.signature"]);
+  });
+
+  test("keeps existing JWT sessions and API keys compatible", async () => {
+    const dependencies = {
+      getAccessTokenSession: async () => null,
+      verify: async () => ({ sub: "user_1" }),
+    };
+    expect(
+      await resolvePresentedCredential(
+        "header.payload.signature",
+        "https://mcp.example.test/mcp",
+        dependencies,
+      ),
+    ).toMatchObject({
+      kind: "oauth",
+      clientToken: "header.payload.signature",
+      providerToken: "header.payload.signature",
+    });
+    expect(
+      await resolvePresentedCredential(
+        "sk_opaque_key",
+        "https://mcp.example.test/mcp",
+        dependencies,
+      ),
+    ).toEqual({ kind: "api_key", token: "sk_opaque_key" });
+  });
+
+  test("rejects missing and wrong-audience Kernel access tokens", async () => {
+    const verify = async () => ({ sub: "user_1" });
+    expect(
+      await resolvePresentedCredential(
+        "kmcp_at_missing",
+        "https://mcp.example.test/mcp",
+        { getAccessTokenSession: async () => null, verify },
+      ),
+    ).toMatchObject({ kind: "invalid" });
+    expect(
+      await resolvePresentedCredential(
+        "kmcp_at_wrong_audience",
+        "https://mcp.example.test/mcp",
+        {
+          getAccessTokenSession: async () => ({
+            providerJwt: "header.payload.signature",
+            resource: "https://other.example.test",
+          }),
+          verify,
+        },
+      ),
+    ).toMatchObject({ kind: "invalid" });
+    expect(
+      await resolvePresentedCredential(
+        "kmcp_at_wrong_path",
+        "https://mcp.example.test/sse",
+        {
+          getAccessTokenSession: async () => ({
+            providerJwt: "header.payload.signature",
+            resource: "https://mcp.example.test/mcp",
+          }),
+          verify,
+        },
+      ),
+    ).toMatchObject({ kind: "invalid" });
+  });
+});

--- a/src/lib/mcp/oauth-credential.ts
+++ b/src/lib/mcp/oauth-credential.ts
@@ -1,0 +1,100 @@
+import { verifyToken } from "@clerk/nextjs/server";
+import { isValidJwtFormat } from "@/lib/auth-utils";
+import {
+  getOAuthAccessTokenSession,
+  type OAuthAccessTokenSession,
+} from "@/lib/redis";
+import { isKernelOAuthAccessToken } from "@/lib/oauth-tokens";
+import { oauthResourceAllowsRequest } from "@/lib/oauth-resource";
+
+export interface PresentedCredentialDependencies {
+  getAccessTokenSession: (
+    token: string,
+  ) => Promise<OAuthAccessTokenSession | null>;
+  verify: (
+    token: string,
+    options: { secretKey?: string },
+  ) => Promise<{ sub?: string }>;
+}
+
+const dependencies: PresentedCredentialDependencies = {
+  getAccessTokenSession: getOAuthAccessTokenSession,
+  verify: verifyToken,
+};
+
+export type PresentedCredential =
+  | { kind: "api_key"; token: string }
+  | {
+      kind: "oauth";
+      clientToken: string;
+      providerToken: string;
+      userId: string;
+    }
+  | { kind: "invalid"; description: string }
+  | { kind: "unavailable" };
+
+export async function resolvePresentedCredential(
+  token: string,
+  requestUrl: string,
+  resolver: PresentedCredentialDependencies = dependencies,
+): Promise<PresentedCredential> {
+  let providerToken = token;
+  if (isKernelOAuthAccessToken(token)) {
+    let session: OAuthAccessTokenSession | null;
+    try {
+      session = await resolver.getAccessTokenSession(token);
+    } catch {
+      return { kind: "unavailable" };
+    }
+    if (!session) {
+      return {
+        kind: "invalid",
+        description: "Access token is invalid or expired",
+      };
+    }
+    try {
+      if (
+        !oauthResourceAllowsRequest({
+          resource: session.resource,
+          requestUrl,
+        })
+      ) {
+        return {
+          kind: "invalid",
+          description: "Access token is not valid for this MCP server",
+        };
+      }
+    } catch {
+      return {
+        kind: "invalid",
+        description: "Access token is not valid for this MCP server",
+      };
+    }
+    providerToken = session.providerJwt;
+  } else if (!isValidJwtFormat(token)) {
+    return { kind: "api_key", token };
+  }
+
+  try {
+    const payload = await resolver.verify(providerToken, {
+      secretKey: process.env.CLERK_SECRET_KEY,
+    });
+    if (!payload.sub) {
+      return {
+        kind: "invalid",
+        description: "Invalid token: No user ID found in token payload",
+      };
+    }
+    return {
+      kind: "oauth",
+      clientToken: token,
+      providerToken,
+      userId: payload.sub,
+    };
+  } catch (error) {
+    return {
+      kind: "invalid",
+      description: `Invalid token: ${error instanceof Error ? error.message : "Authentication failed"}`,
+    };
+  }
+}

--- a/src/lib/oauth-clients.test.ts
+++ b/src/lib/oauth-clients.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import {
+  resolveOAuthClientRedirectUris,
+  type OAuthClientResolverDependencies,
+} from "./oauth-clients";
+
+function dependencies({ cached = null }: { cached?: string[] | null } = {}) {
+  const stored: Array<{ clientId: string; redirectUris: string[] }> = [];
+  const updated: Parameters<
+    OAuthClientResolverDependencies["updateApplication"]
+  >[0][] = [];
+  const listed: Array<{ limit: number; offset: number }> = [];
+  return {
+    stored,
+    updated,
+    listed,
+    value: {
+      getCachedRedirectUris: async () => cached,
+      storeRedirectUris: async (value) => stored.push(value),
+      listApplications: async (value) => {
+        listed.push(value);
+        return {
+          data: [
+            {
+              id: "app_1",
+              clientId: "other_client",
+              name: "Other",
+              redirectUris: ["https://other.test/callback"],
+              scopes: "openid",
+              isPublic: true,
+            },
+            {
+              id: "app_2",
+              clientId: "client_1",
+              name: "Existing client",
+              redirectUris: ["http://localhost:9999/callback"],
+              scopes: "openid",
+              isPublic: true,
+            },
+          ],
+          totalCount: 2,
+        };
+      },
+      updateApplication: async (value) => updated.push(value),
+    } satisfies OAuthClientResolverDependencies,
+  };
+}
+
+describe("OAuth client redirect resolution", () => {
+  test("uses the cached registration without calling Clerk", async () => {
+    const deps = dependencies({ cached: ["http://localhost:9999/callback"] });
+    expect(
+      await resolveOAuthClientRedirectUris(
+        { clientId: "client_1", issuer: "https://auth.example.test" },
+        deps.value,
+      ),
+    ).toEqual(["http://localhost:9999/callback"]);
+    expect(deps.listed).toHaveLength(0);
+    expect(deps.updated).toHaveLength(0);
+  });
+
+  test("migrates an existing Clerk registration to the proxy callback", async () => {
+    const deps = dependencies();
+    expect(
+      await resolveOAuthClientRedirectUris(
+        { clientId: "client_1", issuer: "https://auth.example.test" },
+        deps.value,
+      ),
+    ).toEqual(["http://localhost:9999/callback"]);
+    expect(deps.updated).toEqual([
+      {
+        oauthApplicationId: "app_2",
+        name: "Existing client",
+        redirectUris: [
+          "http://localhost:9999/callback",
+          "https://auth.example.test/oauth/callback",
+        ],
+        scopes: "openid",
+        public: true,
+      },
+    ]);
+    expect(deps.stored).toEqual([
+      {
+        clientId: "client_1",
+        redirectUris: ["http://localhost:9999/callback"],
+      },
+    ]);
+  });
+});

--- a/src/lib/oauth-clients.ts
+++ b/src/lib/oauth-clients.ts
@@ -1,0 +1,95 @@
+import { clerkClient } from "@clerk/nextjs/server";
+import {
+  getOAuthClientRedirectUris,
+  setOAuthClientRedirectUris,
+} from "@/lib/redis";
+import { oauthProxyCallbackUrl } from "@/lib/oauth-proxy";
+
+interface OAuthApplicationRecord {
+  id: string;
+  clientId: string;
+  name: string;
+  redirectUris: string[];
+  scopes: string;
+  isPublic: boolean;
+}
+
+export interface OAuthClientResolverDependencies {
+  getCachedRedirectUris: (clientId: string) => Promise<string[] | null>;
+  storeRedirectUris: (input: {
+    clientId: string;
+    redirectUris: string[];
+  }) => Promise<void>;
+  listApplications: (input: {
+    limit: number;
+    offset: number;
+  }) => Promise<{ data: OAuthApplicationRecord[]; totalCount: number }>;
+  updateApplication: (input: {
+    oauthApplicationId: string;
+    name: string;
+    redirectUris: string[];
+    scopes: string;
+    public: boolean;
+  }) => Promise<void>;
+}
+
+const dependencies: OAuthClientResolverDependencies = {
+  getCachedRedirectUris: getOAuthClientRedirectUris,
+  storeRedirectUris: setOAuthClientRedirectUris,
+  listApplications: async (input) => {
+    const clerk = await clerkClient();
+    return clerk.oauthApplications.list(input);
+  },
+  updateApplication: async (input) => {
+    const clerk = await clerkClient();
+    await clerk.oauthApplications.update(input);
+  },
+};
+
+export async function resolveOAuthClientRedirectUris(
+  {
+    clientId,
+    issuer,
+  }: {
+    clientId: string;
+    issuer: string;
+  },
+  resolver: OAuthClientResolverDependencies = dependencies,
+): Promise<string[] | null> {
+  const cached = await resolver.getCachedRedirectUris(clientId);
+  if (cached) return cached;
+
+  const limit = 100;
+  let offset = 0;
+  let application: OAuthApplicationRecord | undefined;
+  do {
+    const page = await resolver.listApplications({ limit, offset });
+    application = page.data.find(
+      (candidate) => candidate.clientId === clientId,
+    );
+    if (application) break;
+    offset += page.data.length;
+    if (page.data.length === 0 || offset >= page.totalCount) break;
+  } while (!application);
+
+  if (!application) return null;
+
+  const callback = oauthProxyCallbackUrl(issuer);
+  const clientRedirectUris = application.redirectUris.filter(
+    (uri) => uri !== callback,
+  );
+  if (!application.redirectUris.includes(callback)) {
+    await resolver.updateApplication({
+      oauthApplicationId: application.id,
+      name: application.name,
+      redirectUris: [...application.redirectUris, callback],
+      scopes: application.scopes,
+      public: application.isPublic,
+    });
+  }
+  await resolver.storeRedirectUris({
+    clientId,
+    redirectUris: clientRedirectUris,
+  });
+  return clientRedirectUris;
+}

--- a/src/lib/oauth-proxy.test.ts
+++ b/src/lib/oauth-proxy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import {
+  decodeOAuthProxyState,
+  encodeOAuthProxyState,
+  oauthProxyCallbackUrl,
+} from "./oauth-proxy";
+
+process.env.CLERK_SECRET_KEY ??= "test-clerk-secret";
+
+describe("OAuth proxy state", () => {
+  test("round trips the client redirect and state", () => {
+    const encoded = encodeOAuthProxyState({
+      redirectUri: "http://localhost:58432/callback",
+      clientState: "opaque",
+      now: 1_000,
+    });
+
+    expect(decodeOAuthProxyState(encoded, 2_000)).toEqual({
+      redirectUri: "http://localhost:58432/callback",
+      clientState: "opaque",
+    });
+  });
+
+  test("rejects tampered and expired state", () => {
+    const encoded = encodeOAuthProxyState({
+      redirectUri: "http://localhost:58432/callback",
+      clientState: null,
+      now: 1_000,
+    });
+    const [payload, signature] = encoded.split(".");
+
+    expect(decodeOAuthProxyState(`${payload}x.${signature}`, 2_000)).toBeNull();
+    expect(
+      decodeOAuthProxyState(encoded, 1_000 + 60 * 60 * 1000 + 1),
+    ).toBeNull();
+  });
+
+  test("builds an origin-local callback URL", () => {
+    expect(oauthProxyCallbackUrl("https://mcp.example.test")).toBe(
+      "https://mcp.example.test/oauth/callback",
+    );
+  });
+});

--- a/src/lib/oauth-proxy.ts
+++ b/src/lib/oauth-proxy.ts
@@ -1,0 +1,92 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+const STATE_VERSION = 1;
+const STATE_TTL_MS = 60 * 60 * 1000;
+
+interface OAuthProxyState {
+  version: number;
+  redirectUri: string;
+  clientState?: string;
+  expiresAt: number;
+}
+
+function signingKey(): string {
+  const key = process.env.CLERK_SECRET_KEY;
+  if (!key) {
+    throw new Error("CLERK_SECRET_KEY environment variable must be set");
+  }
+  return key;
+}
+
+function signature(payload: string): Buffer {
+  return createHmac("sha256", signingKey()).update(payload).digest();
+}
+
+export function oauthProxyCallbackUrl(origin: string): string {
+  return new URL("/oauth/callback", origin).toString();
+}
+
+export function encodeOAuthProxyState({
+  redirectUri,
+  clientState,
+  now = Date.now(),
+}: {
+  redirectUri: string;
+  clientState: string | null;
+  now?: number;
+}): string {
+  const payload = Buffer.from(
+    JSON.stringify({
+      version: STATE_VERSION,
+      redirectUri,
+      ...(clientState === null ? {} : { clientState }),
+      expiresAt: now + STATE_TTL_MS,
+    } satisfies OAuthProxyState),
+  ).toString("base64url");
+  return `${payload}.${signature(payload).toString("base64url")}`;
+}
+
+export function decodeOAuthProxyState(
+  value: string,
+  now = Date.now(),
+): { redirectUri: string; clientState: string | null } | null {
+  const [payload, encodedSignature, extra] = value.split(".");
+  if (!payload || !encodedSignature || extra) return null;
+
+  let providedSignature: Buffer;
+  try {
+    providedSignature = Buffer.from(encodedSignature, "base64url");
+  } catch {
+    return null;
+  }
+  const expectedSignature = signature(payload);
+  if (
+    providedSignature.length !== expectedSignature.length ||
+    !timingSafeEqual(providedSignature, expectedSignature)
+  ) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(payload, "base64url").toString(),
+    ) as Partial<OAuthProxyState>;
+    if (
+      parsed.version !== STATE_VERSION ||
+      typeof parsed.redirectUri !== "string" ||
+      (parsed.clientState !== undefined &&
+        typeof parsed.clientState !== "string") ||
+      typeof parsed.expiresAt !== "number" ||
+      parsed.expiresAt < now
+    ) {
+      return null;
+    }
+    new URL(parsed.redirectUri);
+    return {
+      redirectUri: parsed.redirectUri,
+      clientState: parsed.clientState ?? null,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/oauth-resource.test.ts
+++ b/src/lib/oauth-resource.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import {
+  oauthResourceAllowsRequest,
+  resolveOAuthResource,
+} from "./oauth-resource";
+
+describe("OAuth resource binding", () => {
+  test("normalizes the server origin and supports legacy omission", () => {
+    for (const requestedResource of [
+      undefined,
+      "https://mcp.example.test",
+      "https://mcp.example.test/",
+    ]) {
+      expect(
+        resolveOAuthResource({
+          requestedResource,
+          issuer: "https://mcp.example.test",
+        }),
+      ).toBe("https://mcp.example.test");
+    }
+  });
+
+  test("binds specific MCP resources to their request path", () => {
+    expect(
+      resolveOAuthResource({
+        requestedResource: "https://mcp.example.test/mcp",
+        issuer: "https://mcp.example.test",
+      }),
+    ).toBe("https://mcp.example.test/mcp");
+    expect(
+      oauthResourceAllowsRequest({
+        resource: "https://mcp.example.test/mcp",
+        requestUrl: "https://mcp.example.test/mcp",
+      }),
+    ).toBe(true);
+    expect(
+      oauthResourceAllowsRequest({
+        resource: "https://mcp.example.test/mcp",
+        requestUrl: "https://mcp.example.test/sse",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects another audience and ambiguous resource URIs", () => {
+    for (const requestedResource of [
+      "https://api.example.test",
+      "https://mcp.example.test/other",
+      "https://mcp.example.test?target=other",
+      "not-a-url",
+    ]) {
+      expect(() =>
+        resolveOAuthResource({
+          requestedResource,
+          issuer: "https://mcp.example.test",
+        }),
+      ).toThrow();
+    }
+  });
+});

--- a/src/lib/oauth-resource.ts
+++ b/src/lib/oauth-resource.ts
@@ -1,0 +1,48 @@
+export function oauthResourceForIssuer(issuer: string): string {
+  return new URL(issuer).origin;
+}
+
+export function resolveOAuthResource({
+  requestedResource,
+  issuer,
+}: {
+  requestedResource: string | null | undefined;
+  issuer: string;
+}): string {
+  const expected = oauthResourceForIssuer(issuer);
+  if (!requestedResource) return expected;
+
+  let requested: URL;
+  try {
+    requested = new URL(requestedResource);
+  } catch {
+    throw new Error("Invalid OAuth resource");
+  }
+  if (
+    requested.username ||
+    requested.password ||
+    requested.search ||
+    requested.hash ||
+    !["", "/", "/mcp"].includes(requested.pathname) ||
+    requested.origin !== expected
+  ) {
+    throw new Error("OAuth resource does not identify this MCP server");
+  }
+  return requested.pathname === "/mcp" ? `${expected}/mcp` : expected;
+}
+
+export function oauthResourceAllowsRequest({
+  resource,
+  requestUrl,
+}: {
+  resource: string;
+  requestUrl: string;
+}): boolean {
+  const request = new URL(requestUrl);
+  const resolved = resolveOAuthResource({
+    requestedResource: resource,
+    issuer: request.origin,
+  });
+  const resourcePath = new URL(resolved).pathname;
+  return resourcePath === "/" || resourcePath === request.pathname;
+}

--- a/src/lib/oauth-scopes.test.ts
+++ b/src/lib/oauth-scopes.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { validatePublicOAuthScope } from "./oauth-scopes";
+
+describe("public OAuth scopes", () => {
+  test("defaults new clients to the MCP resource scope", () => {
+    expect(validatePublicOAuthScope(undefined)).toBe("mcp");
+    expect(validatePublicOAuthScope("mcp")).toBe("mcp");
+  });
+
+  test("accepts the legacy openid scope without arbitrary escalation", () => {
+    expect(validatePublicOAuthScope("openid")).toBe("openid");
+    expect(validatePublicOAuthScope("mcp openid mcp")).toBe("mcp openid");
+    expect(() => validatePublicOAuthScope("profile")).toThrow(
+      "Unsupported OAuth scope",
+    );
+  });
+});

--- a/src/lib/oauth-scopes.ts
+++ b/src/lib/oauth-scopes.ts
@@ -1,0 +1,18 @@
+export const MCP_OAUTH_SCOPE = "mcp";
+export const CLERK_OAUTH_SCOPE = "openid";
+
+export function validatePublicOAuthScope(
+  scope: string | null | undefined,
+): string {
+  if (!scope?.trim()) return MCP_OAUTH_SCOPE;
+  const tokens = [...new Set(scope.trim().split(/\s+/))];
+  if (
+    tokens.length === 0 ||
+    tokens.some(
+      (token) => token !== MCP_OAUTH_SCOPE && token !== CLERK_OAUTH_SCOPE,
+    )
+  ) {
+    throw new Error("Unsupported OAuth scope");
+  }
+  return tokens.join(" ");
+}

--- a/src/lib/oauth-server.test.ts
+++ b/src/lib/oauth-server.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { isMcpAuthorizationServer } from "./oauth-server";
+
+describe("OAuth server aliases", () => {
+  test("keeps CLI auth aliases separate from MCP authorization", () => {
+    expect(isMcpAuthorizationServer("https://mcp.onkernel.com")).toBe(true);
+    expect(isMcpAuthorizationServer("https://mcp.dev.onkernel.com")).toBe(true);
+    expect(isMcpAuthorizationServer("https://preview.example.test")).toBe(true);
+    expect(isMcpAuthorizationServer("https://auth.onkernel.com")).toBe(false);
+    expect(isMcpAuthorizationServer("https://auth.dev.onkernel.com")).toBe(
+      false,
+    );
+  });
+});

--- a/src/lib/oauth-server.ts
+++ b/src/lib/oauth-server.ts
@@ -1,0 +1,5 @@
+const CLI_AUTH_HOSTS = new Set(["auth.onkernel.com", "auth.dev.onkernel.com"]);
+
+export function isMcpAuthorizationServer(origin: string): boolean {
+  return !CLI_AUTH_HOSTS.has(new URL(origin).hostname);
+}

--- a/src/lib/oauth-tokens.test.ts
+++ b/src/lib/oauth-tokens.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isKernelOAuthAccessToken,
+  isKernelOAuthRefreshToken,
+  issueKernelOAuthTokens,
+  openOAuthProviderToken,
+  sealOAuthProviderToken,
+} from "./oauth-tokens";
+
+process.env.CLERK_SECRET_KEY ??= "test-clerk-secret";
+
+describe("Kernel OAuth tokens", () => {
+  test("issues distinct opaque access and refresh credentials", () => {
+    const first = issueKernelOAuthTokens();
+    const second = issueKernelOAuthTokens();
+
+    expect(isKernelOAuthAccessToken(first.accessToken)).toBe(true);
+    expect(isKernelOAuthRefreshToken(first.refreshToken)).toBe(true);
+    expect(first.accessToken).not.toBe(second.accessToken);
+    expect(first.refreshToken).not.toBe(second.refreshToken);
+    expect(first.accessToken.split(".")).toHaveLength(1);
+  });
+
+  test("encrypts provider credentials and rejects tampering", () => {
+    const sealed = sealOAuthProviderToken("provider-secret");
+    expect(sealed).not.toContain("provider-secret");
+    expect(openOAuthProviderToken(sealed)).toBe("provider-secret");
+
+    const parts = sealed.split(".");
+    parts[3] = `${parts[3]?.startsWith("A") ? "B" : "A"}${parts[3]?.slice(1)}`;
+    expect(() => openOAuthProviderToken(parts.join("."))).toThrow(
+      "Invalid encrypted OAuth provider token",
+    );
+  });
+});

--- a/src/lib/oauth-tokens.ts
+++ b/src/lib/oauth-tokens.ts
@@ -1,0 +1,86 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  randomBytes,
+} from "crypto";
+
+export const KERNEL_OAUTH_ACCESS_TOKEN_PREFIX = "kmcp_at_";
+export const KERNEL_OAUTH_REFRESH_TOKEN_PREFIX = "kmcp_rt_";
+
+function randomToken(prefix: string): string {
+  return `${prefix}${randomBytes(32).toString("base64url")}`;
+}
+
+export function issueKernelOAuthTokens(): {
+  accessToken: string;
+  refreshToken: string;
+} {
+  return {
+    accessToken: randomToken(KERNEL_OAUTH_ACCESS_TOKEN_PREFIX),
+    refreshToken: randomToken(KERNEL_OAUTH_REFRESH_TOKEN_PREFIX),
+  };
+}
+
+export function isKernelOAuthAccessToken(token: string): boolean {
+  return token.startsWith(KERNEL_OAUTH_ACCESS_TOKEN_PREFIX);
+}
+
+export function isKernelOAuthRefreshToken(token: string): boolean {
+  return token.startsWith(KERNEL_OAUTH_REFRESH_TOKEN_PREFIX);
+}
+
+function encryptionKey(): Buffer {
+  const secret = process.env.CLERK_SECRET_KEY;
+  if (!secret) {
+    throw new Error("CLERK_SECRET_KEY environment variable must be set");
+  }
+  return createHash("sha256")
+    .update("kernel-mcp-oauth-credential\0")
+    .update(secret)
+    .digest();
+}
+
+export function sealOAuthProviderToken(token: string): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", encryptionKey(), iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(token, "utf8"),
+    cipher.final(),
+  ]);
+  return [
+    "v1",
+    iv.toString("base64url"),
+    ciphertext.toString("base64url"),
+    cipher.getAuthTag().toString("base64url"),
+  ].join(".");
+}
+
+export function openOAuthProviderToken(sealed: string): string {
+  const [version, encodedIv, encodedCiphertext, encodedTag, ...rest] =
+    sealed.split(".");
+  if (
+    version !== "v1" ||
+    !encodedIv ||
+    !encodedCiphertext ||
+    !encodedTag ||
+    rest.length > 0
+  ) {
+    throw new Error("Invalid encrypted OAuth provider token");
+  }
+
+  try {
+    const decipher = createDecipheriv(
+      "aes-256-gcm",
+      encryptionKey(),
+      Buffer.from(encodedIv, "base64url"),
+    );
+    decipher.setAuthTag(Buffer.from(encodedTag, "base64url"));
+    return Buffer.concat([
+      decipher.update(Buffer.from(encodedCiphertext, "base64url")),
+      decipher.final(),
+    ]).toString("utf8");
+  } catch {
+    throw new Error("Invalid encrypted OAuth provider token");
+  }
+}

--- a/src/lib/org-utils.test.ts
+++ b/src/lib/org-utils.test.ts
@@ -14,6 +14,7 @@ process.env.OAUTH_LEGACY_NON_PKCE_CLIENT_IDS = "legacy_client";
 const { resolveAuthorizationContext } = await import("./org-utils");
 
 let requestContext: OAuthAuthorizationContext | null = null;
+let requestResource: string | null = null;
 let clientContext: OAuthAuthorizationContext | null = null;
 let refreshContext: OAuthAuthorizationContext | null = null;
 let requestLookup: { clientId: string; codeChallenge: string } | null = null;
@@ -23,6 +24,7 @@ const dependencies: AuthorizationContextDependencies = {
     requestLookup = value;
     return requestContext;
   },
+  getRequestResource: async () => requestResource,
   getClientContext: async () => clientContext,
   getRefreshContext: async () => refreshContext,
 };
@@ -35,6 +37,7 @@ function resolveContext(
 
 beforeEach(() => {
   requestContext = null;
+  requestResource = null;
   clientContext = null;
   refreshContext = null;
   requestLookup = null;
@@ -42,6 +45,7 @@ beforeEach(() => {
 
 describe("resolveAuthorizationContext", () => {
   test("uses the PKCE-bound request context", async () => {
+    requestResource = "https://mcp.example.test/mcp";
     requestContext = projectAuthorizationContext({
       clerkUserId: "user_1",
       clerkOrgId: "org_1",
@@ -62,6 +66,7 @@ describe("resolveAuthorizationContext", () => {
     expect(result.requestCodeChallenge).toBe(
       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
     );
+    expect(result.requestResource).toBe("https://mcp.example.test/mcp");
   });
 
   test("refresh uses only the refresh-token mapping", async () => {

--- a/src/lib/org-utils.ts
+++ b/src/lib/org-utils.ts
@@ -3,6 +3,7 @@ import {
   getAuthorizationContextForClientId,
   getAuthorizationContextForRefreshTokenSliding,
   getAuthorizationContextForRequest,
+  getAuthorizationResourceForRequest,
 } from "./redis";
 import { isLegacyNonPkceClient, REFRESH_TOKEN_ORG_TTL_SECONDS } from "./const";
 import {
@@ -31,12 +32,14 @@ function createErrorResponse(
 
 export interface AuthorizationContextDependencies {
   getRequestContext: typeof getAuthorizationContextForRequest;
+  getRequestResource: typeof getAuthorizationResourceForRequest;
   getClientContext: typeof getAuthorizationContextForClientId;
   getRefreshContext: typeof getAuthorizationContextForRefreshTokenSliding;
 }
 
 const authorizationContextDependencies: AuthorizationContextDependencies = {
   getRequestContext: getAuthorizationContextForRequest,
+  getRequestResource: getAuthorizationResourceForRequest,
   getClientContext: getAuthorizationContextForClientId,
   getRefreshContext: getAuthorizationContextForRefreshTokenSliding,
 };
@@ -44,6 +47,7 @@ const authorizationContextDependencies: AuthorizationContextDependencies = {
 export interface ResolvedAuthorizationContext {
   authorizationContext: OAuthAuthorizationContext | null;
   requestCodeChallenge?: string;
+  requestResource?: string;
   error?: NextResponse;
 }
 
@@ -65,14 +69,15 @@ export async function resolveAuthorizationContext(
     if (codeVerifier) {
       const codeChallenge = deriveS256CodeChallenge(codeVerifier);
       try {
-        const authorizationContext = await dependencies.getRequestContext({
-          clientId,
-          codeChallenge,
-        });
+        const [authorizationContext, requestResource] = await Promise.all([
+          dependencies.getRequestContext({ clientId, codeChallenge }),
+          dependencies.getRequestResource({ clientId, codeChallenge }),
+        ]);
         if (authorizationContext) {
           return {
             authorizationContext,
             requestCodeChallenge: codeChallenge,
+            ...(requestResource ? { requestResource } : {}),
           };
         }
         return {

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -6,6 +6,10 @@ import {
   parseAuthorizationContext,
   serializeAuthorizationContext,
 } from "@/lib/oauth-context";
+import {
+  openOAuthProviderToken,
+  sealOAuthProviderToken,
+} from "@/lib/oauth-tokens";
 
 const redisUrl = process.env.REDIS_URL;
 const redisTlsServerName = process.env.REDIS_TLS_SERVER_NAME;
@@ -120,24 +124,93 @@ function authorizationRequestKey(
   return `oauth-request:${hashOpaqueToken(`${clientId}:${codeChallenge}`)}`;
 }
 
+function authorizationRequestResourceKey(
+  clientId: string,
+  codeChallenge: string,
+): string {
+  return `oauth-request-resource:${hashOpaqueToken(`${clientId}:${codeChallenge}`)}`;
+}
+
+function oauthClientRegistrationKey(clientId: string): string {
+  return `oauth-client:${hashOpaqueToken(clientId)}`;
+}
+
+function oauthAccessTokenKey(accessToken: string): string {
+  return `oauth-access:${hashOpaqueToken(accessToken)}`;
+}
+
+function oauthProviderRefreshTokenKey(refreshToken: string): string {
+  return `oauth-provider-refresh:${hashOpaqueToken(refreshToken)}`;
+}
+
+export async function setOAuthClientRedirectUris({
+  clientId,
+  redirectUris,
+}: {
+  clientId: string;
+  redirectUris: string[];
+}): Promise<void> {
+  await ensureConnected();
+  await withReconnect(() =>
+    client.set(
+      oauthClientRegistrationKey(clientId),
+      JSON.stringify({ redirect_uris: redirectUris }),
+    ),
+  );
+}
+
+export async function getOAuthClientRedirectUris(
+  clientId: string,
+): Promise<string[] | null> {
+  await ensureConnected();
+  const value = await withReconnect(() =>
+    client.get(oauthClientRegistrationKey(clientId)),
+  );
+  if (!value) return null;
+
+  try {
+    const parsed = JSON.parse(value) as { redirect_uris?: unknown };
+    if (
+      !Array.isArray(parsed.redirect_uris) ||
+      !parsed.redirect_uris.every((uri) => typeof uri === "string")
+    ) {
+      throw new Error("Invalid OAuth client registration");
+    }
+    return parsed.redirect_uris;
+  } catch (error) {
+    console.error("Invalid OAuth client registration in Redis", { error });
+    throw error;
+  }
+}
+
 export async function setAuthorizationContextForRequest({
   clientId,
   codeChallenge,
   authorizationContext,
+  resource,
   ttlSeconds,
 }: {
   clientId: string;
   codeChallenge: string;
   authorizationContext: OAuthAuthorizationContext;
+  resource: string;
   ttlSeconds: number;
 }): Promise<void> {
   await ensureConnected();
   await withReconnect(() =>
-    client.setEx(
-      authorizationRequestKey(clientId, codeChallenge),
-      ttlSeconds,
-      serializeAuthorizationContext(authorizationContext),
-    ),
+    client
+      .multi()
+      .setEx(
+        authorizationRequestKey(clientId, codeChallenge),
+        ttlSeconds,
+        serializeAuthorizationContext(authorizationContext),
+      )
+      .setEx(
+        authorizationRequestResourceKey(clientId, codeChallenge),
+        ttlSeconds,
+        resource,
+      )
+      .exec(),
   );
 }
 
@@ -153,6 +226,19 @@ export async function getAuthorizationContextForRequest({
     client.get(authorizationRequestKey(clientId, codeChallenge)),
   );
   return value ? parseAuthorizationContext(value) : null;
+}
+
+export async function getAuthorizationResourceForRequest({
+  clientId,
+  codeChallenge,
+}: {
+  clientId: string;
+  codeChallenge: string;
+}): Promise<string | null> {
+  await ensureConnected();
+  return await withReconnect(() =>
+    client.get(authorizationRequestResourceKey(clientId, codeChallenge)),
+  );
 }
 
 export async function setAuthorizationContextForClientId({
@@ -258,47 +344,107 @@ export async function getAuthorizationContextForRefreshTokenSliding({
   return value ? parseAuthorizationContext(value) : null;
 }
 
+export interface OAuthAccessTokenSession {
+  providerJwt: string;
+  resource: string;
+}
+
+export async function getOAuthAccessTokenSession(
+  accessToken: string,
+): Promise<OAuthAccessTokenSession | null> {
+  await ensureConnected();
+  const value = await withReconnect(() =>
+    client.get(oauthAccessTokenKey(accessToken)),
+  );
+  if (!value) return null;
+  const parsed = JSON.parse(
+    openOAuthProviderToken(value),
+  ) as Partial<OAuthAccessTokenSession>;
+  if (!parsed.providerJwt || !parsed.resource) {
+    throw new Error("Invalid OAuth access token session");
+  }
+  return { providerJwt: parsed.providerJwt, resource: parsed.resource };
+}
+
+export async function getOAuthProviderRefreshToken(
+  refreshToken: string,
+): Promise<string | null> {
+  await ensureConnected();
+  const value = await withReconnect(() =>
+    client.get(oauthProviderRefreshTokenKey(refreshToken)),
+  );
+  return value ? openOAuthProviderToken(value) : null;
+}
+
 export async function persistOAuthTokenContexts({
-  jwt,
-  newRefreshToken,
-  oldRefreshToken,
+  providerJwt,
+  publicAccessToken,
+  providerRefreshToken,
+  publicRefreshToken,
+  oldPublicRefreshToken,
   authorizationContext,
-  jwtTtlSeconds,
+  resource,
+  accessTokenTtlSeconds,
   refreshTtlSeconds,
   consumedRequest,
 }: {
-  jwt: string;
-  newRefreshToken: string;
-  oldRefreshToken?: string;
+  providerJwt: string;
+  publicAccessToken: string;
+  providerRefreshToken: string;
+  publicRefreshToken: string;
+  oldPublicRefreshToken?: string;
   authorizationContext: OAuthAuthorizationContext;
-  jwtTtlSeconds: number;
+  resource: string;
+  accessTokenTtlSeconds: number;
   refreshTtlSeconds: number;
   consumedRequest?: { clientId: string; codeChallenge: string };
 }): Promise<void> {
   await ensureConnected();
-  const jwtKey = `jwt:${hashJwt(jwt)}`;
-  const newRefreshKey = `refresh:${hashOpaqueToken(newRefreshToken)}`;
-  const oldRefreshKey = oldRefreshToken
-    ? `refresh:${hashOpaqueToken(oldRefreshToken)}`
+  const jwtKey = `jwt:${hashJwt(providerJwt)}`;
+  const accessKey = oauthAccessTokenKey(publicAccessToken);
+  const newRefreshKey = `refresh:${hashOpaqueToken(publicRefreshToken)}`;
+  const providerRefreshKey = oauthProviderRefreshTokenKey(publicRefreshToken);
+  const oldRefreshKey = oldPublicRefreshToken
+    ? `refresh:${hashOpaqueToken(oldPublicRefreshToken)}`
+    : undefined;
+  const oldProviderRefreshKey = oldPublicRefreshToken
+    ? oauthProviderRefreshTokenKey(oldPublicRefreshToken)
     : undefined;
   const value = serializeAuthorizationContext(authorizationContext);
 
   await withReconnect(async () => {
     const transaction = client
       .multi()
-      .setEx(jwtKey, jwtTtlSeconds, value)
-      .setEx(newRefreshKey, refreshTtlSeconds, value);
+      .setEx(jwtKey, accessTokenTtlSeconds, value)
+      .setEx(
+        accessKey,
+        accessTokenTtlSeconds,
+        sealOAuthProviderToken(JSON.stringify({ providerJwt, resource })),
+      )
+      .setEx(newRefreshKey, refreshTtlSeconds, value)
+      .setEx(
+        providerRefreshKey,
+        refreshTtlSeconds,
+        sealOAuthProviderToken(providerRefreshToken),
+      );
 
     if (oldRefreshKey && oldRefreshKey !== newRefreshKey) {
       transaction.del(oldRefreshKey);
     }
+    if (oldProviderRefreshKey && oldProviderRefreshKey !== providerRefreshKey) {
+      transaction.del(oldProviderRefreshKey);
+    }
     if (consumedRequest) {
-      transaction.del(
+      transaction.del([
         authorizationRequestKey(
           consumedRequest.clientId,
           consumedRequest.codeChallenge,
         ),
-      );
+        authorizationRequestResourceKey(
+          consumedRequest.clientId,
+          consumedRequest.codeChallenge,
+        ),
+      ]);
     }
 
     await transaction.exec();

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,6 +8,7 @@ const isPublicRoute = createRouteMatcher([
   "/register",
   "/authorize",
   "/oauth-consent",
+  "/oauth/callback",
   "/token",
   // Public only at this narrow relay boundary. The route itself accepts an
   // unauthenticated single-use exchange and validates scoped managed-auth JWTs


### PR DESCRIPTION
## Summary

- terminate the public OAuth flow at the Kernel issuer so authorization responses carry a matching RFC 9207 `iss` value
- issue resource-bound opaque MCP access and refresh tokens while keeping Clerk credentials encrypted and server-side
- advertise an MCP resource scope, protected-resource metadata, and standards-compliant dynamic registration responses
- migrate existing Clerk client registrations lazily and accept existing Clerk JWT and refresh credentials during rollout
- preserve the existing `auth.onkernel.com` CLI token flow unchanged

## Validation

- `bun test` (277 tests)
- production build with required environment variables
- Redis integration test covering authorization-resource binding, encrypted credential lookup, request consumption, and refresh rotation
- OAuth conformance fixture covering discovery, registration, PKCE, callback issuer validation, organization/project scopes, token exchange, and refresh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This rewires the public OAuth token boundary, Redis-backed credential storage, and MCP authentication. Mistakes here can leak Clerk tokens, break existing clients, or weaken redirect/resource binding.
> 
> **Overview**
> MCP OAuth now terminates at Kernel: clients receive opaque `kmcp_at_` / `kmcp_rt_` tokens bound to an RFC 8707 resource, while Clerk JWTs and refresh tokens stay encrypted server-side and are never returned as MCP credentials.
> 
> Authorization is proxied through `/oauth/callback` so the public `iss` matches the Kernel issuer (RFC 9207). Dynamic registration advertises the `mcp` scope, stores client redirect URIs, and lazily migrates existing Clerk apps onto the proxy callback. Token and MCP handlers validate resource, registered redirects, and presented Kernel tokens (with JWT/API-key fallback). The `auth.onkernel.com` CLI flow still returns Clerk credentials unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cdfc7eb023078e08977a5dcb2c22acb7847d2e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->