### PR TITLE
Record the OAuth Redis persistence contract as golden fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,16 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 20
     steps:
       - uses: actions/checkout@v4
 
@@ -28,3 +38,11 @@ jobs:
 
       - name: Test
         run: bun test
+
+      - name: OAuth Redis recordings are up to date
+        run: |
+          bun scripts/record-oauth-redis-contract.ts
+          git diff --exit-code -- fixtures/oauth-redis-recordings.json \
+            || (echo "fixtures/oauth-redis-recordings.json differs from what the OAuth code now writes." \
+                echo "Re-run: bun scripts/record-oauth-redis-contract.ts, review the diff, and commit it." \
+                exit 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,8 @@ jobs:
       - name: OAuth Redis recordings are up to date
         run: |
           bun scripts/record-oauth-redis-contract.ts
-          git diff --exit-code -- fixtures/oauth-redis-recordings.json \
-            || (echo "fixtures/oauth-redis-recordings.json differs from what the OAuth code now writes." \
-                echo "Re-run: bun scripts/record-oauth-redis-contract.ts, review the diff, and commit it." \
-                exit 1)
+          git diff --exit-code -- fixtures/oauth-redis-recordings.json || {
+            echo "fixtures/oauth-redis-recordings.json differs from what the OAuth code now writes."
+            echo "Re-run: bun scripts/record-oauth-redis-contract.ts, review the diff, and commit it."
+            exit 1
+          }

--- a/fixtures/oauth-redis-recordings.json
+++ b/fixtures/oauth-redis-recordings.json
@@ -5,7 +5,7 @@
       "command": "bun scripts/record-oauth-redis-contract.ts",
       "enforcement": "CI regenerates this file and fails when it differs from what is committed.",
       "redis": "Isolated disposable Redis; database 15 is flushed between scenarios.",
-      "ttl_note": "ttl_seconds is read back from Redis immediately after each step; Redis rounds to the nearest second, so treat an off-by-one as timing noise."
+      "ttl_note": "ttl_seconds is read back from Redis and snapped to the nearest pinned TTL (3600 or 2592000) within a 5s tolerance; anything outside tolerance fails the run."
     },
     "key_derivations": {
       "jwt:<hmac>": "HMAC-SHA256(CLERK_SECRET_KEY, access token), hex digest",
@@ -81,7 +81,7 @@
       "authorization_code_org_scoped_pkce: PKCE authorization for an organization-wide scope: authorize stores the oauth-request context, the code exchange consumes it and persists jwt/refresh mappings.",
       "authorization_code_project_scoped_pkce: Same as above but the selected scope is a single project, so the persisted context carries project_id.",
       "refresh_token_rotation_sliding_ttl: An initial org-scoped grant is followed by a refresh_token grant: the old refresh mapping is deleted, the rotated one is written with a fresh sliding TTL.",
-      "legacy_non_pkce_client: A allowlisted legacy client without PKCE: authorize stores the context under the literal client:<client_id> key, which its exchanges read.",
+      "legacy_non_pkce_client: An allowlisted legacy client without PKCE: authorize stores the context under the literal client:<client_id> key, which its exchanges read.",
       "refresh_backfills_clerk_user_id_from_id_token: A pre-existing context without clerk_user_id (stored by older versions) is refreshed: the id_token subject is backfilled into the newly written contexts."
     ]
   },
@@ -191,7 +191,7 @@
     },
     {
       "name": "legacy_non_pkce_client",
-      "description": "A allowlisted legacy client without PKCE: authorize stores the context under the literal client:<client_id> key, which its exchanges read.",
+      "description": "An allowlisted legacy client without PKCE: authorize stores the context under the literal client:<client_id> key, which its exchanges read.",
       "snapshots": [
         {
           "after": "after_authorize",

--- a/fixtures/oauth-redis-recordings.json
+++ b/fixtures/oauth-redis-recordings.json
@@ -5,7 +5,7 @@
       "command": "bun scripts/record-oauth-redis-contract.ts",
       "enforcement": "CI regenerates this file and fails when it differs from what is committed.",
       "redis": "Isolated disposable Redis; must be loopback unless OAUTH_RECORDING_ALLOW_REMOTE_REDIS=1. Database 15 is flushed between scenarios.",
-      "ttl_note": "ttl_seconds is the exact ttlSeconds argument the OAuth code passed to the Redis writers, captured at the dependency seam. The live Redis TTL is only sanity-checked against it (within 10s) to confirm expiration was applied."
+      "ttl_note": "ttl_seconds is the exact ttlSeconds argument the OAuth code passed to the Redis writers, captured at the dependency seam for the specific key it was called with. The live Redis TTL is only sanity-checked against it (within 10s) to confirm expiration was applied."
     },
     "key_derivations": {
       "jwt:<hmac>": "HMAC-SHA256(CLERK_SECRET_KEY, access token), hex digest",

--- a/fixtures/oauth-redis-recordings.json
+++ b/fixtures/oauth-redis-recordings.json
@@ -1,0 +1,270 @@
+{
+  "meta": {
+    "purpose": "Golden fixtures of the Redis state written by the OAuth /authorize and /token endpoints for fixed logins. Key names, HMAC derivations, stored values, and TTLs must stay byte-identical unless a diff is reviewed deliberately.",
+    "regeneration": {
+      "command": "bun scripts/record-oauth-redis-contract.ts",
+      "enforcement": "CI regenerates this file and fails when it differs from what is committed.",
+      "redis": "Isolated disposable Redis; database 15 is flushed between scenarios.",
+      "ttl_note": "ttl_seconds is read back from Redis immediately after each step; Redis rounds to the nearest second, so treat an off-by-one as timing noise."
+    },
+    "key_derivations": {
+      "jwt:<hmac>": "HMAC-SHA256(CLERK_SECRET_KEY, access token), hex digest",
+      "refresh:<hmac>": "HMAC-SHA256(CLERK_SECRET_KEY, refresh token), hex digest",
+      "oauth-request:<hmac>": "HMAC-SHA256(CLERK_SECRET_KEY, '<client_id>:<code_challenge>'), hex digest",
+      "client:<client_id>": "Legacy allowlisted clients only; the client id is used literally, not hashed."
+    },
+    "pinned_inputs": {
+      "environment": {
+        "CLERK_SECRET_KEY": "sk_test_recording_fixture",
+        "NEXT_PUBLIC_CLERK_DOMAIN": "clerk.recording.invalid",
+        "KERNEL_CLI_PROD_CLIENT_ID": "rec_cli_prod",
+        "KERNEL_CLI_STAGING_CLIENT_ID": "rec_cli_staging",
+        "KERNEL_CLI_DEV_CLIENT_ID": "rec_cli_dev",
+        "OAUTH_LEGACY_NON_PKCE_CLIENT_IDS": "rec_legacy_client"
+      },
+      "identifiers": {
+        "pkce_client_id": "rec_pkce_client",
+        "project_client_id": "rec_project_client",
+        "legacy_client_id": "rec_legacy_client",
+        "clerk_user_id": "user_rec_1",
+        "clerk_org_id": "org_rec_1",
+        "project_id": "proj_rec_1",
+        "clerk_session_token": "rec-clerk-session-token",
+        "seed_id_token": "rec-id-token-seed-v1",
+        "seed_refresh_token": "rec-refresh-seed-v1"
+      },
+      "pkce": {
+        "code_verifier": "recording-code-verifier-0123456789abcdef",
+        "code_challenge": "EicgRPETe-PXVNj6D8JnnGpVo9wX8fcNL9jNzQegmas",
+        "note": "code_challenge is base64url(SHA-256(code_verifier)) with no padding."
+      },
+      "clerk_responses": {
+        "authorization_code_organization": {
+          "access_token": "rec-clerk-access-token-org",
+          "id_token": "rec-id-token-org-v1",
+          "refresh_token": "rec-refresh-initial-org-v1",
+          "expires_in": 3600,
+          "token_type": "Bearer"
+        },
+        "authorization_code_project": {
+          "access_token": "rec-clerk-access-token-project",
+          "id_token": "rec-id-token-project-v1",
+          "refresh_token": "rec-refresh-initial-project-v1",
+          "expires_in": 3600,
+          "token_type": "Bearer"
+        },
+        "refresh_after_org_grant": {
+          "access_token": "rec-clerk-access-token-refresh",
+          "id_token": "rec-id-token-after-refresh-v1",
+          "refresh_token": "rec-refresh-rotated-v1",
+          "expires_in": 3600,
+          "token_type": "Bearer"
+        },
+        "legacy_non_pkce_exchange": {
+          "access_token": "rec-clerk-access-token-legacy",
+          "id_token": "rec-id-token-legacy-v1",
+          "refresh_token": "rec-refresh-legacy-grant-v1",
+          "expires_in": 3600,
+          "token_type": "Bearer"
+        },
+        "refresh_after_backfill_seed": {
+          "access_token": "rec-clerk-access-token-backfill",
+          "id_token": "rec-id-token-backfill-v1",
+          "refresh_token": "rec-refresh-backfill-rotated-v1",
+          "expires_in": 3600,
+          "token_type": "Bearer"
+        }
+      },
+      "context_serialization": "Stored values are JSON strings whose field order follows the writer: version, clerk_user_id?, clerk_org_id, access_scope[, project_id]."
+    },
+    "coverage": [
+      "authorization_code_org_scoped_pkce: PKCE authorization for an organization-wide scope: authorize stores the oauth-request context, the code exchange consumes it and persists jwt/refresh mappings.",
+      "authorization_code_project_scoped_pkce: Same as above but the selected scope is a single project, so the persisted context carries project_id.",
+      "refresh_token_rotation_sliding_ttl: An initial org-scoped grant is followed by a refresh_token grant: the old refresh mapping is deleted, the rotated one is written with a fresh sliding TTL.",
+      "legacy_non_pkce_client: A allowlisted legacy client without PKCE: authorize stores the context under the literal client:<client_id> key, which its exchanges read.",
+      "refresh_backfills_clerk_user_id_from_id_token: A pre-existing context without clerk_user_id (stored by older versions) is refreshed: the id_token subject is backfilled into the newly written contexts."
+    ]
+  },
+  "scenarios": [
+    {
+      "name": "authorization_code_org_scoped_pkce",
+      "description": "PKCE authorization for an organization-wide scope: authorize stores the oauth-request context, the code exchange consumes it and persists jwt/refresh mappings.",
+      "snapshots": [
+        {
+          "after": "after_authorize",
+          "keys": [
+            {
+              "key": "oauth-request:06dcc014a0e11f4b90a6d48dce64b89085b2cd868b50d7996ee7e793a545f414",
+              "value": "{\"version\":1,\"clerk_user_id\":\"user_rec_1\",\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"organization\"}",
+              "ttl_seconds": 3600
+            }
+          ]
+        },
+        {
+          "after": "after_token_exchange",
+          "keys": [
+            {
+              "key": "jwt:f354fa5d08a8a7980a9e46916d041eaadbd3da546397224b45f37dbbba269f5f",
+              "value": "{\"version\":1,\"clerk_user_id\":\"user_rec_1\",\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"organization\"}",
+              "ttl_seconds": 3600
+            },
+            {
+              "key": "refresh:5a492120707275e568071d1de4a0f33ab6d95247a0a89ac6ee3e94ab4af587c6",
+              "value": "{\"version\":1,\"clerk_user_id\":\"user_rec_1\",\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"organization\"}",
+              "ttl_seconds": 2592000
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "authorization_code_project_scoped_pkce",
+      "description": "Same as above but the selected scope is a single project, so the persisted context carries project_id.",
+      "snapshots": [
+        {
+          "after": "after_authorize",
+          "keys": [
+            {
+              "key": "oauth-request:1a0d98caaf238aeb350c65051b25a0fa9265bf0bf769816c8dd4cf5eb132e760",
+              "value": "{\"version\":1,\"clerk_user_id\":\"user_rec_1\",\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"project\",\"project_id\":\"proj_rec_1\"}",
+              "ttl_seconds": 3600
+            }
+          ]
+        },
+        {
+          "after": "after_token_exchange",
+          "keys": [
+            {
+              "key": "jwt:f9c717769b693a3f41c28e0bdb1241686285b26e84cfa7d89648299cba042836",
+              "value": "{\"version\":1,\"clerk_user_id\":\"user_rec_1\",\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"project\",\"project_id\":\"proj_rec_1\"}",
+              "ttl_seconds": 3600
+            },
+            {
+              "key": "refresh:9152aa32fd1dbd4be8d9d377f258da227855ff0ddac45f87d3ba52bb3c36293a",
+              "value": "{\"version\":1,\"clerk_user_id\":\"user_rec_1\",\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"project\",\"project_id\":\"proj_rec_1\"}",
+              "ttl_seconds": 2592000
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "refresh_token_rotation_sliding_ttl",
+      "description": "An initial org-scoped grant is followed by a refresh_token grant: the old refresh mapping is deleted, the rotated one is written with a fresh sliding TTL.",
+      "snapshots": [
+        {
+          "after": "after_initial_authorization_code_grant",
+          "keys": [
+            {
+              "key": "jwt:f354fa5d08a8a7980a9e46916d041eaadbd3da546397224b45f37dbbba269f5f",
+              "value": "{\"version\":1,\"clerk_user_id\":\"user_rec_1\",\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"organization\"}",
+              "ttl_seconds": 3600
+            },
+            {
+              "key": "refresh:5a492120707275e568071d1de4a0f33ab6d95247a0a89ac6ee3e94ab4af587c6",
+              "value": "{\"version\":1,\"clerk_user_id\":\"user_rec_1\",\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"organization\"}",
+              "ttl_seconds": 2592000
+            }
+          ]
+        },
+        {
+          "after": "after_refresh_grant",
+          "keys": [
+            {
+              "key": "jwt:339e3960e97f29e7f574acf069d5437259977134bf5ca1e6e276bcd0ba83e8c1",
+              "value": "{\"version\":1,\"clerk_user_id\":\"user_rec_1\",\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"organization\"}",
+              "ttl_seconds": 3600
+            },
+            {
+              "key": "jwt:f354fa5d08a8a7980a9e46916d041eaadbd3da546397224b45f37dbbba269f5f",
+              "value": "{\"version\":1,\"clerk_user_id\":\"user_rec_1\",\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"organization\"}",
+              "ttl_seconds": 3600
+            },
+            {
+              "key": "refresh:d5b1e992e291db7209e801cdb0428263e2bb960581aa1d07d97ba92bd256a678",
+              "value": "{\"version\":1,\"clerk_user_id\":\"user_rec_1\",\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"organization\"}",
+              "ttl_seconds": 2592000
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "legacy_non_pkce_client",
+      "description": "A allowlisted legacy client without PKCE: authorize stores the context under the literal client:<client_id> key, which its exchanges read.",
+      "snapshots": [
+        {
+          "after": "after_authorize",
+          "keys": [
+            {
+              "key": "client:rec_legacy_client",
+              "value": "{\"version\":1,\"clerk_user_id\":\"user_rec_1\",\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"organization\"}",
+              "ttl_seconds": 3600
+            }
+          ]
+        },
+        {
+          "after": "after_token_exchange",
+          "keys": [
+            {
+              "key": "client:rec_legacy_client",
+              "value": "{\"version\":1,\"clerk_user_id\":\"user_rec_1\",\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"organization\"}",
+              "ttl_seconds": 3600
+            },
+            {
+              "key": "jwt:abf831c1434d9fd3ffa39ee4b8d08baee0ea3f2820bb397b47020976cd39b8d4",
+              "value": "{\"version\":1,\"clerk_user_id\":\"user_rec_1\",\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"organization\"}",
+              "ttl_seconds": 3600
+            },
+            {
+              "key": "refresh:32ebe0edb7810a711cb9512453d3c35951c92e29d6fdef05b0e113a290b836b7",
+              "value": "{\"version\":1,\"clerk_user_id\":\"user_rec_1\",\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"organization\"}",
+              "ttl_seconds": 2592000
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "refresh_backfills_clerk_user_id_from_id_token",
+      "description": "A pre-existing context without clerk_user_id (stored by older versions) is refreshed: the id_token subject is backfilled into the newly written contexts.",
+      "snapshots": [
+        {
+          "after": "after_seeding_legacy_contexts",
+          "keys": [
+            {
+              "key": "jwt:e7eff5decd43cef2cff150346e1abd0f70148901d02f75f3ff156d4585c2845d",
+              "value": "{\"version\":1,\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"organization\"}",
+              "ttl_seconds": 3600
+            },
+            {
+              "key": "refresh:fbfc42851abca9b7e7916c50bc0ad80c3cfc771a4d01021147b613047802748a",
+              "value": "{\"version\":1,\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"organization\"}",
+              "ttl_seconds": 2592000
+            }
+          ]
+        },
+        {
+          "after": "after_refresh_grant",
+          "keys": [
+            {
+              "key": "jwt:03ce2c74deb9d836999e931f4d325cc28f7587c8063cce6681ed2a05033fc2a2",
+              "value": "{\"version\":1,\"clerk_user_id\":\"user_rec_1\",\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"organization\"}",
+              "ttl_seconds": 3600
+            },
+            {
+              "key": "jwt:e7eff5decd43cef2cff150346e1abd0f70148901d02f75f3ff156d4585c2845d",
+              "value": "{\"version\":1,\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"organization\"}",
+              "ttl_seconds": 3600
+            },
+            {
+              "key": "refresh:72e815980eb0bec62c9a33614c37ba03af317d1797b794eea10f74a941c4e607",
+              "value": "{\"version\":1,\"clerk_user_id\":\"user_rec_1\",\"clerk_org_id\":\"org_rec_1\",\"access_scope\":\"organization\"}",
+              "ttl_seconds": 2592000
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/oauth-redis-recordings.json
+++ b/fixtures/oauth-redis-recordings.json
@@ -4,8 +4,8 @@
     "regeneration": {
       "command": "bun scripts/record-oauth-redis-contract.ts",
       "enforcement": "CI regenerates this file and fails when it differs from what is committed.",
-      "redis": "Isolated disposable Redis; database 15 is flushed between scenarios.",
-      "ttl_note": "ttl_seconds is read back from Redis and snapped to the nearest pinned TTL (3600 or 2592000) within a 5s tolerance; anything outside tolerance fails the run."
+      "redis": "Isolated disposable Redis; must be loopback unless OAUTH_RECORDING_ALLOW_REMOTE_REDIS=1. Database 15 is flushed between scenarios.",
+      "ttl_note": "ttl_seconds is the exact ttlSeconds argument the OAuth code passed to the Redis writers, captured at the dependency seam. The live Redis TTL is only sanity-checked against it (within 10s) to confirm expiration was applied."
     },
     "key_derivations": {
       "jwt:<hmac>": "HMAC-SHA256(CLERK_SECRET_KEY, access token), hex digest",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "start": "next start -p 3002",
     "lint": "next lint",
     "test": "bun test",
+    "record:oauth-redis-contract": "bun scripts/record-oauth-redis-contract.ts",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md}\""
   },

--- a/scripts/record-oauth-redis-contract.ts
+++ b/scripts/record-oauth-redis-contract.ts
@@ -111,6 +111,23 @@ interface Snapshot {
   keys: { key: string; value: string; ttl_seconds: number }[];
 }
 
+// Every TTL this code writes is one of the pinned constants. Reading the
+// TTL back can land a second low depending on timing, so snap values within
+// tolerance to their constant and treat anything else as a contract change.
+const PINNED_TTL_SECONDS = [EXPIRES_IN_SECONDS, REFRESH_TOKEN_ORG_TTL_SECONDS];
+
+function pinnedTtl(seconds: number): number {
+  const pinned = PINNED_TTL_SECONDS.find(
+    (value) => Math.abs(value - seconds) <= 5,
+  );
+  if (!pinned) {
+    throw new Error(
+      `Redis TTL ${seconds}s matches no pinned TTL (${PINNED_TTL_SECONDS.join("s, ")}s)`,
+    );
+  }
+  return pinned;
+}
+
 async function snapshot(after: string): Promise<Snapshot> {
   const keys = (await redisClient.keys("*")).sort();
   return {
@@ -119,7 +136,7 @@ async function snapshot(after: string): Promise<Snapshot> {
       keys.map(async (key) => ({
         key,
         value: (await redisClient.get(key))!,
-        ttl_seconds: await redisClient.ttl(key),
+        ttl_seconds: pinnedTtl(await redisClient.ttl(key)),
       })),
     ),
   };
@@ -179,7 +196,7 @@ async function authorize(query: Record<string, string>): Promise<void> {
   const response = await authorizeRequest(request, authorizeDependencies());
   if (response.status !== 307) {
     throw new Error(
-      `authorize redirected to ${response.status}: ${await response.text()}`,
+      `authorize returned ${response.status}, expected 307 redirect: ${await response.text()}`,
     );
   }
 }
@@ -284,7 +301,7 @@ const scenarios: Scenario[] = [
   {
     name: "legacy_non_pkce_client",
     description:
-      "A allowlisted legacy client without PKCE: authorize stores the context under the literal client:<client_id> key, which its exchanges read.",
+      "An allowlisted legacy client without PKCE: authorize stores the context under the literal client:<client_id> key, which its exchanges read.",
     run: async () => {
       await authorize({
         client_id: LEGACY_CLIENT_ID,
@@ -353,7 +370,7 @@ async function main(): Promise<void> {
         redis:
           "Isolated disposable Redis; database 15 is flushed between scenarios.",
         ttl_note:
-          "ttl_seconds is read back from Redis immediately after each step; Redis rounds to the nearest second, so treat an off-by-one as timing noise.",
+          "ttl_seconds is read back from Redis and snapped to the nearest pinned TTL (3600 or 2592000) within a 5s tolerance; anything outside tolerance fails the run.",
       },
       key_derivations: {
         "jwt:<hmac>": "HMAC-SHA256(CLERK_SECRET_KEY, access token), hex digest",

--- a/scripts/record-oauth-redis-contract.ts
+++ b/scripts/record-oauth-redis-contract.ts
@@ -12,6 +12,8 @@
 // OAUTH_RECORDING_ALLOW_REMOTE_REDIS=1. Point it at an isolated instance
 // with OAUTH_RECORDING_REDIS_URL (default redis://127.0.0.1:6379/15).
 
+import { createHmac } from "crypto";
+
 // Hard-assign every environment input the OAuth code reads instead of
 // inheriting ambient values: recordings must be reproducible, and an
 // inherited REDIS_URL could point the flushes below at real data.
@@ -43,16 +45,12 @@ process.env.OAUTH_LEGACY_NON_PKCE_CLIENT_IDS = "rec_legacy_client";
 import type { NextResponse } from "next/server";
 import type { TokenDependencies } from "@/app/token/route";
 import type { AuthorizeDependencies } from "@/app/authorize/route";
-import type { OAuthAuthorizationContext } from "@/lib/oauth-context";
 
 const { NextRequest } = await import("next/server");
 const { tokenRequest } = await import("@/app/token/route");
 const { authorizeRequest } = await import("@/app/authorize/route");
-const {
-  deriveS256CodeChallenge,
-  organizationAuthorizationContext,
-  serializeAuthorizationContext,
-} = await import("@/lib/oauth-context");
+const { deriveS256CodeChallenge, organizationAuthorizationContext } =
+  await import("@/lib/oauth-context");
 const { resolveAuthorizationContext } = await import("@/lib/org-utils");
 const { REFRESH_TOKEN_ORG_TTL_SECONDS } = await import("@/lib/const");
 const {
@@ -126,47 +124,48 @@ interface Snapshot {
   keys: { key: string; value: string; ttl_seconds: number }[];
 }
 
-interface CapturedWrite {
-  value: string;
-  ttlSeconds: number;
-}
-
 // TTLs are captured where production code hands them to the real writers,
-// so the fixture records exactly what was requested. The live Redis TTL is
-// read back only as a sanity check that expiration was applied.
-let capturedWrites: CapturedWrite[] = [];
+// keyed by the exact Redis key each writer derives, so a recorded TTL is
+// definitionally the TTL requested for that key — writes carrying the same
+// serialized value (e.g. oauth-request vs jwt vs refresh) can never be
+// attributed to each other. The live Redis TTL is read back only as a
+// sanity check that expiration was applied.
+const capturedTtlByKey = new Map<string, number>();
 
 const TTL_SANITY_TOLERANCE_SECONDS = 10;
 
-function captureWrite(
-  authorizationContext: OAuthAuthorizationContext,
-  ttlSeconds: number,
-): void {
-  capturedWrites.push({
-    value: serializeAuthorizationContext(authorizationContext),
-    ttlSeconds,
-  });
+// Same derivation as src/lib/redis.ts; CLERK_SECRET_KEY is pinned above.
+function redisKeyHash(input: string): string {
+  return createHmac("sha256", process.env.CLERK_SECRET_KEY!)
+    .update(input)
+    .digest("hex");
 }
 
 async function recordingPersist(
   args: Parameters<typeof persistOAuthTokenContexts>[0],
 ): Promise<void> {
-  captureWrite(args.authorizationContext, args.jwtTtlSeconds);
-  captureWrite(args.authorizationContext, args.refreshTtlSeconds);
+  capturedTtlByKey.set(`jwt:${redisKeyHash(args.jwt)}`, args.jwtTtlSeconds);
+  capturedTtlByKey.set(
+    `refresh:${redisKeyHash(args.newRefreshToken)}`,
+    args.refreshTtlSeconds,
+  );
   return persistOAuthTokenContexts(args);
 }
 
 async function recordingSetRequestContext(
   input: Parameters<AuthorizeDependencies["setRequestContext"]>[0],
 ): Promise<void> {
-  captureWrite(input.authorizationContext, input.ttlSeconds);
+  capturedTtlByKey.set(
+    `oauth-request:${redisKeyHash(`${input.clientId}:${input.codeChallenge}`)}`,
+    input.ttlSeconds,
+  );
   return setAuthorizationContextForRequest(input);
 }
 
 async function recordingSetClientContext(
   input: Parameters<AuthorizeDependencies["setClientContext"]>[0],
 ): Promise<void> {
-  captureWrite(input.authorizationContext, input.ttlSeconds);
+  capturedTtlByKey.set(`client:${input.clientId}`, input.ttlSeconds);
   return setAuthorizationContextForClientId(input);
 }
 
@@ -176,20 +175,23 @@ async function snapshot(after: string): Promise<Snapshot> {
     after,
     keys: await Promise.all(
       keys.map(async (key) => {
-        const value = (await redisClient.get(key))!;
+        const expectedTtl = capturedTtlByKey.get(key);
+        if (expectedTtl === undefined) {
+          throw new Error(`no captured write explains ${key}`);
+        }
+        // The recorded TTL is exact by construction; the Redis read only
+        // confirms expiration was applied.
         const liveTtl = await redisClient.ttl(key);
-        const write = capturedWrites.find(
-          (candidate) =>
-            candidate.value === value &&
-            Math.abs(candidate.ttlSeconds - liveTtl) <=
-              TTL_SANITY_TOLERANCE_SECONDS,
-        );
-        if (!write) {
+        if (Math.abs(liveTtl - expectedTtl) > TTL_SANITY_TOLERANCE_SECONDS) {
           throw new Error(
-            `no captured write explains ${key} (Redis TTL ${liveTtl}s)`,
+            `${key} expires in ${liveTtl}s but production wrote ${expectedTtl}s`,
           );
         }
-        return { key, value, ttl_seconds: write.ttlSeconds };
+        return {
+          key,
+          value: (await redisClient.get(key))!,
+          ttl_seconds: expectedTtl,
+        };
       }),
     ),
   };
@@ -402,7 +404,7 @@ async function main(): Promise<void> {
   let keyCount = 0;
   for (const scenario of scenarios) {
     await redisClient.flushDb();
-    capturedWrites = [];
+    capturedTtlByKey.clear();
     const snapshots = await scenario.run();
     keyCount += snapshots.at(-1)!.keys.length;
     recordedScenarios.push({
@@ -423,7 +425,7 @@ async function main(): Promise<void> {
         redis:
           "Isolated disposable Redis; must be loopback unless OAUTH_RECORDING_ALLOW_REMOTE_REDIS=1. Database 15 is flushed between scenarios.",
         ttl_note:
-          "ttl_seconds is the exact ttlSeconds argument the OAuth code passed to the Redis writers, captured at the dependency seam. The live Redis TTL is only sanity-checked against it (within 10s) to confirm expiration was applied.",
+          "ttl_seconds is the exact ttlSeconds argument the OAuth code passed to the Redis writers, captured at the dependency seam for the specific key it was called with. The live Redis TTL is only sanity-checked against it (within 10s) to confirm expiration was applied.",
       },
       key_derivations: {
         "jwt:<hmac>": "HMAC-SHA256(CLERK_SECRET_KEY, access token), hex digest",

--- a/scripts/record-oauth-redis-contract.ts
+++ b/scripts/record-oauth-redis-contract.ts
@@ -1,0 +1,420 @@
+// Records the exact Redis contract the OAuth endpoints produce for a fixed
+// set of logins: key names, HMAC key derivations, stored values, and TTLs
+// are dumped to fixtures/oauth-redis-recordings.json. CI regenerates this
+// file and fails on any diff, so a change to token persistence shows up as
+// a reviewable fixture change instead of silently remapping live tokens.
+//
+// Usage:
+//   bun scripts/record-oauth-redis-contract.ts
+//
+// Requires a disposable Redis: every key in the selected database is
+// flushed between scenarios. Point it at an isolated instance with
+// OAUTH_RECORDING_REDIS_URL (default redis://127.0.0.1:6379/15).
+
+// Hard-assign every environment input the OAuth code reads instead of
+// inheriting ambient values: recordings must be reproducible, and an
+// inherited REDIS_URL could point the flushes below at real data.
+const recordingRedisUrl =
+  process.env.OAUTH_RECORDING_REDIS_URL ?? "redis://127.0.0.1:6379/15";
+if (!new URL(recordingRedisUrl).pathname.endsWith("/15")) {
+  throw new Error(
+    "OAUTH_RECORDING_REDIS_URL must select database 15: this script flushes it between scenarios",
+  );
+}
+process.env.REDIS_URL = recordingRedisUrl;
+process.env.CLERK_SECRET_KEY = "sk_test_recording_fixture";
+process.env.NEXT_PUBLIC_CLERK_DOMAIN = "clerk.recording.invalid";
+process.env.KERNEL_CLI_PROD_CLIENT_ID = "rec_cli_prod";
+process.env.KERNEL_CLI_STAGING_CLIENT_ID = "rec_cli_staging";
+process.env.KERNEL_CLI_DEV_CLIENT_ID = "rec_cli_dev";
+process.env.OAUTH_LEGACY_NON_PKCE_CLIENT_IDS = "rec_legacy_client";
+
+import type { NextResponse } from "next/server";
+import type { TokenDependencies } from "@/app/token/route";
+import type { AuthorizeDependencies } from "@/app/authorize/route";
+
+const { NextRequest } = await import("next/server");
+const { tokenRequest } = await import("@/app/token/route");
+const { authorizeRequest } = await import("@/app/authorize/route");
+const { deriveS256CodeChallenge, organizationAuthorizationContext } =
+  await import("@/lib/oauth-context");
+const { resolveAuthorizationContext } = await import("@/lib/org-utils");
+const { REFRESH_TOKEN_ORG_TTL_SECONDS } = await import("@/lib/const");
+const {
+  persistOAuthTokenContexts,
+  setAuthorizationContextForClientId,
+  setAuthorizationContextForRequest,
+  redisClient,
+} = await import("@/lib/redis");
+
+// Pinned inputs. Every value is fake and exists only so that HMAC hashes,
+// serialization, and TTLs are identical on every run.
+const PKCE_CLIENT_ID = "rec_pkce_client";
+const PROJECT_CLIENT_ID = "rec_project_client";
+const LEGACY_CLIENT_ID = "rec_legacy_client";
+const CODE_VERIFIER = "recording-code-verifier-0123456789abcdef";
+const CODE_CHALLENGE = deriveS256CodeChallenge(CODE_VERIFIER);
+const USER_ID = "user_rec_1";
+const ORG_ID = "org_rec_1";
+const PROJECT_ID = "proj_rec_1";
+const CLERK_SESSION_TOKEN = "rec-clerk-session-token";
+const EXPIRES_IN_SECONDS = 3600;
+
+interface ClerkTokens {
+  access_token: string;
+  id_token: string;
+  refresh_token: string;
+  expires_in: number;
+  token_type: string;
+}
+
+const clerkResponses: Record<string, ClerkTokens> = {
+  authorization_code_organization: {
+    access_token: "rec-clerk-access-token-org",
+    id_token: "rec-id-token-org-v1",
+    refresh_token: "rec-refresh-initial-org-v1",
+    expires_in: EXPIRES_IN_SECONDS,
+    token_type: "Bearer",
+  },
+  authorization_code_project: {
+    access_token: "rec-clerk-access-token-project",
+    id_token: "rec-id-token-project-v1",
+    refresh_token: "rec-refresh-initial-project-v1",
+    expires_in: EXPIRES_IN_SECONDS,
+    token_type: "Bearer",
+  },
+  refresh_after_org_grant: {
+    access_token: "rec-clerk-access-token-refresh",
+    id_token: "rec-id-token-after-refresh-v1",
+    refresh_token: "rec-refresh-rotated-v1",
+    expires_in: EXPIRES_IN_SECONDS,
+    token_type: "Bearer",
+  },
+  legacy_non_pkce_exchange: {
+    access_token: "rec-clerk-access-token-legacy",
+    id_token: "rec-id-token-legacy-v1",
+    refresh_token: "rec-refresh-legacy-grant-v1",
+    expires_in: EXPIRES_IN_SECONDS,
+    token_type: "Bearer",
+  },
+  refresh_after_backfill_seed: {
+    access_token: "rec-clerk-access-token-backfill",
+    id_token: "rec-id-token-backfill-v1",
+    refresh_token: "rec-refresh-backfill-rotated-v1",
+    expires_in: EXPIRES_IN_SECONDS,
+    token_type: "Bearer",
+  },
+};
+
+interface Snapshot {
+  after: string;
+  keys: { key: string; value: string; ttl_seconds: number }[];
+}
+
+async function snapshot(after: string): Promise<Snapshot> {
+  const keys = (await redisClient.keys("*")).sort();
+  return {
+    after,
+    keys: await Promise.all(
+      keys.map(async (key) => ({
+        key,
+        value: (await redisClient.get(key))!,
+        ttl_seconds: await redisClient.ttl(key),
+      })),
+    ),
+  };
+}
+
+function tokenDependencies(clerkTokens: ClerkTokens): TokenDependencies {
+  return {
+    exchange: async () => Response.json(clerkTokens),
+    resolveContext: resolveAuthorizationContext,
+    verify: async () => ({ sub: USER_ID }),
+    hasMembership: async () => true,
+    persistContexts: persistOAuthTokenContexts,
+  };
+}
+
+function authorizeDependencies(): AuthorizeDependencies {
+  return {
+    getAuth: async () => ({
+      userId: USER_ID,
+      orgId: ORG_ID,
+      getToken: async () => CLERK_SESSION_TOKEN,
+    }),
+    setRequestContext: setAuthorizationContextForRequest,
+    setClientContext: setAuthorizationContextForClientId,
+    requireProject: async () => ({
+      id: PROJECT_ID,
+      name: "recording project",
+      status: "active",
+    }),
+  };
+}
+
+async function runToken(
+  body: Record<string, string>,
+  dependencies: TokenDependencies,
+): Promise<void> {
+  const request = new NextRequest("https://auth.recording.invalid/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(body),
+  });
+  const response: NextResponse = await tokenRequest(request, dependencies);
+  if (response.status !== 200) {
+    throw new Error(
+      `token exchange failed with ${response.status}: ${await response.text()}`,
+    );
+  }
+}
+
+async function authorize(query: Record<string, string>): Promise<void> {
+  const request = new NextRequest(
+    `https://auth.recording.invalid/authorize?${new URLSearchParams({
+      org_id: ORG_ID,
+      ...query,
+    })}`,
+  );
+  const response = await authorizeRequest(request, authorizeDependencies());
+  if (response.status !== 307) {
+    throw new Error(
+      `authorize redirected to ${response.status}: ${await response.text()}`,
+    );
+  }
+}
+
+function exchangeCode(
+  clientId: string,
+  clerkTokens: ClerkTokens,
+  codeVerifier?: string,
+): Promise<void> {
+  return runToken(
+    {
+      grant_type: "authorization_code",
+      client_id: clientId,
+      code: "rec-code",
+      ...(codeVerifier ? { code_verifier: codeVerifier } : {}),
+    },
+    tokenDependencies(clerkTokens),
+  );
+}
+
+const pkceQuery = {
+  code_challenge: CODE_CHALLENGE,
+  code_challenge_method: "S256",
+};
+
+interface Scenario {
+  name: string;
+  description: string;
+  run: () => Promise<Snapshot[]>;
+}
+
+const scenarios: Scenario[] = [
+  {
+    name: "authorization_code_org_scoped_pkce",
+    description:
+      "PKCE authorization for an organization-wide scope: authorize stores the oauth-request context, the code exchange consumes it and persists jwt/refresh mappings.",
+    run: async () => {
+      await authorize({
+        client_id: PKCE_CLIENT_ID,
+        access_scope: "organization",
+        ...pkceQuery,
+      });
+      const afterAuthorize = await snapshot("after_authorize");
+      await exchangeCode(
+        PKCE_CLIENT_ID,
+        clerkResponses.authorization_code_organization!,
+        CODE_VERIFIER,
+      );
+      return [afterAuthorize, await snapshot("after_token_exchange")];
+    },
+  },
+  {
+    name: "authorization_code_project_scoped_pkce",
+    description:
+      "Same as above but the selected scope is a single project, so the persisted context carries project_id.",
+    run: async () => {
+      await authorize({
+        client_id: PROJECT_CLIENT_ID,
+        access_scope: "project",
+        project_id: PROJECT_ID,
+        ...pkceQuery,
+      });
+      const afterAuthorize = await snapshot("after_authorize");
+      await exchangeCode(
+        PROJECT_CLIENT_ID,
+        clerkResponses.authorization_code_project!,
+        CODE_VERIFIER,
+      );
+      return [afterAuthorize, await snapshot("after_token_exchange")];
+    },
+  },
+  {
+    name: "refresh_token_rotation_sliding_ttl",
+    description:
+      "An initial org-scoped grant is followed by a refresh_token grant: the old refresh mapping is deleted, the rotated one is written with a fresh sliding TTL.",
+    run: async () => {
+      await authorize({
+        client_id: PKCE_CLIENT_ID,
+        access_scope: "organization",
+        ...pkceQuery,
+      });
+      await exchangeCode(
+        PKCE_CLIENT_ID,
+        clerkResponses.authorization_code_organization!,
+        CODE_VERIFIER,
+      );
+      const afterInitialGrant = await snapshot(
+        "after_initial_authorization_code_grant",
+      );
+      await runToken(
+        {
+          grant_type: "refresh_token",
+          client_id: PKCE_CLIENT_ID,
+          refresh_token:
+            clerkResponses.authorization_code_organization!.refresh_token,
+        },
+        tokenDependencies(clerkResponses.refresh_after_org_grant!),
+      );
+      return [afterInitialGrant, await snapshot("after_refresh_grant")];
+    },
+  },
+  {
+    name: "legacy_non_pkce_client",
+    description:
+      "A allowlisted legacy client without PKCE: authorize stores the context under the literal client:<client_id> key, which its exchanges read.",
+    run: async () => {
+      await authorize({
+        client_id: LEGACY_CLIENT_ID,
+        access_scope: "organization",
+      });
+      const afterAuthorize = await snapshot("after_authorize");
+      await exchangeCode(
+        LEGACY_CLIENT_ID,
+        clerkResponses.legacy_non_pkce_exchange!,
+      );
+      return [afterAuthorize, await snapshot("after_token_exchange")];
+    },
+  },
+  {
+    name: "refresh_backfills_clerk_user_id_from_id_token",
+    description:
+      "A pre-existing context without clerk_user_id (stored by older versions) is refreshed: the id_token subject is backfilled into the newly written contexts.",
+    run: async () => {
+      await persistOAuthTokenContexts({
+        jwt: "rec-id-token-seed-v1",
+        newRefreshToken: "rec-refresh-seed-v1",
+        authorizationContext: organizationAuthorizationContext({
+          clerkOrgId: ORG_ID,
+        }),
+        jwtTtlSeconds: EXPIRES_IN_SECONDS,
+        refreshTtlSeconds: REFRESH_TOKEN_ORG_TTL_SECONDS,
+      });
+      const afterSeed = await snapshot("after_seeding_legacy_contexts");
+      await runToken(
+        {
+          grant_type: "refresh_token",
+          client_id: PKCE_CLIENT_ID,
+          refresh_token: "rec-refresh-seed-v1",
+        },
+        tokenDependencies(clerkResponses.refresh_after_backfill_seed!),
+      );
+      return [afterSeed, await snapshot("after_refresh_grant")];
+    },
+  },
+];
+
+async function main(): Promise<void> {
+  await redisClient.connect();
+  const recordedScenarios = [];
+  let keyCount = 0;
+  for (const scenario of scenarios) {
+    await redisClient.flushDb();
+    const snapshots = await scenario.run();
+    keyCount += snapshots.at(-1)!.keys.length;
+    recordedScenarios.push({
+      name: scenario.name,
+      description: scenario.description,
+      snapshots,
+    });
+  }
+  await redisClient.flushDb();
+
+  const recording = {
+    meta: {
+      purpose:
+        "Golden fixtures of the Redis state written by the OAuth /authorize and /token endpoints for fixed logins. Key names, HMAC derivations, stored values, and TTLs must stay byte-identical unless a diff is reviewed deliberately.",
+      regeneration: {
+        command: "bun scripts/record-oauth-redis-contract.ts",
+        enforcement:
+          "CI regenerates this file and fails when it differs from what is committed.",
+        redis:
+          "Isolated disposable Redis; database 15 is flushed between scenarios.",
+        ttl_note:
+          "ttl_seconds is read back from Redis immediately after each step; Redis rounds to the nearest second, so treat an off-by-one as timing noise.",
+      },
+      key_derivations: {
+        "jwt:<hmac>": "HMAC-SHA256(CLERK_SECRET_KEY, access token), hex digest",
+        "refresh:<hmac>":
+          "HMAC-SHA256(CLERK_SECRET_KEY, refresh token), hex digest",
+        "oauth-request:<hmac>":
+          "HMAC-SHA256(CLERK_SECRET_KEY, '<client_id>:<code_challenge>'), hex digest",
+        "client:<client_id>":
+          "Legacy allowlisted clients only; the client id is used literally, not hashed.",
+      },
+      pinned_inputs: {
+        environment: {
+          CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY,
+          NEXT_PUBLIC_CLERK_DOMAIN: process.env.NEXT_PUBLIC_CLERK_DOMAIN,
+          KERNEL_CLI_PROD_CLIENT_ID: process.env.KERNEL_CLI_PROD_CLIENT_ID,
+          KERNEL_CLI_STAGING_CLIENT_ID:
+            process.env.KERNEL_CLI_STAGING_CLIENT_ID,
+          KERNEL_CLI_DEV_CLIENT_ID: process.env.KERNEL_CLI_DEV_CLIENT_ID,
+          OAUTH_LEGACY_NON_PKCE_CLIENT_IDS:
+            process.env.OAUTH_LEGACY_NON_PKCE_CLIENT_IDS,
+        },
+        identifiers: {
+          pkce_client_id: PKCE_CLIENT_ID,
+          project_client_id: PROJECT_CLIENT_ID,
+          legacy_client_id: LEGACY_CLIENT_ID,
+          clerk_user_id: USER_ID,
+          clerk_org_id: ORG_ID,
+          project_id: PROJECT_ID,
+          clerk_session_token: CLERK_SESSION_TOKEN,
+          seed_id_token: "rec-id-token-seed-v1",
+          seed_refresh_token: "rec-refresh-seed-v1",
+        },
+        pkce: {
+          code_verifier: CODE_VERIFIER,
+          code_challenge: CODE_CHALLENGE,
+          note: "code_challenge is base64url(SHA-256(code_verifier)) with no padding.",
+        },
+        clerk_responses: clerkResponses,
+        context_serialization:
+          "Stored values are JSON strings whose field order follows the writer: version, clerk_user_id?, clerk_org_id, access_scope[, project_id].",
+      },
+      coverage: scenarios.map(
+        (scenario) => `${scenario.name}: ${scenario.description}`,
+      ),
+    },
+    scenarios: recordedScenarios,
+  };
+
+  const prettier = await import("prettier");
+  const contents = await prettier.format(JSON.stringify(recording, null, 2), {
+    parser: "json",
+  });
+  const fixturePath = new URL(
+    "../fixtures/oauth-redis-recordings.json",
+    import.meta.url,
+  ).pathname;
+  await Bun.write(fixturePath, contents);
+  console.log(
+    `Recorded ${scenarios.length} scenarios (${keyCount} final keys) to ${fixturePath}`,
+  );
+}
+
+await main();
+await redisClient.disconnect();

--- a/scripts/record-oauth-redis-contract.ts
+++ b/scripts/record-oauth-redis-contract.ts
@@ -8,17 +8,28 @@
 //   bun scripts/record-oauth-redis-contract.ts
 //
 // Requires a disposable Redis: every key in the selected database is
-// flushed between scenarios. Point it at an isolated instance with
-// OAUTH_RECORDING_REDIS_URL (default redis://127.0.0.1:6379/15).
+// flushed between scenarios. Non-loopback hosts are refused unless
+// OAUTH_RECORDING_ALLOW_REMOTE_REDIS=1. Point it at an isolated instance
+// with OAUTH_RECORDING_REDIS_URL (default redis://127.0.0.1:6379/15).
 
 // Hard-assign every environment input the OAuth code reads instead of
 // inheriting ambient values: recordings must be reproducible, and an
 // inherited REDIS_URL could point the flushes below at real data.
 const recordingRedisUrl =
   process.env.OAUTH_RECORDING_REDIS_URL ?? "redis://127.0.0.1:6379/15";
-if (!new URL(recordingRedisUrl).pathname.endsWith("/15")) {
+const parsedRecordingRedisUrl = new URL(recordingRedisUrl);
+if (!parsedRecordingRedisUrl.pathname.endsWith("/15")) {
   throw new Error(
     "OAUTH_RECORDING_REDIS_URL must select database 15: this script flushes it between scenarios",
+  );
+}
+const loopbackHosts = ["127.0.0.1", "::1", "localhost"];
+if (
+  !loopbackHosts.includes(parsedRecordingRedisUrl.hostname) &&
+  process.env.OAUTH_RECORDING_ALLOW_REMOTE_REDIS !== "1"
+) {
+  throw new Error(
+    "OAUTH_RECORDING_REDIS_URL must be loopback; export OAUTH_RECORDING_ALLOW_REMOTE_REDIS=1 to target a remote instance you know is disposable",
   );
 }
 process.env.REDIS_URL = recordingRedisUrl;
@@ -32,12 +43,16 @@ process.env.OAUTH_LEGACY_NON_PKCE_CLIENT_IDS = "rec_legacy_client";
 import type { NextResponse } from "next/server";
 import type { TokenDependencies } from "@/app/token/route";
 import type { AuthorizeDependencies } from "@/app/authorize/route";
+import type { OAuthAuthorizationContext } from "@/lib/oauth-context";
 
 const { NextRequest } = await import("next/server");
 const { tokenRequest } = await import("@/app/token/route");
 const { authorizeRequest } = await import("@/app/authorize/route");
-const { deriveS256CodeChallenge, organizationAuthorizationContext } =
-  await import("@/lib/oauth-context");
+const {
+  deriveS256CodeChallenge,
+  organizationAuthorizationContext,
+  serializeAuthorizationContext,
+} = await import("@/lib/oauth-context");
 const { resolveAuthorizationContext } = await import("@/lib/org-utils");
 const { REFRESH_TOKEN_ORG_TTL_SECONDS } = await import("@/lib/const");
 const {
@@ -111,21 +126,48 @@ interface Snapshot {
   keys: { key: string; value: string; ttl_seconds: number }[];
 }
 
-// Every TTL this code writes is one of the pinned constants. Reading the
-// TTL back can land a second low depending on timing, so snap values within
-// tolerance to their constant and treat anything else as a contract change.
-const PINNED_TTL_SECONDS = [EXPIRES_IN_SECONDS, REFRESH_TOKEN_ORG_TTL_SECONDS];
+interface CapturedWrite {
+  value: string;
+  ttlSeconds: number;
+}
 
-function pinnedTtl(seconds: number): number {
-  const pinned = PINNED_TTL_SECONDS.find(
-    (value) => Math.abs(value - seconds) <= 5,
-  );
-  if (!pinned) {
-    throw new Error(
-      `Redis TTL ${seconds}s matches no pinned TTL (${PINNED_TTL_SECONDS.join("s, ")}s)`,
-    );
-  }
-  return pinned;
+// TTLs are captured where production code hands them to the real writers,
+// so the fixture records exactly what was requested. The live Redis TTL is
+// read back only as a sanity check that expiration was applied.
+let capturedWrites: CapturedWrite[] = [];
+
+const TTL_SANITY_TOLERANCE_SECONDS = 10;
+
+function captureWrite(
+  authorizationContext: OAuthAuthorizationContext,
+  ttlSeconds: number,
+): void {
+  capturedWrites.push({
+    value: serializeAuthorizationContext(authorizationContext),
+    ttlSeconds,
+  });
+}
+
+async function recordingPersist(
+  args: Parameters<typeof persistOAuthTokenContexts>[0],
+): Promise<void> {
+  captureWrite(args.authorizationContext, args.jwtTtlSeconds);
+  captureWrite(args.authorizationContext, args.refreshTtlSeconds);
+  return persistOAuthTokenContexts(args);
+}
+
+async function recordingSetRequestContext(
+  input: Parameters<AuthorizeDependencies["setRequestContext"]>[0],
+): Promise<void> {
+  captureWrite(input.authorizationContext, input.ttlSeconds);
+  return setAuthorizationContextForRequest(input);
+}
+
+async function recordingSetClientContext(
+  input: Parameters<AuthorizeDependencies["setClientContext"]>[0],
+): Promise<void> {
+  captureWrite(input.authorizationContext, input.ttlSeconds);
+  return setAuthorizationContextForClientId(input);
 }
 
 async function snapshot(after: string): Promise<Snapshot> {
@@ -133,11 +175,22 @@ async function snapshot(after: string): Promise<Snapshot> {
   return {
     after,
     keys: await Promise.all(
-      keys.map(async (key) => ({
-        key,
-        value: (await redisClient.get(key))!,
-        ttl_seconds: pinnedTtl(await redisClient.ttl(key)),
-      })),
+      keys.map(async (key) => {
+        const value = (await redisClient.get(key))!;
+        const liveTtl = await redisClient.ttl(key);
+        const write = capturedWrites.find(
+          (candidate) =>
+            candidate.value === value &&
+            Math.abs(candidate.ttlSeconds - liveTtl) <=
+              TTL_SANITY_TOLERANCE_SECONDS,
+        );
+        if (!write) {
+          throw new Error(
+            `no captured write explains ${key} (Redis TTL ${liveTtl}s)`,
+          );
+        }
+        return { key, value, ttl_seconds: write.ttlSeconds };
+      }),
     ),
   };
 }
@@ -148,7 +201,7 @@ function tokenDependencies(clerkTokens: ClerkTokens): TokenDependencies {
     resolveContext: resolveAuthorizationContext,
     verify: async () => ({ sub: USER_ID }),
     hasMembership: async () => true,
-    persistContexts: persistOAuthTokenContexts,
+    persistContexts: recordingPersist,
   };
 }
 
@@ -159,8 +212,8 @@ function authorizeDependencies(): AuthorizeDependencies {
       orgId: ORG_ID,
       getToken: async () => CLERK_SESSION_TOKEN,
     }),
-    setRequestContext: setAuthorizationContextForRequest,
-    setClientContext: setAuthorizationContextForClientId,
+    setRequestContext: recordingSetRequestContext,
+    setClientContext: recordingSetClientContext,
     requireProject: async () => ({
       id: PROJECT_ID,
       name: "recording project",
@@ -320,7 +373,7 @@ const scenarios: Scenario[] = [
     description:
       "A pre-existing context without clerk_user_id (stored by older versions) is refreshed: the id_token subject is backfilled into the newly written contexts.",
     run: async () => {
-      await persistOAuthTokenContexts({
+      await recordingPersist({
         jwt: "rec-id-token-seed-v1",
         newRefreshToken: "rec-refresh-seed-v1",
         authorizationContext: organizationAuthorizationContext({
@@ -349,6 +402,7 @@ async function main(): Promise<void> {
   let keyCount = 0;
   for (const scenario of scenarios) {
     await redisClient.flushDb();
+    capturedWrites = [];
     const snapshots = await scenario.run();
     keyCount += snapshots.at(-1)!.keys.length;
     recordedScenarios.push({
@@ -357,7 +411,6 @@ async function main(): Promise<void> {
       snapshots,
     });
   }
-  await redisClient.flushDb();
 
   const recording = {
     meta: {
@@ -368,9 +421,9 @@ async function main(): Promise<void> {
         enforcement:
           "CI regenerates this file and fails when it differs from what is committed.",
         redis:
-          "Isolated disposable Redis; database 15 is flushed between scenarios.",
+          "Isolated disposable Redis; must be loopback unless OAUTH_RECORDING_ALLOW_REMOTE_REDIS=1. Database 15 is flushed between scenarios.",
         ttl_note:
-          "ttl_seconds is read back from Redis and snapped to the nearest pinned TTL (3600 or 2592000) within a 5s tolerance; anything outside tolerance fails the run.",
+          "ttl_seconds is the exact ttlSeconds argument the OAuth code passed to the Redis writers, captured at the dependency seam. The live Redis TTL is only sanity-checked against it (within 10s) to confirm expiration was applied.",
       },
       key_derivations: {
         "jwt:<hmac>": "HMAC-SHA256(CLERK_SECRET_KEY, access token), hex digest",
@@ -433,5 +486,12 @@ async function main(): Promise<void> {
   );
 }
 
-await main();
-await redisClient.disconnect();
+try {
+  await main();
+} finally {
+  try {
+    if (redisClient.isReady) await redisClient.flushDb();
+  } finally {
+    if (redisClient.isOpen) await redisClient.disconnect();
+  }
+}


### PR DESCRIPTION
## Summary

The OAuth /token and /authorize endpoints persist org/project authorization context to Redis, and other services read those exact keys and values back on every authenticated request. Today nothing pins that contract: a change to a key name, HMAC derivation, serialization shape, or TTL can merge silently and remap existing tokens.

This PR adds a recording harness that drives the real request handlers (`tokenRequest`, `authorizeRequest`) through their existing dependency-injection seams with pinned fake Clerk responses (exchange, verify, membership) and fake auth — persistence itself is untouched production code writing to a real Redis. Every key written is dumped with its value and TTL to a committed JSON fixture whose inputs are all fixed (secret, client ids, PKCE verifier, token strings), so re-runs are byte-identical.

CI regenerates the fixture and fails when it differs from what's committed, so any change to the Redis contract now shows up as a reviewable diff.

- `scripts/record-oauth-redis-contract.ts` — harness; runs against an isolated disposable Redis (default db 15, flushed between scenarios)
- `fixtures/oauth-redis-recordings.json` — the recordings plus self-documentation: pinned env values, identifiers, PKCE pair, per-flow Clerk response bodies, and key-derivation notes sufficient for a foreign implementation to replay
- `.github/workflows/ci.yml` — redis service container + regeneration/diff enforcement step

## Scenarios recorded

1. `authorization_code_org_scoped_pkce` — authorize writes `oauth-request:<hmac(client_id:code_challenge)>`; the exchange consumes it and persists `jwt:`/`refresh:` mappings
2. `authorization_code_project_scoped_pkce` — same, with `project_id` in the persisted context
3. `refresh_token_rotation_sliding_ttl` — old `refresh:` key deleted, rotated key written with the full sliding TTL
4. `legacy_non_pkce_client` — allowlisted non-PKCE client stores under literal `client:<client_id>`
5. `refresh_backfills_clerk_user_id_from_id_token` — legacy context without `clerk_user_id` gets it backfilled from the id_token subject on refresh

## Test plan

- [x] `bun test`: 248 pass
- [x] `bunx tsc --noEmit` clean; prettier clean on changed files
- [x] Harness run twice consecutively produces byte-identical fixtures
- [x] Recorded HMAC keys independently verified against the documented derivations