### PR TITLE
Fix managed auth telemetry JSON Schema refs

### DIFF
--- a/src/lib/mcp/tools/auth-connections.test.ts
+++ b/src/lib/mcp/tools/auth-connections.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { organizationWideAuthInfo } from "@/lib/mcp/auth-context.test-fixtures";
+import { connectTestMcp } from "@/lib/mcp/mcp-test-fixtures";
+import { registerAuthConnectionTools } from "./auth-connections";
 import { toSafeAuthConnection } from "./managed-auth-state";
 import {
   assertNoSecrets,
@@ -44,6 +46,25 @@ describe("manage_auth_connections programmatic surface", () => {
       }).success,
     ).toBe(false);
     expect(schema?.sign_in_option_id).toBeUndefined();
+  });
+
+  test("publishes browser telemetry categories without JSON Schema references", async () => {
+    const { client, close } = await connectTestMcp(
+      registerAuthConnectionTools,
+      unusedKernelClient,
+    );
+
+    try {
+      const tool = (await client.listTools()).tools.find(
+        ({ name }) => name === "manage_auth_connections",
+      );
+      const browserTelemetry = tool?.inputSchema.properties?.browser_telemetry;
+
+      expect(browserTelemetry).toBeDefined();
+      expect(JSON.stringify(browserTelemetry)).not.toContain('"$ref"');
+    } finally {
+      await close();
+    }
   });
 
   test("passes the optional project selector through to the client", async () => {

--- a/src/lib/mcp/tools/managed-auth-telemetry.ts
+++ b/src/lib/mcp/tools/managed-auth-telemetry.ts
@@ -1,19 +1,21 @@
 import { z } from "zod";
 
-const telemetryCategorySchema = z.object({
-  enabled: z.boolean().optional(),
-});
+function telemetryCategorySchema() {
+  return z.object({
+    enabled: z.boolean().optional(),
+  });
+}
 
 const telemetryCategoriesSchema = z.object({
-  captcha: telemetryCategorySchema.optional(),
-  connection: telemetryCategorySchema.optional(),
-  console: telemetryCategorySchema.optional(),
-  control: telemetryCategorySchema.optional(),
-  interaction: telemetryCategorySchema.optional(),
-  network: telemetryCategorySchema.optional(),
-  page: telemetryCategorySchema.optional(),
-  screenshot: telemetryCategorySchema.optional(),
-  system: telemetryCategorySchema.optional(),
+  captcha: telemetryCategorySchema().optional(),
+  connection: telemetryCategorySchema().optional(),
+  console: telemetryCategorySchema().optional(),
+  control: telemetryCategorySchema().optional(),
+  interaction: telemetryCategorySchema().optional(),
+  network: telemetryCategorySchema().optional(),
+  page: telemetryCategorySchema().optional(),
+  screenshot: telemetryCategorySchema().optional(),
+  system: telemetryCategorySchema().optional(),
 });
 
 export const managedAuthBrowserTelemetrySchema = z


### PR DESCRIPTION
## summary

- generate independent schemas for each managed-auth browser telemetry category
- prevent MCP `tools/list` from emitting local `$ref` entries that some JSON Schema consumers cannot resolve
- add a regression test against the published tool schema

## testing

- `bun test`
- `bunx tsc --noEmit`
- `bunx prettier --check src/lib/mcp/tools/auth-connections.test.ts src/lib/mcp/tools/managed-auth-telemetry.ts`
- reproduced with Zod 4.4.3 `fromJSONSchema` before the fix and verified conversion succeeds after it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-shape refactor with unchanged validation rules (`superRefine` preserved) plus a regression test; no runtime auth or API behavior changes.
> 
> **Overview**
> Fixes MCP `tools/list` output for **`manage_auth_connections`** (and related tools using the same schema) so **`browser_telemetry`** no longer embeds unresolved local **`$ref`** entries.
> 
> **`telemetryCategorySchema`** is now a factory that returns a fresh Zod object for each browser category (captcha, network, page, etc.) instead of reusing one shared schema. Zod’s JSON Schema conversion was deduplicating that shared shape into **`$ref`**s, which broke consumers such as Zod 4’s **`fromJSONSchema`**.
> 
> Adds an integration test that lists MCP tools and asserts the published **`browser_telemetry`** property JSON does not contain **`"$ref"`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f77cb64eb1426ef3add433fc318938838638e009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->