### PR TITLE
Install the breakglass caller

### DIFF
--- a/.github/workflows/breakglass.yml
+++ b/.github/workflows/breakglass.yml
@@ -1,0 +1,21 @@
+name: Breakglass
+
+# Comment `/breakglass <reason>` on a PR to merge it without its required approval.
+# The mechanism lives in kernel/security-workflows; this file is the whole per-repo install
+# and should never grow logic. See kernel/infra docs/breakglass.md.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  merge:
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/breakglass')
+    uses: kernel/security-workflows/.github/workflows/breakglass-merge.yml@main
+    # Named rather than `secrets: inherit`: this calls a workflow in another repository, and
+    # inherit would hand it every secret this repo holds.
+    secrets:
+      BREAKGLASS_APP_ID: ${{ secrets.BREAKGLASS_APP_ID }}
+      BREAKGLASS_APP_PRIVATE_KEY: ${{ secrets.BREAKGLASS_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Nineteen lines, no logic — the whole per-repo install for breakglass.

Comment `/breakglass <reason>` on a PR here and it merges without its required approval, recording the reason on the PR. The mechanism lives in [kernel/security-workflows](https://github.com/kernel/security-workflows/pull/18) and is shared, so changes to it need no PR here.

**This repo is public**, which is why the mechanism is hosted in a public repo — a public repository cannot call a reusable workflow stored in a private one, and the failure is silent (run created, zero jobs, nothing on the PR).

Why a file per repo: `issue_comment` fires in the repo where the comment is left, and GitHub only runs a workflow if the file is on *that* repo's default branch. Reusable workflows share logic, not triggers.

Docs: [kernel/infra docs/breakglass.md](https://github.com/kernel/infra/blob/main/docs/breakglass.md)

Depends on kernel/security-workflows#18 landing first. Requires the org-level `BREAKGLASS_APP_ID` / `BREAKGLASS_APP_PRIVATE_KEY` secrets shared with this repo, and the `kernel-breakglass` app installed on it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds CI-only automation with no application code changes; secret scope is intentionally limited to breakglass credentials.
> 
> **Overview**
> Adds a **minimal GitHub Actions workflow** so reviewers can comment `/breakglass <reason>` on a PR to merge without required approvals; the reason is recorded on the PR.
> 
> The workflow listens for `issue_comment` on PRs, runs only when the comment starts with `/breakglass`, and **delegates all logic** to the shared reusable workflow `kernel/security-workflows/.github/workflows/breakglass-merge.yml@main`. It passes only `BREAKGLASS_APP_ID` and `BREAKGLASS_APP_PRIVATE_KEY` explicitly (not `secrets: inherit`) because the callee lives in another repo.
> 
> This is the standard per-repo install pattern: `issue_comment` fires in the repo where the comment is left, and GitHub requires the workflow file on that repo’s default branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 119a9e7d5c29bf7c742a410ff3c2627c88226063. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->