### PR TITLE
Encourage accessibility snapshots in Playwright results

### DIFF
--- a/src/lib/mcp/tools/playwright.ts
+++ b/src/lib/mcp/tools/playwright.ts
@@ -31,7 +31,7 @@ export function registerPlaywrightTool(
       code: z
         .string()
         .describe(
-          "Playwright/TypeScript code with `page`, `context`, and `browser` objects in scope; the value you `return` is sent back. Example: `await page.goto('https://example.com'); return await page.title();` Return only what you need — prefer a targeted selector (e.g. `await page.locator('h1').innerText()`) or a region-scoped snapshot (e.g. `await page.locator('main').ariaSnapshot()`) rather than dumping the whole page.",
+          "Playwright/TypeScript code with `page`, `context`, and `browser` objects in scope; the value you `return` is sent back. Every invocation should return useful page state. After navigation or interaction, return a condensed accessibility snapshot of the relevant region, e.g. `await page.goto('https://example.com'); return await page.locator('main').ariaSnapshot();` or `await page.getByRole('button', { name: 'Submit' }).click(); return await page.locator('main').ariaSnapshot();`. For targeted reads, return a compact value or object. Do not dump the full DOM or body text.",
         ),
       session_id: z
         .string()


### PR DESCRIPTION
## Summary

- update the `execute_playwright_code` input description to ask every invocation for useful page state
- recommend a region-scoped `ariaSnapshot()` after navigation and interaction
- retain compact targeted values for read-only queries and discourage full DOM/body dumps

## Why

Browser agents need the result of each Playwright call to decide the next action. Explicitly returning a compact accessibility snapshot keeps that state useful without producing a full-page payload.

This is intentionally separated from #162 so the ClawBench workflow can benchmark this description-only change against its base SHA.

## Replay

[Watch the successful Kernel MCP ClawBench replay](https://htmlpreview.github.io/?https://gist.githubusercontent.com/rgarcia/738017a0fe77e83e786f5308906f8375/raw/b231e3545216c438432db3e0b0f7cef2e5b3829c/clawbench-theordinary-replay.html) for `v2-1202-beauty-cart-quantity-theordinary` at 4× speed.

The task requires the agent to find Multi-Peptide + HA Serum, open the correct product, change its quantity to `2`, and add it to the cart. ClawBench intercepted the resulting `Cart-AddProduct` request and the strict judge verified that it contained the correct product and quantity. The run scored `1.0` for interception and strict reward.

This run exposed only Kernel MCP `execute_playwright_code` to Codex with GPT-5.6 Luna. Its source was the exact description-change commit `37273e3`, and the trajectory used `ariaSnapshot()` in 11 browser calls. The published 51-second replay contains no credentials, signed Kernel URLs, session IDs, or private benchmark artifacts.

## Test plan

- `bun test src/lib/mcp/register.test.ts`
- `bunx tsc --noEmit`
- `bunx prettier --check src/lib/mcp/tools/playwright.ts`


