### PR TITLE
Add OpenAI app domain verification challenge

### DIFF
--- a/src/app/.well-known/openai-apps-challenge/route.ts
+++ b/src/app/.well-known/openai-apps-challenge/route.ts
@@ -1,0 +1,8 @@
+const OPENAI_APPS_CHALLENGE_TOKEN =
+  "5ufJ4BzJR-nDzwTWcxy5dpQ5pq-tZDvbkklG_6VKE-A";
+
+export function GET(): Response {
+  return new Response(OPENAI_APPS_CHALLENGE_TOKEN, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}

--- a/src/app/openai-apps-challenge.test.ts
+++ b/src/app/openai-apps-challenge.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { GET } from "./.well-known/openai-apps-challenge/route";
+
+describe("GET /.well-known/openai-apps-challenge", () => {
+  test("returns only the OpenAI domain-verification token", async () => {
+    const response = GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/plain; charset=utf-8",
+    );
+    expect(await response.text()).toBe(
+      "5ufJ4BzJR-nDzwTWcxy5dpQ5pq-tZDvbkklG_6VKE-A",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- serve the OpenAI Apps domain-verification token as plain text at /.well-known/openai-apps-challenge
- add a regression test that requires the exact token and response content type

## Test plan
- bun test (250 passed)
- bun x tsc --noEmit --incremental false
- bun x prettier --check on the changed files

Official contract: https://developers.openai.com/apps-sdk/deploy/submission/#domain-verification